### PR TITLE
feat(#138): regex-tests.eo as test case for `UnitTestIsNotVerb` lint

### DIFF
--- a/src/test/java/org/eolang/lints/misc/UnitTestIsNotVerbTest.java
+++ b/src/test/java/org/eolang/lints/misc/UnitTestIsNotVerbTest.java
@@ -24,7 +24,7 @@
 package org.eolang.lints.misc;
 
 import com.yegor256.MayBeSlow;
-import com.yegor256.WeAreOnline;
+import java.io.IOException;
 import org.cactoos.io.ResourceOf;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 final class UnitTestIsNotVerbTest {
 
     @Test
-    @ExtendWith(WeAreOnline.class)
     @ExtendWith(MayBeSlow.class)
     void catchesBadName() throws Exception {
         MatcherAssert.assertThat(
@@ -57,7 +56,6 @@ final class UnitTestIsNotVerbTest {
     }
 
     @Test
-    @ExtendWith(WeAreOnline.class)
     @ExtendWith(MayBeSlow.class)
     void allowsGoodNames() throws Exception {
         MatcherAssert.assertThat(
@@ -70,6 +68,22 @@ final class UnitTestIsNotVerbTest {
                 ).parsed()
             ),
             Matchers.hasSize(0)
+        );
+    }
+
+    @Test
+    @ExtendWith(MayBeSlow.class)
+    void lintsRegexTests() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects size doesn't match with expected",
+            new UnitTestIsNotVerb().defects(
+                new EoSyntax(
+                    new ResourceOf(
+                        "org/eolang/lints/misc/test-object-is-not-verb-in-singular/regex-tests.eo"
+                    )
+                ).parsed()
+            ),
+            Matchers.hasSize(12)
         );
     }
 }

--- a/src/test/resources/org/eolang/lints/misc/test-object-is-not-verb-in-singular/regex-tests.eo
+++ b/src/test/resources/org/eolang/lints/misc/test-object-is-not-verb-in-singular/regex-tests.eo
@@ -1,0 +1,174 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias org.eolang.txt.regex
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++tests
++package org.eolang.txt
++version 0.48.1
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > matches-regex-against-the-pattern
+  (regex "/[a-z]+/").compiled.matches "hello" > @
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > does-not-matches-regex-against-the-pattern
+  ((regex "/[a-z]+/").compiled.matches "123").not > @
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > matched-sequence-has-right-border-indexes
+  ((regex "/[a-z]+/").match "!hello!").next > n
+  and. > @
+    0.eq n.start
+    and.
+      1.eq n.from
+      6.eq n.to
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > regex-returns-valid-matched-string-sequence
+  ((regex "/[a-z]+/").match "!hello!").next.text.eq "hello" > @
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > regex-returns-valid-second-matched-block
+  ((regex "/[a-z]+/").match "!hello!world!").next.next > second
+  and. > @
+    and.
+      and.
+        and.
+          second.text.eq "world"
+          second.position.eq 2
+        second.start.eq 6
+      second.from.eq 7
+    second.to.eq 12
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > throws-on-getting-next-on-not-matched-block
+  ((regex "/[a-z]+/").match "123").next.next > @
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > throws-on-getting-from-position-on-not-matched-block
+  ((regex "/[a-z]+/").match "123").next.from > @
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > throws-on-getting-to-position-on-not-matched-block
+  ((regex "/[a-z]+/").match "123").next.to > @
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > throws-on-getting-groups-count-on-not-matched-block
+  ((regex "/[a-z]+/").match "123").next.groups-count > @
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > throws-on-getting-groups-on-not-matched-block
+  ((regex "/[a-z]+/").match "123").next.groups > @
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > throws-on-getting-specified-group-on-not-matched-block
+  ((regex "/[a-z]+/").match "123").next.group 1 > @
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > throws-on-getting-text-on-not-matched-block
+  ((regex "/[a-z]+/").match "123").next.text > @
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > regex-matches-dotall-option
+  regex
+    "/(.*)/s"
+  .compiled
+  .matches > @
+    "too \\n many \\n line \\n Feed\\n"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > regex-matches-with-case-insensitive-option
+  regex
+    "/(string)/i"
+  .compiled
+  .matches > @
+    "StRiNg"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > regex-matches-with-multiline-option
+  regex
+    "/(^([0-9]+).*)/m"
+  .compiled
+  .matches > @
+    "1 bottle of water on the wall. \\n1 bottle of water."
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > regex-matches-entire-pattern
+  regex
+    "/[0-9]/\\d+/"
+  .compiled
+  .matches > @
+    "2/75"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > regex-matches-with-regex-unix-lines
+  regex
+    "/(.+)/d"
+  .compiled
+  .matches > @
+    "A\\r\\nB\\rC\\nD"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > regex-matches-with-regex-case-insensitive-and-caps
+  regex
+    "/(word)/i"
+  .compiled
+  .matches > @
+    "WORD"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > regex-ignores-comments-in-string
+  regex
+    "/(\\d) #ignore this comment/x"
+  .compiled
+  .matches > @
+    "4"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > regex-matches-with-unicode-case-and-insensitive
+  regex
+    "/(yildirim)/ui"
+  .compiled
+  .matches > @
+    "Yıldırım"
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > throws-on-missing-first-slash-in-regex
+  (regex "(.)+").compiled > @
+
+# This unit test is supposed to check the functionality of the corresponding object.
+[] > regex-contains-valid-groups-on-each-matched-block
+  ((regex "/([a-z]+)([1-9]{1})/").compiled.match "!hello1!world2").next > first
+  first.next > second
+  and. > @
+    and.
+      and.
+        first.groups-count.eq 3
+        (first.group 1).eq "hello"
+      (first.group 2).eq "1"
+    and.
+      and.
+        second.groups-count.eq 3
+        (second.group 1).eq "world"
+      (second.group 2).eq "2"


### PR DESCRIPTION
In this pull I've added new test case for `UnitTestIsNotVerb` lint: `regex-tests.eo` as real-world example for the lint.

ref #138