### PR TITLE
feat(#53): incorrect-rt-parts lint

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/incorrect-rt-parts.xsl
+++ b/src/main/resources/org/eolang/lints/critical/incorrect-rt-parts.xsl
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="incorrect-rt-parts" version="2.0">
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="/program/metas/meta">
+        <xsl:variable name="meta-head" select="head"/>
+        <xsl:variable name="meta-tail" select="tail"/>
+        <xsl:variable name="parts" select="count(part)"/>
+        <xsl:if test="$meta-head='rt' and $parts != 2">
+          <xsl:element name="defect">
+            <xsl:attribute name="line">
+              <xsl:value-of select="if (@line) then @line else '0'"/>
+            </xsl:attribute>
+            <xsl:attribute name="severity">
+              <xsl:text>critical</xsl:text>
+            </xsl:attribute>
+            <xsl:text>The +rt meta may have only two parts, which is the name of the runtime, and the location of the runtime, while currently there are </xsl:text>
+            <xsl:value-of select="$parts"/>
+            <xsl:text> parts</xsl:text>
+          </xsl:element>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/critical/incorrect-rt-parts.md
+++ b/src/main/resources/org/eolang/motives/critical/incorrect-rt-parts.md
@@ -1,0 +1,21 @@
+# Incorrect `+rt` parts
+
+Special `+rt` meta must have exactly two parts, which is the name of the
+runtime, and the location of the runtime.
+
+Incorrect:
+
+```eo
++rt jvm
++rt jvm eolang
+
+[] > foo
+```
+
+Correct:
+
+```eo
++rt jvm org.eolang:eo-runtime:0.0.0
+
+[] > foo
+```

--- a/src/test/resources/org/eolang/lints/eo-packs/catches-incorrect-rt-parts.yaml
+++ b/src/test/resources/org/eolang/lints/eo-packs/catches-incorrect-rt-parts.yaml
@@ -23,7 +23,7 @@
 xsls:
   - /org/eolang/lints/critical/incorrect-rt-parts.xsl
 tests:
-  - /defects[count(defect[@severity='critical'])=3]
+  - /defects[count(defect[@severity='critical'])=4]
   - /defects/defect[@line='1']
   - /defects/defect[@line='2']
   - /defects/defect[@line='3']

--- a/src/test/resources/org/eolang/lints/eo-packs/catches-incorrect-rt-parts.yaml
+++ b/src/test/resources/org/eolang/lints/eo-packs/catches-incorrect-rt-parts.yaml
@@ -1,0 +1,38 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+xsls:
+  - /org/eolang/lints/critical/incorrect-rt-parts.xsl
+tests:
+  - /defects[count(defect[@severity='critical'])=3]
+  - /defects/defect[@line='1']
+  - /defects/defect[@line='2']
+  - /defects/defect[@line='3']
+  - /defects/defect[@line='4']
+eo: |
+  +rt hello
+  +rt a b c d e f
+  +rt test test test
+  +rt
+  +rt good good
+
+  [] > foo


### PR DESCRIPTION
In this pull I've introduced new lint: `incorrect-rt-parts` that issues `critical` defect in case `+rt` meta doesn't have 2 parts inside.

closes #53
History:
- **feat(#53): incorrect-rt-parts**
- **feat(#53): motive**
- **feat(#53): more errors**
