### PR TITLE
feat(#19): Lint.motive()

### DIFF
--- a/src/main/java/org/eolang/lints/Lint.java
+++ b/src/main/java/org/eolang/lints/Lint.java
@@ -41,4 +41,10 @@ public interface Lint {
      */
     Collection<Defect> defects(XML xmir) throws IOException;
 
+    /**
+     * Returns motive for a lint, explaining why this lint exists.
+     * @return Motive text about lint
+     * @throws Exception if something went wrong
+     */
+    String motive() throws Exception;
 }

--- a/src/main/java/org/eolang/lints/LintByXsl.java
+++ b/src/main/java/org/eolang/lints/LintByXsl.java
@@ -55,12 +55,17 @@ final class LintByXsl implements Lint {
     private final XSL sheet;
 
     /**
+     * Motive.
+     */
+    private final Input motive;
+
+    /**
      * Ctor.
      * @param xsl Relative path of XSL
      * @throws IOException If fails
      */
     @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
-    LintByXsl(final Input xsl) throws IOException {
+    LintByXsl(final Input xsl, final Input motive) throws IOException {
         final XML xml = new XMLDocument(
             new IoCheckedText(
                 new TextOf(xsl)
@@ -68,6 +73,7 @@ final class LintByXsl implements Lint {
         );
         this.rule = xml.xpath("/xsl:stylesheet/@id").get(0);
         this.sheet = new XSLDocument(xml).with(new ClasspathSources());
+        this.motive = motive;
     }
 
     /**
@@ -79,6 +85,9 @@ final class LintByXsl implements Lint {
         this(
             new ResourceOf(
                 String.format("org/eolang/lints/%s.xsl", xsl)
+            ),
+            new ResourceOf(
+                String.format("org/eolang/motives/%s.md", xsl)
             )
         );
     }
@@ -104,6 +113,11 @@ final class LintByXsl implements Lint {
             );
         }
         return defects;
+    }
+
+    @Override
+    public String motive() throws Exception {
+        return new TextOf(this.motive).asString();
     }
 
     /**

--- a/src/main/java/org/eolang/lints/LintByXsl.java
+++ b/src/main/java/org/eolang/lints/LintByXsl.java
@@ -55,13 +55,14 @@ final class LintByXsl implements Lint {
     private final XSL sheet;
 
     /**
-     * Motive.
+     * Motive document.
      */
-    private final Input motive;
+    private final Input motivedoc;
 
     /**
      * Ctor.
      * @param xsl Relative path of XSL
+     * @param motive Relative path of motive document
      * @throws IOException If fails
      */
     @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
@@ -73,7 +74,7 @@ final class LintByXsl implements Lint {
         );
         this.rule = xml.xpath("/xsl:stylesheet/@id").get(0);
         this.sheet = new XSLDocument(xml).with(new ClasspathSources());
-        this.motive = motive;
+        this.motivedoc = motive;
     }
 
     /**
@@ -117,7 +118,7 @@ final class LintByXsl implements Lint {
 
     @Override
     public String motive() throws Exception {
-        return new TextOf(this.motive).asString();
+        return new TextOf(this.motivedoc).asString();
     }
 
     /**

--- a/src/main/java/org/eolang/lints/XslLints.java
+++ b/src/main/java/org/eolang/lints/XslLints.java
@@ -67,18 +67,16 @@ public final class XslLints extends IterableEnvelope<Lint> {
     private static Iterable<Lint> all() {
         try {
             return new Mapped<>(
-                res -> {
-                    return new LintByXsl(
-                        new InputOf(res.getInputStream()),
-                        new InputOf(
-                            XSL_PATTERN.matcher(
-                                LINTS_PATH.matcher(
-                                    res.getFile().toString()
-                                ).replaceAll("eolang/motives")
-                            ).replaceAll(".md")
-                        )
-                    );
-                },
+                res -> new LintByXsl(
+                    new InputOf(res.getInputStream()),
+                    new InputOf(
+                        XSL_PATTERN.matcher(
+                            LINTS_PATH.matcher(
+                                res.getFile().toString()
+                            ).replaceAll("eolang/motives")
+                        ).replaceAll(".md")
+                    )
+                ),
                 Arrays.asList(
                     new PathMatchingResourcePatternResolver().getResources(
                         "classpath*:org/eolang/lints/**/*.xsl"

--- a/src/main/java/org/eolang/lints/XslLints.java
+++ b/src/main/java/org/eolang/lints/XslLints.java
@@ -26,13 +26,10 @@ package org.eolang.lints;
 import io.github.secretx33.resourceresolver.PathMatchingResourcePatternResolver;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.regex.Pattern;
 import org.cactoos.io.InputOf;
-import org.cactoos.io.ResourceOf;
 import org.cactoos.iterable.IterableEnvelope;
 import org.cactoos.iterable.Mapped;
-import org.cactoos.list.ListOf;
 
 /**
  * All lints defined by XSLs.
@@ -49,6 +46,13 @@ public final class XslLints extends IterableEnvelope<Lint> {
     );
 
     /**
+     * Lints path pattern.
+     */
+    private static final Pattern LINTS_PATH = Pattern.compile(
+        "eolang/lints", Pattern.LITERAL
+    );
+
+    /**
      * Ctor.
      */
     public XslLints() {
@@ -62,35 +66,16 @@ public final class XslLints extends IterableEnvelope<Lint> {
      */
     private static Iterable<Lint> all() {
         try {
-            Arrays.stream(
-                new PathMatchingResourcePatternResolver().getResources(
-                    "classpath*:org/eolang/motives/**/*.md"
-                )
-            ).forEach(res -> {
-                try {
-                    System.out.println(res.getURL());
-                } catch (IOException e) {
-                    throw new IllegalStateException(e);
-                }
-            });
             return new Mapped<>(
                 res -> {
-                    final List<String> dirs = new ListOf<>(
-                        res.getFile().toString().split("/")
-                    );
-                    final int last = dirs.size() - 1;
                     return new LintByXsl(
                         new InputOf(res.getInputStream()),
                         new InputOf(
-                            new ResourceOf(
-                                String.format(
-                                    "org/eolang/motives/%s/%s",
-                                    dirs.get(last - 1),
-                                    XSL_PATTERN.matcher(
-                                        dirs.get(last)
-                                    ).replaceAll(".md")
-                                )
-                            ).stream()
+                            XSL_PATTERN.matcher(
+                                LINTS_PATH.matcher(
+                                    res.getFile().toString()
+                                ).replaceAll("eolang/motives")
+                            ).replaceAll(".md")
                         )
                     );
                 },

--- a/src/main/java/org/eolang/lints/XslLints.java
+++ b/src/main/java/org/eolang/lints/XslLints.java
@@ -62,6 +62,17 @@ public final class XslLints extends IterableEnvelope<Lint> {
      */
     private static Iterable<Lint> all() {
         try {
+            Arrays.stream(
+                new PathMatchingResourcePatternResolver().getResources(
+                    "classpath*:org/eolang/motives/**/*.md"
+                )
+            ).forEach(res -> {
+                try {
+                    System.out.println(res.getURL());
+                } catch (IOException e) {
+                    throw new IllegalStateException(e);
+                }
+            });
             return new Mapped<>(
                 res -> {
                     final List<String> dirs = new ListOf<>(

--- a/src/main/java/org/eolang/lints/comments/AsciiOnly.java
+++ b/src/main/java/org/eolang/lints/comments/AsciiOnly.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Optional;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.text.TextOf;
 import org.eolang.lints.Defect;
 import org.eolang.lints.Lint;
 import org.eolang.lints.Severity;
@@ -40,6 +42,9 @@ import org.eolang.lints.Severity;
  *  For now we just reusing object line number (via @line), which is not correct
  *  for specifying on which line of the program comment is located. This issue
  *  can be solved after <a href="https://github.com/objectionary/eo/issues/3536">this one</a>.
+ * @todo #19:45min Create Lint envelope called `JavaLint` that will fetch motive from
+ *  Markdown file based on the lint's name (Java class name) and lint's dimension
+ *  (Java package, e.g. `comments`).
  * @checkstyle StringLiteralsConcatenationCheck (30 lines)
  */
 public final class AsciiOnly implements Lint {
@@ -76,6 +81,8 @@ public final class AsciiOnly implements Lint {
 
     @Override
     public String motive() throws Exception {
-        throw new UnsupportedOperationException("#motive()");
+        return new TextOf(
+            new ResourceOf("org/eolang/motives/comments/ascii-only.md")
+        ).asString();
     }
 }

--- a/src/main/java/org/eolang/lints/comments/AsciiOnly.java
+++ b/src/main/java/org/eolang/lints/comments/AsciiOnly.java
@@ -44,7 +44,7 @@ import org.eolang.lints.Severity;
  *  can be solved after <a href="https://github.com/objectionary/eo/issues/3536">this one</a>.
  * @todo #19:45min Create Lint envelope called `JavaLint` that will fetch motive from
  *  Markdown file based on the lint's name (Java class name) and lint's dimension
- *  (Java package, e.g. `comments`).
+ *  (Java package name, e.g. `comments`).
  * @checkstyle StringLiteralsConcatenationCheck (30 lines)
  */
 public final class AsciiOnly implements Lint {

--- a/src/main/java/org/eolang/lints/comments/AsciiOnly.java
+++ b/src/main/java/org/eolang/lints/comments/AsciiOnly.java
@@ -73,4 +73,9 @@ public final class AsciiOnly implements Lint {
         }
         return defects;
     }
+
+    @Override
+    public String motive() throws Exception {
+        throw new UnsupportedOperationException("#motive()");
+    }
 }

--- a/src/main/resources/org/eolang/lints/metas/incorrect-version.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-version.xsl
@@ -30,7 +30,7 @@ SOFTWARE.
         <xsl:variable name="meta-head" select="head"/>
         <xsl:variable name="meta-tail" select="tail"/>
         <xsl:if test="$meta-head='version' and not(matches($meta-tail, '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)?(\+[a-zA-Z0-9]+)?$'))">
-        <xsl:element name="defect">
+          <xsl:element name="defect">
             <xsl:attribute name="line">
               <xsl:value-of select="if (@line) then @line else '0'"/>
             </xsl:attribute>

--- a/src/main/resources/org/eolang/motives/aliases/alias-too-long.md
+++ b/src/main/resources/org/eolang/motives/aliases/alias-too-long.md
@@ -1,0 +1,24 @@
+# Alias Too Long
+
+Object alias must have **2 parts at max**. 
+
+Incorrect:
+
+```eo
++alias a b c
+
+# Foo.
+[] > foo
+```
+
+Correct:
+
+```eo
++alias
++alias a
++alias a b
++alias a b.c.d.e
+
+# Foo.
+[] > foo
+```

--- a/src/main/resources/org/eolang/motives/aliases/alias-too-long.md
+++ b/src/main/resources/org/eolang/motives/aliases/alias-too-long.md
@@ -1,6 +1,6 @@
 # Alias Too Long
 
-Object's alias must have **2 parts at max**. 
+Object's alias must have **2 parts at max**.
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/aliases/alias-too-long.md
+++ b/src/main/resources/org/eolang/motives/aliases/alias-too-long.md
@@ -1,6 +1,6 @@
 # Alias Too Long
 
-Object alias must have **2 parts at max**. 
+Object's alias must have **2 parts at max**. 
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/aliases/alias-without-tail.md
+++ b/src/main/resources/org/eolang/motives/aliases/alias-without-tail.md
@@ -1,6 +1,6 @@
 # Alias Without Tail
 
-All aliases must have tail after it.
+Object alias must have a tail.
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/aliases/alias-without-tail.md
+++ b/src/main/resources/org/eolang/motives/aliases/alias-without-tail.md
@@ -1,11 +1,11 @@
-# Alias Too Long
+# Alias Without Tail
 
-Object alias must have **2 parts at max**. 
+All aliases must have tail after it.
 
 Incorrect:
 
 ```eo
-+alias a b c
++alias
 
 # Foo.
 [] > foo
@@ -16,7 +16,8 @@ Correct:
 ```eo
 +alias a
 +alias a b
-+alias a b.c.d.e
++alias a b c
++alias a b c d
 
 # Foo.
 [] > foo

--- a/src/main/resources/org/eolang/motives/aliases/alias-without-tail.md
+++ b/src/main/resources/org/eolang/motives/aliases/alias-without-tail.md
@@ -1,6 +1,6 @@
 # Alias Without Tail
 
-Object alias must have a tail.
+Object's alias must have a tail.
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/aliases/broken-alias.md
+++ b/src/main/resources/org/eolang/motives/aliases/broken-alias.md
@@ -1,9 +1,9 @@
 # Broken Alias
 
-Object's alias parts must follow the following regexes:
+Object's alias parts must follow regexes:
 
-* First part: `^[a-z]+[^><.\[\]()!:"\""@^$#&/\s]*$'))`
-* Second part: `^[a-z]+[^><.\[\]()!:"\""@^$#&/\s]*(\.[a-z]+[^&gt;&lt;.\[\]()!:"\""@^$#&/\s]*)*$'))`
+* First part: `^[a-z]+[^><.\[\]()!:"@^$#&/\s]*$'))`
+* Second part: `^[a-z]+[^><.\[\]()!:"@^$#&/\s]*(\.[a-z]+[^><.\[\]()!:"@^$#&/\s]*)*$'))`
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/aliases/broken-alias.md
+++ b/src/main/resources/org/eolang/motives/aliases/broken-alias.md
@@ -1,0 +1,46 @@
+# Broken Alias
+
+Object's alias parts must follow the following regexes:
+
+* First part: `^[a-z]+[^><.\[\]()!:"\""@^$#&/\s]*$'))`
+* Second part: `^[a-z]+[^><.\[\]()!:"\""@^$#&/\s]*(\.[a-z]+[^&gt;&lt;.\[\]()!:"\""@^$#&/\s]*)*$'))`
+
+Incorrect:
+
+```eo
++alias FirstLetter Capital.Letters.Prohibited.Here
++alias good Should.Be.Small
++alias with-Dash-and-number-999 0.1.2
++alias caseInsensitive thiS.IS.2
++alias the  symbol.is.not.allowed
++alias the! symbol.is.not.allowed
++alias the" symbol.is.not.allowed
++alias the# symbol.is.not.allowed
++alias the$ symbol.is.not.allowed
++alias the& symbol.is.not.allowed
++alias the( symbol.is.not.allowed
++alias the) symbol.is.not.allowed
++alias the. symbol.is.not.allowed
++alias the/ symbol.is.not.allowed
++alias the: symbol.is.not.allowed
++alias the< symbol.is.not.allowed
++alias the> symbol.is.not.allowed
++alias the@ symbol.is.not.allowed
++alias the[ symbol.is.not.allowed
++alias the] symbol.is.not.allowed
++alias the^ symbol.is.not.allowed
+
+# Foo.
+[] > foo
+```
+
+Correct:
+
+```eo
++alias one
++alias one-two
++alias one-two-three-four
+
+# Foo.
+[] > foo
+```

--- a/src/main/resources/org/eolang/motives/aliases/duplicate-aliases.md
+++ b/src/main/resources/org/eolang/motives/aliases/duplicate-aliases.md
@@ -11,7 +11,7 @@ Incorrect:
 
 # Print text to stdout.
 [] > main
-    (stdout "Hello, world!").print
+  (stdout "Hello, world!").print
 ```
 
 Correct:
@@ -22,5 +22,5 @@ Correct:
 
 # Print text to stdout.
 [] > main
-    (stdout "Hello, world!").print
+  (stdout "Hello, world!").print
 ```

--- a/src/main/resources/org/eolang/motives/aliases/duplicate-aliases.md
+++ b/src/main/resources/org/eolang/motives/aliases/duplicate-aliases.md
@@ -1,0 +1,26 @@
+# Duplicate Aliases
+
+Object's aliases must not be duplicated.
+
+Incorrect:
+
+```eo
++alias stdin org.eolang.io.stdin
++alias stdout org.eolang.io.stdout
++alias stdout org.eolang.io.stdout
+
+# Print text to stdout.
+[] > main
+    (stdout "Hello, world!").print
+```
+
+Correct:
+
+```eo
++alias stdin org.eolang.io.stdin
++alias stdout org.eolang.io.stdout
+
+# Print text to stdout.
+[] > main
+    (stdout "Hello, world!").print
+```

--- a/src/main/resources/org/eolang/motives/aliases/unused-alias.md
+++ b/src/main/resources/org/eolang/motives/aliases/unused-alias.md
@@ -1,0 +1,25 @@
+# Unused Alias
+
+All defined object's aliases must be in use.
+
+Incorrect:
+
+```eo
++alias err org.eolang.io.stderr
++alias in org.eolang.io.stdin
++alias org.eolang.io.stdout
+
+# Foo.
+[x] > foo
+    x.div in.nextInt > @
+```
+
+Correct:
+
+```eo
++alias in org.eolang.io.stdin
+
+# Foo.
+[x] > foo
+    x.div in.nextInt > @
+```

--- a/src/main/resources/org/eolang/motives/aliases/unused-alias.md
+++ b/src/main/resources/org/eolang/motives/aliases/unused-alias.md
@@ -11,7 +11,7 @@ Incorrect:
 
 # Foo.
 [x] > foo
-    x.div in.nextInt > @
+  x.div in.nextInt > @
 ```
 
 Correct:
@@ -21,5 +21,5 @@ Correct:
 
 # Foo.
 [x] > foo
-    x.div in.nextInt > @
+  x.div in.nextInt > @
 ```

--- a/src/main/resources/org/eolang/motives/comments/ascii-only.md
+++ b/src/main/resources/org/eolang/motives/comments/ascii-only.md
@@ -8,10 +8,12 @@ Incorrect:
 # привет.
 # 你好，伙计
 # Γεια σας
+[] > foo
 ```
 
 Correct:
 
 ```eo
 # This is comment with all ASCII characters.
+[] > foo
 ```

--- a/src/main/resources/org/eolang/motives/comments/ascii-only.md
+++ b/src/main/resources/org/eolang/motives/comments/ascii-only.md
@@ -14,6 +14,6 @@ Incorrect:
 Correct:
 
 ```eo
-# This is comment with all ASCII characters.
+# This is the comment with all ASCII characters.
 [] > foo
 ```

--- a/src/main/resources/org/eolang/motives/comments/ascii-only.md
+++ b/src/main/resources/org/eolang/motives/comments/ascii-only.md
@@ -1,0 +1,17 @@
+# ASCII-Only Characters in Comment
+
+All comments must include only ASCII characters.
+
+Incorrect:
+
+```eo
+# привет.
+# 你好，伙计
+# Γεια σας
+```
+
+Correct:
+
+```eo
+# This is comment with all ASCII characters.
+```

--- a/src/main/resources/org/eolang/motives/comments/comment-not-capitalized.md
+++ b/src/main/resources/org/eolang/motives/comments/comment-not-capitalized.md
@@ -7,7 +7,7 @@ Incorrect:
 ```eo
 # this comment doesn't start with capital English letter.
 [] > foo
-    42 > @
+  42 > @
 ```
 
 Correct:
@@ -15,5 +15,5 @@ Correct:
 ```eo
 # This comment does start with capital English letter.
 [] > foo
-    42 > @
+  42 > @
 ```

--- a/src/main/resources/org/eolang/motives/comments/comment-not-capitalized.md
+++ b/src/main/resources/org/eolang/motives/comments/comment-not-capitalized.md
@@ -1,0 +1,19 @@
+# Comment Not Capitalized
+
+Comment must start with the capital letter.
+
+Incorrect:
+
+```eo
+# this comment doesn't start with capital English letter.
+[] > foo
+    42 > @
+```
+
+Correct:
+
+```eo
+# This comment does start with capital English letter.
+[] > foo
+    42 > @
+```

--- a/src/main/resources/org/eolang/motives/comments/comment-too-short.md
+++ b/src/main/resources/org/eolang/motives/comments/comment-too-short.md
@@ -1,0 +1,19 @@
+# Comment Too Short
+
+Comment must be 32+ characters long.
+
+Incorrect:
+
+```eo
+# This comment is short.
+[] > foo
+    42 > @
+```
+
+Correct:
+
+```eo
+# This is the default 32+ characters comment in front of abstract object.
+[] > foo
+    42 > @
+```

--- a/src/main/resources/org/eolang/motives/comments/comment-too-short.md
+++ b/src/main/resources/org/eolang/motives/comments/comment-too-short.md
@@ -7,7 +7,7 @@ Incorrect:
 ```eo
 # This comment is short.
 [] > foo
-    42 > @
+  42 > @
 ```
 
 Correct:
@@ -15,5 +15,5 @@ Correct:
 ```eo
 # This is the default 32+ characters comment in front of abstract object.
 [] > foo
-    42 > @
+  42 > @
 ```

--- a/src/main/resources/org/eolang/motives/comments/comment-without-dot.md
+++ b/src/main/resources/org/eolang/motives/comments/comment-without-dot.md
@@ -1,0 +1,19 @@
+# Comment Without Dot
+
+Comment must end with a dot.
+
+Incorrect:
+
+```eo
+# This comment doesn't end with a dot
+[] > foo
+    42 > @
+```
+
+Correct:
+
+```eo
+# This does end with a dot.
+[] > foo
+    42 > @
+```

--- a/src/main/resources/org/eolang/motives/comments/comment-without-dot.md
+++ b/src/main/resources/org/eolang/motives/comments/comment-without-dot.md
@@ -7,7 +7,7 @@ Incorrect:
 ```eo
 # This comment doesn't end with a dot
 [] > foo
-    42 > @
+  42 > @
 ```
 
 Correct:
@@ -15,5 +15,5 @@ Correct:
 ```eo
 # This does end with a dot.
 [] > foo
-    42 > @
+  42 > @
 ```

--- a/src/main/resources/org/eolang/motives/critical/duplicate-names.md
+++ b/src/main/resources/org/eolang/motives/critical/duplicate-names.md
@@ -1,0 +1,4 @@
+@todo #19:35min Document motives for `critical` lints.
+ We should document motives for each critical lint, including:
+ `duplicate-names.md`, `not-empty-atoms.md`, `same-line-names.md`, and
+ `self-naming.md`.

--- a/src/main/resources/org/eolang/motives/critical/duplicate-names.md
+++ b/src/main/resources/org/eolang/motives/critical/duplicate-names.md
@@ -6,13 +6,13 @@ Incorrect:
 
 ```eo
 foo
-    1 > name
-    2 > name
+  1 > name
+  2 > name
 ```
 
 ```eo
 [x] > first
-    second > x
+  second > x
 
 18 > first
 ```
@@ -21,13 +21,13 @@ Correct:
 
 ```eo
 foo
-    1 > one
-    2 > two
+  1 > one
+  2 > two
 ```
 
 ```eo
 [x] > first
-    second > x
+  second > x
 
 18 > age
 ```

--- a/src/main/resources/org/eolang/motives/critical/duplicate-names.md
+++ b/src/main/resources/org/eolang/motives/critical/duplicate-names.md
@@ -1,4 +1,33 @@
-@todo #19:35min Document motives for `critical` lints.
- We should document motives for each critical lint, including:
- `duplicate-names.md`, `not-empty-atoms.md`, `same-line-names.md`, and
- `self-naming.md`.
+# Duplicate Names
+
+Object's name must not be duplicated.
+
+Incorrect:
+
+```eo
+foo
+    1 > name
+    2 > name
+```
+
+```eo
+[x] > first
+    second > x
+
+18 > first
+```
+
+Correct:
+
+```eo
+foo
+    1 > one
+    2 > two
+```
+
+```eo
+[x] > first
+    second > x
+
+18 > age
+```

--- a/src/main/resources/org/eolang/motives/critical/not-empty-atoms.md
+++ b/src/main/resources/org/eolang/motives/critical/not-empty-atoms.md
@@ -1,0 +1,5 @@
+# Not Empty Atoms
+
+@todo #19:35min Document motives for `not-empty-atoms` lint.
+Currently, we don't have a test case for this `not-empty-atoms` lint.
+We should create a new test case, and then document a motive for this lint.

--- a/src/main/resources/org/eolang/motives/critical/not-empty-atoms.md
+++ b/src/main/resources/org/eolang/motives/critical/not-empty-atoms.md
@@ -1,5 +1,5 @@
 # Not Empty Atoms
 
 @todo #19:35min Document motives for `not-empty-atoms` lint.
-Currently, we don't have a test case for this `not-empty-atoms` lint.
-We should create a new test case, and then document a motive for this lint.
+ Currently, we don't have a test case for this `not-empty-atoms` lint.
+ We should create a new test case, and then document a motive for this lint.

--- a/src/main/resources/org/eolang/motives/critical/same-line-names.md
+++ b/src/main/resources/org/eolang/motives/critical/same-line-names.md
@@ -1,0 +1,5 @@
+# Same Line Names
+
+@todo #19:35min Document motives for `same-line-names` lint.
+Currently, we don't have a test case for this `same-line-names` lint.
+We should create a new test case, and then document a motive for this lint.

--- a/src/main/resources/org/eolang/motives/critical/same-line-names.md
+++ b/src/main/resources/org/eolang/motives/critical/same-line-names.md
@@ -1,5 +1,5 @@
 # Same Line Names
 
 @todo #19:35min Document motives for `same-line-names` lint.
-Currently, we don't have a test case for this `same-line-names` lint.
-We should create a new test case, and then document a motive for this lint.
+ Currently, we don't have a test case for this `same-line-names` lint.
+ We should create a new test case, and then document a motive for this lint.

--- a/src/main/resources/org/eolang/motives/critical/self-naming.md
+++ b/src/main/resources/org/eolang/motives/critical/self-naming.md
@@ -6,12 +6,12 @@ Incorrect:
 
 ```eo
 [] > foo
-    a > a
+  a > a
 ```
 
 Correct:
 
 ```eo
 [] > foo
-    a > b
+  a > b
 ```

--- a/src/main/resources/org/eolang/motives/critical/self-naming.md
+++ b/src/main/resources/org/eolang/motives/critical/self-naming.md
@@ -1,0 +1,17 @@
+# Self Naming
+
+Object must not refer to itself.
+
+Incorrect:
+
+```eo
+[] > foo
+    a > a
+```
+
+Correct:
+
+```eo
+[] > foo
+    a > b
+```

--- a/src/main/resources/org/eolang/motives/errors/abstract-decoratee.md
+++ b/src/main/resources/org/eolang/motives/errors/abstract-decoratee.md
@@ -1,0 +1,19 @@
+# Abstract Decoratee
+
+Abstract object shouldn't be used as a decoratee.
+
+Incorrect:
+
+```eo
+[] > main
+  [] > @
+    hello > test
+```
+
+Correct:
+
+```eo
+[args] > main
+  foo > @
+    hello > test
+```

--- a/src/main/resources/org/eolang/motives/errors/atom-without-rt.md
+++ b/src/main/resources/org/eolang/motives/errors/atom-without-rt.md
@@ -1,0 +1,32 @@
+# Atom Without `rt` Meta
+
+Defined atom must have `+rt` meta.
+
+Incorrect:
+
+```eo
++architect jeff@foo.com
++home https://github.com/objectionary/eo
++package org.eolang
++version 0.0.0
+
+[] > bytes
+  [x] > eq /bool
+    
+  [y] > not /bool
+```
+
+Correct:
+
+```eo
++architect jeff@foo.com
++home https://github.com/objectionary/eo
++package org.eolang
++version 0.0.0
++rt jvm org.eolang:eo-runtime:0.43.2
+
+[] > bytes
+  [x] > eq /bool
+    
+  [y] > not /bool
+```

--- a/src/main/resources/org/eolang/motives/errors/empty-object.md
+++ b/src/main/resources/org/eolang/motives/errors/empty-object.md
@@ -3,6 +3,6 @@
 Objects without any attributes: neither void nor attached are prohibited.
 
 @todo #19:35min Document motives and examples for `empty-object` lint.
-Currently, we don't have a test case for this `empty-object` lint.
-We should create a new test case, and then document a motive with examples
-for this lint.
+ Currently, we don't have a test case for this `empty-object` lint.
+ We should create a new test case, and then document a motive with examples
+ for this lint.

--- a/src/main/resources/org/eolang/motives/errors/empty-object.md
+++ b/src/main/resources/org/eolang/motives/errors/empty-object.md
@@ -1,0 +1,8 @@
+# Empty Object
+
+Objects without any attributes: neither void nor attached are prohibited.
+
+@todo #19:35min Document motives and examples for `empty-object` lint.
+Currently, we don't have a test case for this `empty-object` lint.
+We should create a new test case, and then document a motive with examples
+for this lint.

--- a/src/main/resources/org/eolang/motives/errors/external-weak-typed-atoms.md
+++ b/src/main/resources/org/eolang/motives/errors/external-weak-typed-atoms.md
@@ -1,0 +1,19 @@
+# External Weak Typed Atoms
+
+Weak typing `/?` does not allowed outside of `org.eolang` package.
+
+Incorrect:
+
+```eo
++package my.awesome.package
+
+[] > my-awesome-object /?
+```
+
+Correct:
+
+```eo
++package my.awesome.package
+
+[] > my-awesome-object /int
+```

--- a/src/main/resources/org/eolang/motives/errors/global-nonames.md
+++ b/src/main/resources/org/eolang/motives/errors/global-nonames.md
@@ -1,0 +1,23 @@
+# Global Nonames
+
+Global object must have a name.
+
+Incorrect:
+
+```eo
+3.14 > pi
+
+fake
+
+a.b > good
+```
+
+Correct:
+
+```eo
+3.14 > pi
+
+fake > app
+
+a.b > good    
+```

--- a/src/main/resources/org/eolang/motives/errors/many-free-attributes.md
+++ b/src/main/resources/org/eolang/motives/errors/many-free-attributes.md
@@ -1,0 +1,17 @@
+# Many Free Attributes
+
+Object must have at **max 5 attributes**.
+
+Incorrect:
+
+```eo
+[a b c d e f] > with-many
+  something > @
+```
+
+Correct:
+
+```eo
+[a b c d e] > with-ok
+  something > @
+```

--- a/src/main/resources/org/eolang/motives/errors/noname-attributes.md
+++ b/src/main/resources/org/eolang/motives/errors/noname-attributes.md
@@ -1,0 +1,29 @@
+# Noname Attributes
+
+Each object's attribute must have a name.
+
+Incorrect:
+
+```eo
+[] > foo
+  first
+  second
+```
+
+```eo
+[args] > main
+  (stdout "Hello!").print
+```
+
+Correct:
+
+```eo
+[] > foo
+  first > hi
+  second > hey
+```
+
+```eo
+[args] > main
+  (stdout "Hello!").print > out
+```

--- a/src/main/resources/org/eolang/motives/errors/rt-without-atoms.md
+++ b/src/main/resources/org/eolang/motives/errors/rt-without-atoms.md
@@ -1,0 +1,20 @@
+# `+rt` Without Atoms
+
+Special `+rt` meta must be used only with atoms.
+
+Incorrect:
+
+```eo
++rt node eo2js-runtime:0.0.0
+
+[attr] > foo
+```
+
+Correct:
+
+```eo
++rt node eo2js-runtime:0.0.0
+
+[attr] > foo
+  [] > test /int
+```

--- a/src/main/resources/org/eolang/motives/errors/signed-binding-indexes.md
+++ b/src/main/resources/org/eolang/motives/errors/signed-binding-indexes.md
@@ -1,0 +1,15 @@
+# Signed Binding Indexes
+
+Binding index of application must not be a signed number.
+
+Incorrect:
+
+```eo
+object c:-1 d:-2 a:0 b:1 e:+12
+```
+
+Correct:
+
+```eo
+object c:1 d:2 a:0 b:1 e:12
+```

--- a/src/main/resources/org/eolang/motives/errors/unknown-names.md
+++ b/src/main/resources/org/eolang/motives/errors/unknown-names.md
@@ -1,0 +1,19 @@
+# Unknown Names
+
+Used object must be defined in the program.
+
+Incorrect:
+
+```eo
+[] > foo
+  test > @
+```
+
+Correct:
+
+```eo
++alias test
+
+[] > foo
+  test > @
+```

--- a/src/main/resources/org/eolang/motives/metas/correct-package-meta.md
+++ b/src/main/resources/org/eolang/motives/metas/correct-package-meta.md
@@ -1,0 +1,19 @@
+# Correct `+package` Meta
+
+Special meta `+package` must have a correct tail.
+
+Incorrect:
+
+```eo
++package
+
+[] > foo
+```
+
+Correct:
+
+```eo
++package my.awesome.package
+
+[] > foo
+```

--- a/src/main/resources/org/eolang/motives/metas/duplicate-metas.md
+++ b/src/main/resources/org/eolang/motives/metas/duplicate-metas.md
@@ -1,0 +1,20 @@
+# Duplicate Metas
+
+Metas must not be duplicated.
+
+Incorrect:
+
+```eo
++home https://github.com/objectionary/eo
++home https://github.com/objectionary/eo
+
+[] > foo
+```
+
+Correct:
+
+```eo
++home https://github.com/objectionary/eo
+
+[] > foo
+```

--- a/src/main/resources/org/eolang/motives/metas/incorrect-architect.md
+++ b/src/main/resources/org/eolang/motives/metas/incorrect-architect.md
@@ -1,0 +1,27 @@
+# Incorrect `+architect`
+
+Architect's email must follow regex:
+
+```regexp
+^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$
+```
+
+Incorrect:
+
+```eo
++architect hello
++architect hello@mail
++architect someone@@
++architect @gmail.com
++architect someone24@.com
+
+[] > foo
+```
+
+Correct:
+
+```eo
++architect hello@gmail.com
+
+[] > foo
+```

--- a/src/main/resources/org/eolang/motives/metas/incorrect-home.md
+++ b/src/main/resources/org/eolang/motives/metas/incorrect-home.md
@@ -1,0 +1,24 @@
+# Incorrect `+home`
+
+Special meta `+home` must follow regex:
+
+```regexp
+^(?:http(s)?://)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#\[\]@!$&'()*+,;=]+$
+```
+
+Incorrect:
+
+```eo
++home url
+
+[] > foo
+```
+
+Correct:
+
+```eo
++home https://github.com/objectionary/eo
++home 255.255.255.255
+
+[] > foo
+```

--- a/src/main/resources/org/eolang/motives/metas/incorrect-version.md
+++ b/src/main/resources/org/eolang/motives/metas/incorrect-version.md
@@ -1,0 +1,30 @@
+# Incorrect `+version`
+
+Tail of the special `+version` meta must follow [SemVer] format.
+
+Incorrect:
+
+```eo
++version 0.0
++version 123
++version 1. 1 .1
++version 1.1.alpha
++version 1-alpha
++version alpha.1.1
+
+[] > foo
+```
+
+Correct:
+
+```eo
++version 0.0.0
++version 0.2.1
++version 42.0.555555
++version 0.0.1-alpha
++version 0.0.1-beta-1
+
+[] > foo
+```
+
+[SemVer]: https://semver.org/

--- a/src/main/resources/org/eolang/motives/metas/mandatory-home-meta.md
+++ b/src/main/resources/org/eolang/motives/metas/mandatory-home-meta.md
@@ -1,0 +1,24 @@
+# Mandatory `+home` Meta
+
+Program should have only one `+home` special meta.
+
+Incorrect:
+
+```eo
+[] > foo
+```
+
+```eo
++home https://github.com/objectionary/eo
++home https://github.com/objectionary/eolang
+
+[] > foo
+```
+
+Correct:
+
+```eo
++home https://github.com/objectionary/eo
+
+[] > foo
+```

--- a/src/main/resources/org/eolang/motives/metas/mandatory-package-meta.md
+++ b/src/main/resources/org/eolang/motives/metas/mandatory-package-meta.md
@@ -1,0 +1,24 @@
+# Mandatory `+package` Meta
+
+Program should have only one `+package` special meta.
+
+Incorrect:
+
+```eo
+[] > foo
+```
+
+```eo
++package org.eolang
++package org.eo
+
+[] > foo
+```
+
+Correct:
+
+```eo
++package org.eolang
+
+[] > foo
+```

--- a/src/main/resources/org/eolang/motives/metas/mandatory-version-meta.md
+++ b/src/main/resources/org/eolang/motives/metas/mandatory-version-meta.md
@@ -1,0 +1,24 @@
+# Mandatory `+version` Meta
+
+Program should have only one `+version` special meta.
+
+Incorrect:
+
+```eo
+[] > foo
+```
+
+```eo
++version 0.0.1
++version 0.0.2
+
+[] > foo
+```
+
+Correct:
+
+```eo
++package 0.0.1
+
+[] > foo
+```

--- a/src/main/resources/org/eolang/motives/metas/prohibited-package.md
+++ b/src/main/resources/org/eolang/motives/metas/prohibited-package.md
@@ -1,0 +1,20 @@
+# Prohibited `+package`
+
+Special package `org.eolang` is reserved for internal object only, and can not
+be used outside.
+
+Incorrect:
+
+```eo
++package org.eolang
+
+[] > foo
+```
+
+Correct:
+
+```eo
++package my.awesome.package
+
+[] > foo
+```

--- a/src/main/resources/org/eolang/motives/metas/unsorted-metas.md
+++ b/src/main/resources/org/eolang/motives/metas/unsorted-metas.md
@@ -1,0 +1,21 @@
+# Unsorted Metas
+
+Metas must be alphabetically ordered.
+
+Incorrect:
+
+```eo
++alias org.eolang.io.stdout
++alias org.eolang.io.stdin
+
+[] > foo
+```
+
+Correct:
+
+```eo
++alias org.eolang.io.stdin
++alias org.eolang.io.stdout
+
+[] > foo
+```

--- a/src/main/resources/org/eolang/motives/metas/zero-version.md
+++ b/src/main/resources/org/eolang/motives/metas/zero-version.md
@@ -1,6 +1,6 @@
 # Zero Version
 
-Objects inside `src/(main|test)` must use `0.0.0` version during the 
+Objects inside `src/(main|test)` must use `0.0.0` version during the
 development.
 
 Incorrect:

--- a/src/main/resources/org/eolang/motives/metas/zero-version.md
+++ b/src/main/resources/org/eolang/motives/metas/zero-version.md
@@ -1,0 +1,20 @@
+# Zero Version
+
+Objects inside `src/(main|test)` must use `0.0.0` version during the 
+development.
+
+Incorrect:
+
+```eo
++version 1.2.3
+
+[] > foo
+```
+
+Correct:
+
+```eo
++version 0.0.0
+
+[] > foo
+```

--- a/src/main/resources/org/eolang/motives/misc/sparse-decoration.md
+++ b/src/main/resources/org/eolang/motives/misc/sparse-decoration.md
@@ -1,0 +1,25 @@
+# Sparse Decoration
+
+Sparse decoration of the base object is prohibited.
+
+Incorrect:
+
+```eo
+[] > decorates-five
+  five > @
+```
+
+Correct:
+
+```eo
+[] > decorates-application
+  if > @
+    true
+    5
+    five
+```
+
+```eo
+[free] > decorates-with-free-args
+  five > @
+```

--- a/src/main/resources/org/eolang/motives/misc/unit-test-without-phi.md
+++ b/src/main/resources/org/eolang/motives/misc/unit-test-without-phi.md
@@ -1,0 +1,21 @@
+# Unit Test Without Phi
+
+Unit test must have `@` attribute.
+
+Incorrect:
+
+```eo
++tests
+
+[] > test
+  true
+```
+
+Correct:
+
+```eo
++tests
+
+[] > test
+  true > @
+```

--- a/src/main/resources/org/eolang/motives/refs/broken-refs.md
+++ b/src/main/resources/org/eolang/motives/refs/broken-refs.md
@@ -1,0 +1,14 @@
+# Broken Refs
+
+Object ref must follow regex:
+
+```regexp
+^[0-9]+(\.[0-9]+)*$
+```
+
+Object ref must not refer to the absent object.
+
+@todo #19:30min Document more about `broken-refs` lint.
+ Currently, there is no unit test that finds defects with broken refs.
+ Let's add a few, and only then add more docs in broken-ref's motive.
+TBD..

--- a/src/test/java/org/eolang/lints/LintByXslTest.java
+++ b/src/test/java/org/eolang/lints/LintByXslTest.java
@@ -30,6 +30,7 @@ import org.eolang.parser.CheckPack;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -65,6 +66,15 @@ final class LintByXslTest {
             String.format("The check pack has failed: %n%s", pack),
             check.failures(),
             Matchers.empty()
+        );
+    }
+
+    @Test
+    void returnsMotive() throws Exception {
+        MatcherAssert.assertThat(
+            "The motive was not found or empty",
+            new LintByXsl("critical/duplicate-names").motive().isEmpty(),
+            new IsEqual<>(false)
         );
     }
 

--- a/src/test/java/org/eolang/lints/XslLintsTest.java
+++ b/src/test/java/org/eolang/lints/XslLintsTest.java
@@ -79,7 +79,7 @@ final class XslLintsTest {
     }
 
     @Test
-    void checksTextOfEachLintMotive() throws Exception {
+    void checksAllMotives() throws Exception {
         for (final Lint lint : new XslLints()) {
             MatcherAssert.assertThat(
                 lint.motive().isEmpty(),

--- a/src/test/java/org/eolang/lints/XslLintsTest.java
+++ b/src/test/java/org/eolang/lints/XslLintsTest.java
@@ -34,6 +34,7 @@ import org.cactoos.proc.ForEach;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -75,6 +76,16 @@ final class XslLintsTest {
                 )
             )
         );
+    }
+
+    @Test
+    void checksTextOfEachLintMotive() throws Exception {
+        for (final Lint lint : new XslLints()) {
+            MatcherAssert.assertThat(
+                lint.motive().isEmpty(),
+                Matchers.equalTo(false)
+            );
+        }
     }
 
 }

--- a/src/test/java/org/eolang/lints/XslLintsTest.java
+++ b/src/test/java/org/eolang/lints/XslLintsTest.java
@@ -34,7 +34,6 @@ import org.cactoos.proc.ForEach;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -82,6 +81,7 @@ final class XslLintsTest {
     void checksAllMotives() throws Exception {
         for (final Lint lint : new XslLints()) {
             MatcherAssert.assertThat(
+                "Lint's motive is empty, but should not be",
                 lint.motive().isEmpty(),
                 Matchers.equalTo(false)
             );

--- a/src/test/java/org/eolang/lints/comments/AsciiOnlyTest.java
+++ b/src/test/java/org/eolang/lints/comments/AsciiOnlyTest.java
@@ -31,6 +31,7 @@ import org.eolang.lints.Defect;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -58,6 +59,15 @@ final class AsciiOnlyTest {
             Matchers.is(
                 "Only ASCII characters are allowed in comments, while 'п' is used at the 3th line at the 1th position"
             )
+        );
+    }
+
+    @Test
+    void explainsMotive() throws Exception {
+        MatcherAssert.assertThat(
+            "The motive doesn't contain expected string",
+            new AsciiOnly().motive().contains("# ASCII-Only Characters in Comment"),
+            new IsEqual<>(true)
         );
     }
 


### PR DESCRIPTION
In this pull I've added new method to the `Lint` interface: `motive()`, that returns motive of the lint.

closes #19 
History:
- **feat(#19): locate motives**
- **feat(#19): implement**
- **feat(#19): ascii-only motive**
- **feat(#19): alias too long**
- **feat(#19): foo obj**
- **feat(#19): alias without tail**
- **feat(#19): typo**
- **feat(#19): broken-alias.md**
- **feat(#19): duplicate-names.md**
- **feat(#19): unused alias**
- **feat(#19): typos**
- **feat(#19): puzzle**
- **feat(#19): typo**
- **feat(#19): returnsMotive**
- **feat(#19): AsciiOnly#motive test case**
- **feat(#19): typos**
- **feat(#19): comment-not-capitalized.md**
- **feat(#19): comment motives**
- **feat(#19): document critical**
- **feat(#19): error motives**
- **feat(#19): indents**
- **feat(#19): metas**
- **feat(#19): misc**
- **feat(#19): refs**
- **feat(#19): clean for qulice**
- **feat(#19): checks all motives**
- **feat(#19): checksAllMotives**
- **feat(#19): clean for qulice**
