### PR TITLE
feat(#54): package-contains-multiple-parts lint

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/package-contains-multiple-parts.xsl
+++ b/src/main/resources/org/eolang/lints/critical/package-contains-multiple-parts.xsl
@@ -29,7 +29,8 @@ SOFTWARE.
       <xsl:for-each select="/program/metas/meta">
         <xsl:variable name="meta-head" select="head"/>
         <xsl:variable name="meta-tail" select="tail"/>
-        <xsl:if test="$meta-head='package' and count(part) != 1">
+        <xsl:variable name="parts" select="count(part)" />
+        <xsl:if test="$meta-head='package' and $parts != 1">
           <xsl:element name="defect">
             <xsl:attribute name="line">
               <xsl:value-of select="if (@line) then @line else '0'"/>
@@ -37,9 +38,7 @@ SOFTWARE.
             <xsl:attribute name="severity">
               <xsl:text>critical</xsl:text>
             </xsl:attribute>
-            <xsl:text>Package meta must have the only one part "</xsl:text>
-            <xsl:value-of select="$meta-tail"/>
-            <xsl:text>"</xsl:text>
+            <xsl:value-of select="concat('The ', '+package meta may have only one part, which is the name of the package, while currently there are ', $parts, ' parts')"/>
           </xsl:element>
         </xsl:if>
       </xsl:for-each>

--- a/src/main/resources/org/eolang/lints/critical/package-contains-multiple-parts.xsl
+++ b/src/main/resources/org/eolang/lints/critical/package-contains-multiple-parts.xsl
@@ -37,7 +37,7 @@ SOFTWARE.
             <xsl:attribute name="severity">
               <xsl:text>critical</xsl:text>
             </xsl:attribute>
-            <xsl:text>Package meta must have only one part "</xsl:text>
+            <xsl:text>Package meta must have the only one part "</xsl:text>
             <xsl:value-of select="$meta-tail"/>
             <xsl:text>"</xsl:text>
           </xsl:element>

--- a/src/main/resources/org/eolang/lints/critical/package-contains-multiple-parts.xsl
+++ b/src/main/resources/org/eolang/lints/critical/package-contains-multiple-parts.xsl
@@ -38,7 +38,7 @@ SOFTWARE.
             <xsl:attribute name="severity">
               <xsl:text>critical</xsl:text>
             </xsl:attribute>
-            <xsl:value-of select="concat('The ', '+package meta may have only one part, which is the name of the package, while currently there are ', $parts, ' parts')"/>
+            <xsl:value-of select="concat('The +package meta may have only one part, which is the name of the package, while currently there are ', $parts, ' parts')"/>
           </xsl:element>
         </xsl:if>
       </xsl:for-each>

--- a/src/main/resources/org/eolang/lints/critical/package-contains-multiple-parts.xsl
+++ b/src/main/resources/org/eolang/lints/critical/package-contains-multiple-parts.xsl
@@ -29,7 +29,7 @@ SOFTWARE.
       <xsl:for-each select="/program/metas/meta">
         <xsl:variable name="meta-head" select="head"/>
         <xsl:variable name="meta-tail" select="tail"/>
-        <xsl:if test="$meta-head='package' and count(tokenize($meta-tail, ' ')) != 1">
+        <xsl:if test="$meta-head='package' and count(part) != 1">
           <xsl:element name="defect">
             <xsl:attribute name="line">
               <xsl:value-of select="if (@line) then @line else '0'"/>

--- a/src/main/resources/org/eolang/lints/critical/package-contains-multiple-parts.xsl
+++ b/src/main/resources/org/eolang/lints/critical/package-contains-multiple-parts.xsl
@@ -29,7 +29,7 @@ SOFTWARE.
       <xsl:for-each select="/program/metas/meta">
         <xsl:variable name="meta-head" select="head"/>
         <xsl:variable name="meta-tail" select="tail"/>
-        <xsl:variable name="parts" select="count(part)" />
+        <xsl:variable name="parts" select="count(part)"/>
         <xsl:if test="$meta-head='package' and $parts != 1">
           <xsl:element name="defect">
             <xsl:attribute name="line">
@@ -38,7 +38,9 @@ SOFTWARE.
             <xsl:attribute name="severity">
               <xsl:text>critical</xsl:text>
             </xsl:attribute>
-            <xsl:value-of select="concat('The +package meta may have only one part, which is the name of the package, while currently there are ', $parts, ' parts')"/>
+            <xsl:text>The +package meta may have only one part, which is the name of the package, while currently there are </xsl:text>
+            <xsl:value-of select="$parts"/>
+            <xsl:text> parts</xsl:text>
           </xsl:element>
         </xsl:if>
       </xsl:for-each>

--- a/src/main/resources/org/eolang/lints/critical/package-contains-multiple-parts.xsl
+++ b/src/main/resources/org/eolang/lints/critical/package-contains-multiple-parts.xsl
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="package-contains-multiple-parts" version="2.0">
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="/program/metas/meta">
+        <xsl:variable name="meta-head" select="head"/>
+        <xsl:variable name="meta-tail" select="tail"/>
+        <xsl:if test="$meta-head='package' and count(tokenize($meta-tail, ' ')) != 1">
+          <xsl:element name="defect">
+            <xsl:attribute name="line">
+              <xsl:value-of select="if (@line) then @line else '0'"/>
+            </xsl:attribute>
+            <xsl:attribute name="severity">
+              <xsl:text>critical</xsl:text>
+            </xsl:attribute>
+            <xsl:text>Package meta must have only one part "</xsl:text>
+            <xsl:value-of select="$meta-tail"/>
+            <xsl:text>"</xsl:text>
+          </xsl:element>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/metas/incorrect-package.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-package.xsl
@@ -29,7 +29,8 @@ SOFTWARE.
       <xsl:for-each select="/program/metas/meta">
         <xsl:variable name="meta-head" select="head"/>
         <xsl:variable name="meta-tail" select="tail"/>
-        <xsl:if test="$meta-head='package' and not(matches($meta-tail, '^[a-z][a-z0-9_]*(\.[a-z0-9_]+)+[0-9a-z_]$'))">
+        <xsl:variable name="first" select="normalize-space(substring-before(concat($meta-tail, ' '), ' '))"/>
+        <xsl:if test="$meta-head='package' and not(matches($first, '^[a-z][a-z0-9_]*(\.[a-z0-9_]+)+[0-9a-z_]$'))">
           <xsl:element name="defect">
             <xsl:attribute name="line">
               <xsl:value-of select="if (@line) then @line else '0'"/>
@@ -38,7 +39,7 @@ SOFTWARE.
               <xsl:text>warning</xsl:text>
             </xsl:attribute>
             <xsl:text>Wrong format of package name "</xsl:text>
-            <xsl:value-of select="$meta-tail"/>
+            <xsl:value-of select="$first"/>
             <xsl:text>"</xsl:text>
           </xsl:element>
         </xsl:if>

--- a/src/main/resources/org/eolang/motives/critical/package-contains-multiple-parts.md
+++ b/src/main/resources/org/eolang/motives/critical/package-contains-multiple-parts.md
@@ -1,0 +1,19 @@
+# `+package` contains multiple parts
+
+Special `+package` meta must be constructed from exact one part.
+
+Incorrect:
+
+```eo
++package foo bar
+
+[] > foo
+```
+
+Correct:
+
+```eo
++package foo.bar
+
+[] > foo
+```

--- a/src/test/resources/org/eolang/lints/eo-packs/catches-incorrect-package.yaml
+++ b/src/test/resources/org/eolang/lints/eo-packs/catches-incorrect-package.yaml
@@ -23,12 +23,13 @@
 xsls:
   - /org/eolang/lints/metas/incorrect-package.xsl
 tests:
-  - /defects[count(defect[@severity='warning'])=5]
+  - /defects[count(defect[@severity='warning'])=6]
   - /defects/defect[@line='1']
   - /defects/defect[@line='2']
   - /defects/defect[@line='3']
   - /defects/defect[@line='4']
   - /defects/defect[@line='5']
+  - /defects/defect[@line='9']
 eo: |
   +package test
   +package test.
@@ -38,5 +39,6 @@ eo: |
   +package org.eolang
   +package my.awesome.package
   +package test.xy
+  +package hello world
 
   [] > foo

--- a/src/test/resources/org/eolang/lints/eo-packs/catches-package-contains-multiple-parts.yaml
+++ b/src/test/resources/org/eolang/lints/eo-packs/catches-package-contains-multiple-parts.yaml
@@ -1,0 +1,40 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+xsls:
+  - /org/eolang/lints/critical/package-contains-multiple-parts.xsl
+tests:
+  - /defects[count(defect[@severity='critical'])=2]
+  - /defects/defect[@line='8']
+  - /defects/defect[@line='9']
+eo: |
+  +package test
+  +package test.
+  +package test.x
+  +package привет.foo
+  +package org.eolang
+  +package my.awesome.package
+  +package test.xy
+  +package hello world
+  +package привет, как дела?
+
+  [] > foo

--- a/src/test/resources/org/eolang/lints/eo-packs/catches-package-contains-multiple-parts.yaml
+++ b/src/test/resources/org/eolang/lints/eo-packs/catches-package-contains-multiple-parts.yaml
@@ -23,9 +23,10 @@
 xsls:
   - /org/eolang/lints/critical/package-contains-multiple-parts.xsl
 tests:
-  - /defects[count(defect[@severity='critical'])=2]
+  - /defects[count(defect[@severity='critical'])=3]
   - /defects/defect[@line='8']
   - /defects/defect[@line='9']
+  - /defects/defect[@line='10']
 eo: |
   +package test
   +package test.
@@ -36,5 +37,6 @@ eo: |
   +package test.xy
   +package hello world
   +package привет, как дела?
+  +package
 
   [] > foo


### PR DESCRIPTION
In this pull I've introduced new lint: `package-contains-multiple-parts` that issues `critical` defect if more than one part is used in `+package` tail. `incorrect-package` lint now checks only the first part of the `+package` tail, instead of full one.

closes #54
History:
- **feat(#54): check the first part**
- **feat(#54): package-contains-multiple-parts**
- **feat(#54): motive**
