### PR TITLE
feat(#14): show abusive character in AsciiOnly.java

### DIFF
--- a/src/main/java/org/eolang/lints/comments/AsciiOnly.java
+++ b/src/main/java/org/eolang/lints/comments/AsciiOnly.java
@@ -52,23 +52,24 @@ public final class AsciiOnly implements Lint {
                 .filter(chr -> chr < 32 || chr > 127)
                 .mapToObj(chr -> (char) chr)
                 .findFirst();
-            if (abusive.isPresent()) {
-                final String line = comment.xpath("@line").get(0);
-                final Character chr = abusive.get();
-                defects.add(
-                    new Defect.Default(
-                        "ascii-only",
-                        Severity.ERROR,
-                        Integer.parseInt(line),
-                        String.format(
-                            "Only ASCII characters are allowed in comments, while '%s' is used at the %sth line at the %sth position",
-                            chr,
-                            line,
-                            comment.xpath("text()").get(0).indexOf(chr) + 1
-                        )
-                    )
-                );
+            if (!abusive.isPresent()) {
+                continue;
             }
+            final String line = comment.xpath("@line").get(0);
+            final Character chr = abusive.get();
+            defects.add(
+                new Defect.Default(
+                    "ascii-only",
+                    Severity.ERROR,
+                    Integer.parseInt(line),
+                    String.format(
+                        "Only ASCII characters are allowed in comments, while '%s' is used at the %sth line at the %sth position",
+                        chr,
+                        line,
+                        comment.xpath("text()").get(0).indexOf(chr) + 1
+                    )
+                )
+            );
         }
         return defects;
     }

--- a/src/main/java/org/eolang/lints/comments/AsciiOnly.java
+++ b/src/main/java/org/eolang/lints/comments/AsciiOnly.java
@@ -27,6 +27,7 @@ import com.jcabi.xml.XML;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.Optional;
 import org.eolang.lints.Defect;
 import org.eolang.lints.Lint;
 import org.eolang.lints.Severity;
@@ -42,15 +43,23 @@ public final class AsciiOnly implements Lint {
     public Collection<Defect> defects(final XML xmir) throws IOException {
         final Collection<Defect> defects = new LinkedList<>();
         for (final XML comment : xmir.nodes("/program/comments/comment")) {
-            if (comment.xpath("text()").get(0).chars().anyMatch(chr -> chr < 32 || chr > 127)) {
+            final Optional<Character> abusive = comment.xpath("text()").get(0).chars()
+                .filter(chr -> chr < 32 || chr > 127)
+                .mapToObj(chr -> (char) chr)
+                .findFirst();
+            if (abusive.isPresent()) {
+                final String line = comment.xpath("@line").get(0);
+                final Character chr = abusive.get();
                 defects.add(
                     new Defect.Default(
                         "ascii-only",
                         Severity.ERROR,
-                        Integer.parseInt(comment.xpath("@line").get(0)),
+                        Integer.parseInt(line),
                         String.format(
-                        "Comment must contain only ASCII printable characters: %s",
-                            comment.xpath("text()").get(0)
+                            "Only ASCII characters are allowed in comments, while '%s' is used at the %sth line at the %sth position",
+                            chr,
+                            line,
+                            comment.xpath("text()").get(0).indexOf(chr)
                         )
                     )
                 );

--- a/src/main/java/org/eolang/lints/comments/AsciiOnly.java
+++ b/src/main/java/org/eolang/lints/comments/AsciiOnly.java
@@ -36,6 +36,10 @@ import org.eolang.lints.Severity;
  * A comment must include only ASCII characters.
  *
  * @since 0.1.0
+ * @todo #14:35min Calculate comment line number with abusive character.
+ *  For now we just reusing object line number (via @line), which is not correct
+ *  for specifying on which line of the program comment is located. This issue
+ *  can be solved after <a href="https://github.com/objectionary/eo/issues/3536">this one</a>.
  */
 public final class AsciiOnly implements Lint {
 

--- a/src/main/java/org/eolang/lints/comments/AsciiOnly.java
+++ b/src/main/java/org/eolang/lints/comments/AsciiOnly.java
@@ -59,7 +59,7 @@ public final class AsciiOnly implements Lint {
                             "Only ASCII characters are allowed in comments, while '%s' is used at the %sth line at the %sth position",
                             chr,
                             line,
-                            comment.xpath("text()").get(0).indexOf(chr)
+                            comment.xpath("text()").get(0).indexOf(chr) + 1
                         )
                     )
                 );

--- a/src/main/java/org/eolang/lints/comments/AsciiOnly.java
+++ b/src/main/java/org/eolang/lints/comments/AsciiOnly.java
@@ -40,6 +40,7 @@ import org.eolang.lints.Severity;
  *  For now we just reusing object line number (via @line), which is not correct
  *  for specifying on which line of the program comment is located. This issue
  *  can be solved after <a href="https://github.com/objectionary/eo/issues/3536">this one</a>.
+ * @checkstyle StringLiteralsConcatenationCheck (30 lines)
  */
 public final class AsciiOnly implements Lint {
 

--- a/src/main/java/org/eolang/lints/comments/AsciiOnly.java
+++ b/src/main/java/org/eolang/lints/comments/AsciiOnly.java
@@ -48,7 +48,10 @@ public final class AsciiOnly implements Lint {
                         "ascii-only",
                         Severity.ERROR,
                         Integer.parseInt(comment.xpath("@line").get(0)),
-                        "Comment must contain only ASCII printable characters: 0x20-0x7f"
+                        String.format(
+                        "Comment must contain only ASCII printable characters: %s",
+                            comment.xpath("text()").get(0)
+                        )
                     )
                 );
             }

--- a/src/test/java/org/eolang/lints/comments/AsciiOnlyTest.java
+++ b/src/test/java/org/eolang/lints/comments/AsciiOnlyTest.java
@@ -31,7 +31,6 @@ import org.eolang.lints.Defect;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/src/test/java/org/eolang/lints/comments/AsciiOnlyTest.java
+++ b/src/test/java/org/eolang/lints/comments/AsciiOnlyTest.java
@@ -24,10 +24,14 @@
 package org.eolang.lints.comments;
 
 import java.io.IOException;
+import java.util.Collection;
 import org.cactoos.io.InputOf;
+import org.cactoos.list.ListOf;
+import org.eolang.lints.Defect;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,14 +43,20 @@ final class AsciiOnlyTest {
 
     @Test
     void catchesNonAsciiInComment() throws IOException {
+        final Collection<Defect> defects = new AsciiOnly().defects(
+            new EoSyntax(
+                new InputOf("# привет\n# как дела?\n[] > foo\n")
+            ).parsed()
+        );
         MatcherAssert.assertThat(
             "non-ascii comment is not welcome",
-            new AsciiOnly().defects(
-                new EoSyntax(
-                    new InputOf("# привет\n# как дела?\n[] > foo\n")
-                ).parsed()
-            ),
+            defects,
             Matchers.hasSize(Matchers.greaterThan(0))
+        );
+        MatcherAssert.assertThat(
+            "non-ascii comment error should contain abusive character",
+            new ListOf<>(defects).get(0).text().contains("приветкак дела?"),
+            Matchers.is(true)
         );
     }
 

--- a/src/test/java/org/eolang/lints/comments/AsciiOnlyTest.java
+++ b/src/test/java/org/eolang/lints/comments/AsciiOnlyTest.java
@@ -54,8 +54,10 @@ final class AsciiOnlyTest {
         );
         MatcherAssert.assertThat(
             "non-ascii comment error should contain abusive character",
-            new ListOf<>(defects).get(0).text().contains("приветкак дела?"),
-            Matchers.is(true)
+            new ListOf<>(defects).get(0).text(),
+            Matchers.is(
+                "Only ASCII characters are allowed in comments, while 'п' is used at the 3th line at the 1th position"
+            )
         );
     }
 


### PR DESCRIPTION
In this pull I've added abusive character to show in the logs in `AsciiOnly.java` lint.

closes #14
History:
- **feat(#14): abusive character**
- **feat(#14): unused import**
