### PR TITLE
feat(#71): prohibited-package allowed in tests

### DIFF
--- a/src/main/resources/org/eolang/lints/metas/prohibited-package.xsl
+++ b/src/main/resources/org/eolang/lints/metas/prohibited-package.xsl
@@ -52,10 +52,11 @@ SOFTWARE.
   <xsl:variable name="name" select="//objects/o[1]/@name"/>
   <xsl:template match="/">
     <defects>
+      <xsl:variable name="tested" select="/program/metas/meta[head='tests']"/>
       <xsl:for-each select="/program/metas/meta">
         <xsl:variable name="meta-head" select="head"/>
         <xsl:variable name="meta-tail" select="tail"/>
-        <xsl:if test="$meta-head='package' and $meta-tail='org.eolang' and not($white-list/a=$name)">
+        <xsl:if test="not($tested) and $meta-head='package' and $meta-tail='org.eolang' and not($white-list/a=$name)">
           <xsl:element name="defect">
             <xsl:attribute name="line">
               <xsl:value-of select="if (@line) then @line else '0'"/>

--- a/src/test/resources/org/eolang/lints/eo-packs/prohibited-package/allows-packages-in-tests.yaml
+++ b/src/test/resources/org/eolang/lints/eo-packs/prohibited-package/allows-packages-in-tests.yaml
@@ -1,0 +1,33 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+xsls:
+  - /org/eolang/lints/metas/prohibited-package.xsl
+  - /org/eolang/lints/set-fake-schema.xsl
+tests:
+  - /defects[count(defect[@severity='warning'])=0]
+eo: |
+  +package org.eolang
+  +tests
+
+  # No comments.
+  [] > main


### PR DESCRIPTION
In this pull I've updated `prohibited-package` lint in order to not issue defect when preserved packages are used in tests.

closes #71