### PR TITLE
feat(#25): incorrect-package lint

### DIFF
--- a/src/main/resources/org/eolang/lints/metas/incorrect-package.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-package.xsl
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="incorrect-package" version="2.0">
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="/program/metas/meta">
+        <xsl:variable name="meta-head" select="head"/>
+        <xsl:variable name="meta-tail" select="tail"/>
+        <xsl:if test="$meta-head='package' and not(matches($meta-tail, '^[a-z][a-z0-9_]*(\.[a-z0-9_]+)+[0-9a-z_]$'))">
+          <xsl:element name="defect">
+            <xsl:attribute name="line">
+              <xsl:value-of select="if (@line) then @line else '0'"/>
+            </xsl:attribute>
+            <xsl:attribute name="severity">
+              <xsl:text>warning</xsl:text>
+            </xsl:attribute>
+            <xsl:text>Wrong format of package name "</xsl:text>
+            <xsl:value-of select="$meta-tail"/>
+            <xsl:text>"</xsl:text>
+          </xsl:element>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/metas/incorrect-package.md
+++ b/src/main/resources/org/eolang/motives/metas/incorrect-package.md
@@ -1,0 +1,28 @@
+# Incorrect `+package`
+
+Special meta `+package` should follow regexp:
+
+```regexp
+^[a-z][a-z0-9_]*(\.[a-z0-9_]+)+[0-9a-z_]$
+```
+
+Incorrect:
+
+```eo
++package foo
++package foo.x
++package привет, как дела?
++package привет.как
+
+[] > foo
+```
+
+Correct:
+
+```eo
++package foo.bar
++package my.awesome.package
++package test.xy
+
+[] > foo
+```

--- a/src/test/resources/org/eolang/lints/catches-incorrect-package.yaml
+++ b/src/test/resources/org/eolang/lints/catches-incorrect-package.yaml
@@ -38,5 +38,5 @@ eo: |
   +package org.eolang
   +package my.awesome.package
   +package test.xy
-  
+
   [] > foo

--- a/src/test/resources/org/eolang/lints/catches-incorrect-package.yaml
+++ b/src/test/resources/org/eolang/lints/catches-incorrect-package.yaml
@@ -1,0 +1,42 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+xsls:
+  - /org/eolang/lints/metas/incorrect-package.xsl
+tests:
+  - /defects[count(defect[@severity='warning'])=5]
+  - /defects/defect[@line='1']
+  - /defects/defect[@line='2']
+  - /defects/defect[@line='3']
+  - /defects/defect[@line='4']
+  - /defects/defect[@line='5']
+eo: |
+  +package test
+  +package test.
+  +package test.x
+  +package привет, как дела?
+  +package привет.foo
+  +package org.eolang
+  +package my.awesome.package
+  +package test.xy
+  
+  [] > foo


### PR DESCRIPTION
In this pull I've introduced new lint: `incorrect-package`, that checks correctness of the `+package` meta tail.

closes #25
History:
- **feat(#25): incorrect-package**
- **feat(#25): motive**
