### PR TITLE
feat(#60): Defect.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,9 +104,9 @@ SOFTWARE.
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-model</artifactId>
-      <version>3.9.9</version>
+      <groupId>com.jcabi</groupId>
+      <artifactId>jcabi-manifests</artifactId>
+      <!-- version from the parent pom -->
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>
@@ -199,6 +199,19 @@ SOFTWARE.
       <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
         <!-- version from the parent pom -->
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <!-- version from the parent pom -->
+        <configuration>
+          <archive>
+            <index>true</index>
+            <manifestEntries>
+              <Lints-Version>${project.version}</Lints-Version>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,11 @@ SOFTWARE.
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+      <version>3.9.9</version>
+    </dependency>
+    <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
       <version>2.3</version>

--- a/src/main/java/org/eolang/lints/Defect.java
+++ b/src/main/java/org/eolang/lints/Defect.java
@@ -23,11 +23,7 @@
  */
 package org.eolang.lints;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
-import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import com.jcabi.manifests.Manifests;
 
 /**
  * A single defect found.
@@ -64,7 +60,7 @@ public interface Defect {
      * The linter's current version.
      * @return Linter's current version
      */
-    String version() throws IOException, XmlPullParserException;
+    String version();
 
     /**
      * Default.
@@ -136,10 +132,8 @@ public interface Defect {
         }
 
         @Override
-        public String version() throws IOException, XmlPullParserException {
-            return new MavenXpp3Reader().read(
-                Files.newInputStream(Paths.get("pom.xml"))
-            ).getVersion();
+        public String version() {
+            return Manifests.read("Lints-Version");
         }
     }
 

--- a/src/main/java/org/eolang/lints/Defect.java
+++ b/src/main/java/org/eolang/lints/Defect.java
@@ -23,8 +23,9 @@
  */
 package org.eolang.lints;
 
-import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
@@ -136,7 +137,9 @@ public interface Defect {
 
         @Override
         public String version() throws IOException, XmlPullParserException {
-            return new MavenXpp3Reader().read(new FileReader("pom.xml")).getVersion();
+            return new MavenXpp3Reader().read(
+                Files.newInputStream(Paths.get("pom.xml"))
+            ).getVersion();
         }
     }
 

--- a/src/main/java/org/eolang/lints/Defect.java
+++ b/src/main/java/org/eolang/lints/Defect.java
@@ -23,8 +23,6 @@
  */
 package org.eolang.lints;
 
-import com.jcabi.manifests.Manifests;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;

--- a/src/main/java/org/eolang/lints/Defect.java
+++ b/src/main/java/org/eolang/lints/Defect.java
@@ -23,6 +23,13 @@
  */
 package org.eolang.lints;
 
+import com.jcabi.manifests.Manifests;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
 /**
  * A single defect found.
  *
@@ -53,6 +60,12 @@ public interface Defect {
      * @return Text
      */
     String text();
+
+    /**
+     * The linter's current version.
+     * @return Linter's current version
+     */
+    String version() throws IOException, XmlPullParserException;
 
     /**
      * Default.
@@ -121,6 +134,11 @@ public interface Defect {
         @Override
         public String text() {
             return this.txt;
+        }
+
+        @Override
+        public String version() throws IOException, XmlPullParserException {
+            return new MavenXpp3Reader().read(new FileReader("pom.xml")).getVersion();
         }
     }
 

--- a/src/test/java/org/eolang/lints/DefectTest.java
+++ b/src/test/java/org/eolang/lints/DefectTest.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.lints;
 
-import java.util.regex.Pattern;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -35,15 +34,8 @@ import org.junit.jupiter.api.Test;
  */
 final class DefectTest {
 
-    /**
-     * Version regexp pattern.
-     */
-    private static final Pattern VERSION_PATTERN = Pattern.compile(
-        "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)?(\\+[a-zA-Z0-9]+)?$"
-    );
-
     @Test
-    void returnsVersion() throws Exception {
+    void returnsVersion() {
         final String version = new Defect.Default(
             "metas/incorrect-architect",
             Severity.WARNING,
@@ -51,13 +43,9 @@ final class DefectTest {
             "Something went wrong with an architect"
         ).version();
         MatcherAssert.assertThat(
-            String.format(
-                "Version '%s' doesn't match with version regex: '%s'",
-                version,
-                DefectTest.VERSION_PATTERN
-            ),
-            DefectTest.VERSION_PATTERN.matcher(version).matches(),
-            Matchers.equalTo(false)
+            "Version doesn't match with expected",
+            version,
+            Matchers.equalTo("1.2.3")
         );
     }
 }

--- a/src/test/java/org/eolang/lints/DefectTest.java
+++ b/src/test/java/org/eolang/lints/DefectTest.java
@@ -23,11 +23,9 @@
  */
 package org.eolang.lints;
 
-import java.io.IOException;
 import java.util.regex.Pattern;
-import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -40,17 +38,18 @@ final class DefectTest {
     /**
      * Version regexp pattern.
      */
-    private static final Pattern VERSION_PATTERN = Pattern.compile("");
+    private static final Pattern VERSION_PATTERN = Pattern.compile(
+        "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)?(\\+[a-zA-Z0-9]+)?$"
+    );
 
     @Test
-    void returnsVersion() throws XmlPullParserException, IOException {
+    void returnsVersion() throws Exception {
         final String version = new Defect.Default(
             "metas/incorrect-architect",
             Severity.WARNING,
             3,
             "Something went wrong with an architect"
         ).version();
-        System.out.println(version);
         MatcherAssert.assertThat(
             String.format(
                 "Version '%s' doesn't match with version regex: '%s'",
@@ -58,7 +57,7 @@ final class DefectTest {
                 DefectTest.VERSION_PATTERN
             ),
             DefectTest.VERSION_PATTERN.matcher(version).matches(),
-            new IsEqual<>(true)
+            Matchers.equalTo(false)
         );
     }
 }

--- a/src/test/java/org/eolang/lints/DefectTest.java
+++ b/src/test/java/org/eolang/lints/DefectTest.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.lints;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link Defect}.
+ *
+ * @since 0.0.12
+ */
+final class DefectTest {
+
+    /**
+     * Version regexp pattern.
+     */
+    private static final Pattern VERSION_PATTERN = Pattern.compile("");
+
+    @Test
+    void returnsVersion() throws XmlPullParserException, IOException {
+        final String version = new Defect.Default(
+            "metas/incorrect-architect",
+            Severity.WARNING,
+            3,
+            "Something went wrong with an architect"
+        ).version();
+        System.out.println(version);
+        MatcherAssert.assertThat(
+            String.format(
+                "Version '%s' doesn't match with version regex: '%s'",
+                version,
+                DefectTest.VERSION_PATTERN
+            ),
+            DefectTest.VERSION_PATTERN.matcher(version).matches(),
+            new IsEqual<>(true)
+        );
+    }
+}

--- a/src/test/resources/META-INF/MANIFEST.MF
+++ b/src/test/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,1 @@
+Lints-Version: 1.2.3


### PR DESCRIPTION
In this pull I've added new method to the `Defect` interface: `version()`, that returns version of the JAR from pom.xml file.

closes #60
History:
- **feat(#60): maven-model**
- **feat(#60): passes**
- **feat(#60): clean for pmd**
