### PR TITLE
feat(#52): unknown-rt lint

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/unknown-rt.xsl
+++ b/src/main/resources/org/eolang/lints/critical/unknown-rt.xsl
@@ -29,8 +29,17 @@ SOFTWARE.
       <xsl:for-each select="/program/metas/meta">
         <xsl:variable name="meta-head" select="head"/>
         <xsl:variable name="meta-tail" select="tail"/>
-        <xsl:variable name="first" select="substring-before($meta-tail, ' ')"/>
         <xsl:variable name="allowed" select="('jvm', 'node')"/>
+        <xsl:variable name="first">
+          <xsl:choose>
+            <xsl:when test="contains($meta-tail, ' ')">
+              <xsl:value-of select="substring-before($meta-tail, ' ')"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="$meta-tail"/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:variable>
         <xsl:if test="$meta-head='rt' and count(part) &gt; 0 and not($first = $allowed)">
           <xsl:element name="defect">
             <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/lints/critical/unknown-rt.xsl
+++ b/src/main/resources/org/eolang/lints/critical/unknown-rt.xsl
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="unknown-rt" version="2.0">
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="/program/metas/meta">
+        <xsl:variable name="meta-head" select="head"/>
+        <xsl:variable name="meta-tail" select="tail"/>
+        <xsl:variable name="first" select="substring-before($meta-tail, ' ')"/>
+        <xsl:variable name="allowed" select="('jvm', 'node')"/>
+        <xsl:if test="$meta-head='rt' and count(part) &gt; 0 and not($first = $allowed)">
+          <xsl:element name="defect">
+            <xsl:attribute name="line">
+              <xsl:value-of select="if (@line) then @line else '0'"/>
+            </xsl:attribute>
+            <xsl:attribute name="severity">
+              <xsl:text>critical</xsl:text>
+            </xsl:attribute>
+            <xsl:text>Unknown runtime used "</xsl:text>
+            <xsl:value-of select="$first"/>
+            <xsl:text>"</xsl:text>
+          </xsl:element>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/critical/unknown-rt.md
+++ b/src/main/resources/org/eolang/motives/critical/unknown-rt.md
@@ -1,0 +1,25 @@
+# Unknown `+rt`
+
+Special `+rt` meta must use only allowed values at it's first part. Currently,
+the following runtimes are supported:
+
+* [jvm](https://github.com/objectionary/eo)
+* [node](https://github.com/objectionary/eo2js)
+
+Incorrect:
+
+```eo
++rt test
++rt foo bar
+
+[] > foo
+```
+
+Correct:
+
+```eo
++rt jvm org.eolang:eo-runtime:0.0.0
++rt node eo2js-runtime:0.0.0
+
+[] > foo
+```

--- a/src/test/resources/org/eolang/lints/eo-packs/catches-unknown-rt.yaml
+++ b/src/test/resources/org/eolang/lints/eo-packs/catches-unknown-rt.yaml
@@ -1,0 +1,39 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+xsls:
+  - /org/eolang/lints/critical/unknown-rt.xsl
+  - /org/eolang/lints/set-fake-schema.xsl
+tests:
+  - /defects[count(defect[@severity='critical'])=4]
+  - /defects/defect[@line='3']
+  - /defects/defect[@line='4']
+  - /defects/defect[@line='5']
+eo: |
+  +rt jvm org.eolang:eo-runtime:0.0.0
+  +rt node path
+  +rt test test
+  +rt привет, как дела?
+  +rt foo
+  +rt
+
+  [] > foo

--- a/src/test/resources/org/eolang/lints/eo-packs/catches-unknown-rt.yaml
+++ b/src/test/resources/org/eolang/lints/eo-packs/catches-unknown-rt.yaml
@@ -24,7 +24,7 @@ xsls:
   - /org/eolang/lints/critical/unknown-rt.xsl
   - /org/eolang/lints/set-fake-schema.xsl
 tests:
-  - /defects[count(defect[@severity='critical'])=4]
+  - /defects[count(defect[@severity='critical'])=3]
   - /defects/defect[@line='3']
   - /defects/defect[@line='4']
   - /defects/defect[@line='5']

--- a/src/test/resources/org/eolang/lints/eo-packs/unknown-rt/allows-good-rt.yaml
+++ b/src/test/resources/org/eolang/lints/eo-packs/unknown-rt/allows-good-rt.yaml
@@ -28,5 +28,6 @@ tests:
 eo: |
   +rt jvm org.eolang:eo-runtime:0.0.0
   +rt node path
+  +rt
 
   [] > foo

--- a/src/test/resources/org/eolang/lints/eo-packs/unknown-rt/allows-good-rt.yaml
+++ b/src/test/resources/org/eolang/lints/eo-packs/unknown-rt/allows-good-rt.yaml
@@ -1,0 +1,32 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+xsls:
+  - /org/eolang/lints/critical/unknown-rt.xsl
+  - /org/eolang/lints/set-fake-schema.xsl
+tests:
+  - /defects[count(defect[@severity='critical'])=0]
+eo: |
+  +rt jvm org.eolang:eo-runtime:0.0.0
+  +rt node path
+
+  [] > foo

--- a/src/test/resources/org/eolang/lints/eo-packs/unknown-rt/catches-unknown-rt.yaml
+++ b/src/test/resources/org/eolang/lints/eo-packs/unknown-rt/catches-unknown-rt.yaml
@@ -25,15 +25,12 @@ xsls:
   - /org/eolang/lints/set-fake-schema.xsl
 tests:
   - /defects[count(defect[@severity='critical'])=3]
+  - /defects/defect[@line='1']
+  - /defects/defect[@line='2']
   - /defects/defect[@line='3']
-  - /defects/defect[@line='4']
-  - /defects/defect[@line='5']
 eo: |
-  +rt jvm org.eolang:eo-runtime:0.0.0
-  +rt node path
   +rt test test
   +rt привет, как дела?
   +rt foo
-  +rt
 
   [] > foo


### PR DESCRIPTION
In this pull I've introduced new lint: `unknown-rt`, that issues `critical` error in case of the first part of runtime meta `+rt` is not in the allowed scope.

closes #52
History:
- **feat(#52): unknown-rt.xsl**
- **feat(#52): passes**
