### PR TITLE
feat(#129): StanfordNLP in UnitTestIsNotVerb lint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,9 +109,15 @@ SOFTWARE.
       <!-- version from the parent pom -->
     </dependency>
     <dependency>
-      <groupId>org.apache.opennlp</groupId>
-      <artifactId>opennlp-tools</artifactId>
-      <version>2.2.0</version>
+      <groupId>edu.stanford.nlp</groupId>
+      <artifactId>stanford-corenlp</artifactId>
+      <version>4.5.7</version>
+    </dependency>
+    <dependency>
+      <groupId>edu.stanford.nlp</groupId>
+      <artifactId>stanford-corenlp</artifactId>
+      <version>4.5.7</version>
+      <classifier>models</classifier>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>

--- a/src/main/java/org/eolang/lints/ProgramLints.java
+++ b/src/main/java/org/eolang/lints/ProgramLints.java
@@ -24,8 +24,6 @@
 package org.eolang.lints;
 
 import com.jcabi.xml.XML;
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.Arrays;
 import org.cactoos.Scalar;
 import org.cactoos.iterable.Joined;
@@ -41,26 +39,14 @@ public final class ProgramLints implements Scalar<Iterable<Lint<XML>>> {
 
     @Override
     public Iterable<Lint<XML>> value() {
-        try {
-            return new Sticky<>(
-                new Joined<Lint<XML>>(
-                    new XslLints(),
-                    Arrays.asList(
-                        new AsciiOnly(),
-                        new UnitTestIsNotVerb()
-                    )
+        return new Sticky<>(
+            new Joined<Lint<XML>>(
+                new XslLints(),
+                Arrays.asList(
+                    new AsciiOnly(),
+                    new UnitTestIsNotVerb()
                 )
-            );
-        } catch (final IOException exception) {
-            throw new IllegalStateException(
-                "Failed to allocate lints",
-                exception
-            );
-        } catch (final URISyntaxException exception) {
-            throw new IllegalStateException(
-                "URI syntax is broken",
-                exception
-            );
-        }
+            )
+        );
     }
 }

--- a/src/main/java/org/eolang/lints/misc/UnitTestIsNotVerb.java
+++ b/src/main/java/org/eolang/lints/misc/UnitTestIsNotVerb.java
@@ -46,11 +46,6 @@ import org.eolang.lints.Severity;
  * Lint that checks test object name is a verb in singular.
  *
  * @since 0.0.22
- * @todo #72:60min Configure maven to download model file during the build and place into the JAR.
- *  Currently, we download model file each time when creating the lint, which may
- *  be slow in the usage of this lint. Instead, let's configure maven to download
- *  model file during the build, and place into JAR, so lint will be able to locate
- *  file from resources faster.
  */
 public final class UnitTestIsNotVerb implements Lint<XML> {
 

--- a/src/main/java/org/eolang/lints/misc/UnitTestIsNotVerb.java
+++ b/src/main/java/org/eolang/lints/misc/UnitTestIsNotVerb.java
@@ -44,8 +44,20 @@ import org.eolang.lints.Severity;
 
 /**
  * Lint that checks test object name is a verb in singular.
- *
+ * This lint uses <a href="https://stanfordnlp.github.io/CoreNLP/">Stanford CoreNLP model</a>
+ * with POS tagging capabilities in order to determine the part of speech and
+ * tense for test object name. Originally, we used <a href="https://opennlp.apache.org/">OpenNLP</a>
+ * library to do that, but switched to the Stanford CoreNLP, due to merging all
+ * verb tags into single `VERB` POS tag, that sacrifices important information
+ * for us about verb tenses, and appeared in OpenNLP 2.4.0+. You can read more
+ * about the reason of this <a href="https://github.com/objectionary/lints/issues/129">here</a>
+ * and <a href="https://github.com/objectionary/lints/pull/126#issuecomment-2531121073">here</a>.
  * @since 0.0.22
+ * @todo #129:60min Library stanford-corenlp-4.5.7-models.jar takes too much in size.
+ *  Currently, JAR takes ~452mb, which may cause some troubles to the users of
+ *  the lints library. Let's think what we can do about this. We should check is
+ *  it possible to get rid of this dependency and download models from the other
+ *  source.
  */
 public final class UnitTestIsNotVerb implements Lint<XML> {
 

--- a/src/main/java/org/eolang/lints/misc/UnitTestIsNotVerb.java
+++ b/src/main/java/org/eolang/lints/misc/UnitTestIsNotVerb.java
@@ -92,7 +92,8 @@ public final class UnitTestIsNotVerb implements Lint<XML> {
                     .concat(
                         Stream.of("It"),
                         Arrays.stream(UnitTestIsNotVerb.KEBAB.split(name))
-                    ).map(s -> s.toLowerCase(Locale.ROOT))
+                    )
+                    .map(s -> s.toLowerCase(Locale.ROOT))
                     .collect(Collectors.joining(" "))
             );
             this.pipeline.annotate(doc);

--- a/src/test/java/org/eolang/lints/misc/UnitTestIsNotVerbTest.java
+++ b/src/test/java/org/eolang/lints/misc/UnitTestIsNotVerbTest.java
@@ -66,7 +66,7 @@ final class UnitTestIsNotVerbTest {
                     )
                 ).parsed()
             ),
-            Matchers.hasSize(38)
+            Matchers.hasSize(40)
         );
     }
 

--- a/src/test/resources/org/eolang/lints/misc/test-object-is-not-verb-in-singular/bad-tests.eo
+++ b/src/test/resources/org/eolang/lints/misc/test-object-is-not-verb-in-singular/bad-tests.eo
@@ -173,3 +173,11 @@
 # Test.
 [] > chicken-as-expected
   42 > @
+
+# Test
+[] > please-reboot
+  42 > @
+
+# Test.
+[] > hope-it-works
+  42 > @

--- a/src/test/resources/org/eolang/lints/misc/test-object-is-not-verb-in-singular/good-tests.eo
+++ b/src/test/resources/org/eolang/lints/misc/test-object-is-not-verb-in-singular/good-tests.eo
@@ -113,11 +113,3 @@
 # Test.
 [] > is-almost-correct
   42 > @
-
-# Test
-[] > please-reboot
-  42 > @
-
-# Test.
-[] > hope-it-works
-  42 > @


### PR DESCRIPTION
In this pull request I've replaced `opennlp` with `stanford-corenlp` library, and made `UnitTestIsNotVerb` lint stricter by allowing only `VBZ` (Verb, 3rd person singular present) verbs in the test names.

closes #129