### PR TITLE
feat(#16): comment-is-too-wide lint

### DIFF
--- a/src/main/resources/org/eolang/lints/comments/comment-is-too-wide.xsl
+++ b/src/main/resources/org/eolang/lints/comments/comment-is-too-wide.xsl
@@ -33,19 +33,19 @@ SOFTWARE.
         <xsl:choose>
           <xsl:when test="count($lines) &gt; 1">
             <xsl:for-each select="$lines[string-length(.) &gt; $max]">
-                <xsl:element name="defect">
-                  <xsl:attribute name="line">
-                    <xsl:value-of select="$line"/>
-                  </xsl:attribute>
-                  <xsl:attribute name="severity">
-                    <xsl:text>warning</xsl:text>
-                  </xsl:attribute>
-                  <xsl:text>The comment line width is "</xsl:text>
-                  <xsl:value-of select="string-length(.)"/>
-                  <xsl:text>", while "</xsl:text>
-                  <xsl:value-of select="$max"/>
-                  <xsl:text>" is max allowed</xsl:text>
-                </xsl:element>
+              <xsl:element name="defect">
+                <xsl:attribute name="line">
+                  <xsl:value-of select="$line"/>
+                </xsl:attribute>
+                <xsl:attribute name="severity">
+                  <xsl:text>warning</xsl:text>
+                </xsl:attribute>
+                <xsl:text>The comment line width is "</xsl:text>
+                <xsl:value-of select="string-length(.)"/>
+                <xsl:text>", while "</xsl:text>
+                <xsl:value-of select="$max"/>
+                <xsl:text>" is max allowed</xsl:text>
+              </xsl:element>
             </xsl:for-each>
           </xsl:when>
           <xsl:otherwise>

--- a/src/main/resources/org/eolang/lints/comments/comment-is-too-wide.xsl
+++ b/src/main/resources/org/eolang/lints/comments/comment-is-too-wide.xsl
@@ -27,20 +27,45 @@ SOFTWARE.
   <xsl:template match="/">
     <xsl:variable name="max" select="80"/>
     <defects>
-      <xsl:for-each select="/program/comments/comment[string-length(.) &gt; $max]">
-        <xsl:element name="defect">
-          <xsl:attribute name="line">
-            <xsl:value-of select="if (@line) then @line else '0'"/>
-          </xsl:attribute>
-          <xsl:attribute name="severity">
-            <xsl:text>warning</xsl:text>
-          </xsl:attribute>
-          <xsl:text>The comment width is "</xsl:text>
-          <xsl:value-of select="string-length(.)"/>
-          <xsl:text>", while "</xsl:text>
-          <xsl:value-of select="$max"/>
-          <xsl:text>" is max allowed</xsl:text>
-        </xsl:element>
+      <xsl:for-each select="/program/comments/comment">
+        <xsl:variable name="line" select="if (@line) then @line else '0'"/>
+        <xsl:variable name="lines" select="tokenize(replace(., '\\n', '&#xA;'), '&#xA;')"/>
+        <xsl:choose>
+          <xsl:when test="count($lines) &gt; 1">
+            <xsl:for-each select="$lines[string-length(.) &gt; $max]">
+                <xsl:element name="defect">
+                  <xsl:attribute name="line">
+                    <xsl:value-of select="$line"/>
+                  </xsl:attribute>
+                  <xsl:attribute name="severity">
+                    <xsl:text>warning</xsl:text>
+                  </xsl:attribute>
+                  <xsl:text>The comment line width is "</xsl:text>
+                  <xsl:value-of select="string-length(.)"/>
+                  <xsl:text>", while "</xsl:text>
+                  <xsl:value-of select="$max"/>
+                  <xsl:text>" is max allowed</xsl:text>
+                </xsl:element>
+            </xsl:for-each>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:if test="string-length(.) &gt; $max">
+              <xsl:element name="defect">
+                <xsl:attribute name="line">
+                  <xsl:value-of select="$line"/>
+                </xsl:attribute>
+                <xsl:attribute name="severity">
+                  <xsl:text>warning</xsl:text>
+                </xsl:attribute>
+                <xsl:text>The comment width is "</xsl:text>
+                <xsl:value-of select="string-length(.)"/>
+                <xsl:text>", while "</xsl:text>
+                <xsl:value-of select="$max"/>
+                <xsl:text>" is max allowed</xsl:text>
+              </xsl:element>
+            </xsl:if>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:for-each>
     </defects>
   </xsl:template>

--- a/src/main/resources/org/eolang/lints/comments/comment-is-too-wide.xsl
+++ b/src/main/resources/org/eolang/lints/comments/comment-is-too-wide.xsl
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="comment-is-too-wide" version="2.0">
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <xsl:variable name="max" select="80"/>
+    <defects>
+      <xsl:for-each select="/program/comments/comment[string-length(.) &gt; $max]">
+        <xsl:element name="defect">
+          <xsl:attribute name="line">
+            <xsl:value-of select="if (@line) then @line else '0'"/>
+          </xsl:attribute>
+          <xsl:attribute name="severity">
+            <xsl:text>warning</xsl:text>
+          </xsl:attribute>
+          <xsl:text>The comment width is "</xsl:text>
+          <xsl:value-of select="string-length(.)"/>
+          <xsl:text>", while "</xsl:text>
+          <xsl:value-of select="$max"/>
+          <xsl:text>" is max allowed</xsl:text>
+        </xsl:element>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/comments/comment-is-too-wide.xsl
+++ b/src/main/resources/org/eolang/lints/comments/comment-is-too-wide.xsl
@@ -29,7 +29,7 @@ SOFTWARE.
     <defects>
       <xsl:for-each select="/program/comments/comment">
         <xsl:variable name="line" select="if (@line) then @line else '0'"/>
-        <xsl:variable name="lines" select="tokenize(replace(., '\\n', '&#xA;'), '&#xA;')"/>
+        <xsl:variable name="lines" select="tokenize(replace(., '\\n', '&#10;'), '&#10;')"/>
         <xsl:choose>
           <xsl:when test="count($lines) &gt; 1">
             <xsl:for-each select="$lines[string-length(.) &gt; $max]">

--- a/src/main/resources/org/eolang/motives/comments/comment-is-too-wide.md
+++ b/src/main/resources/org/eolang/motives/comments/comment-is-too-wide.md
@@ -1,0 +1,17 @@
+# Comment is too wide
+
+Each comment should be not wider than 80 characters.
+
+Incorrect:
+
+```eo
+# This is a very long comment that contains more than eighty characters and should be flagged by the lint as too wide.
+[] > foo
+```
+
+Correct:
+
+```eo
+# This is a good comment.
+[] > foo
+```

--- a/src/test/resources/org/eolang/lints/packs/comment-is-too-wide/allows-good-comment-width.yaml
+++ b/src/test/resources/org/eolang/lints/packs/comment-is-too-wide/allows-good-comment-width.yaml
@@ -1,0 +1,30 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/comments/comment-is-too-wide.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # This comment is good.
+  [] > foo
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/comment-is-too-wide/allows-multiline-good-comment.yaml
+++ b/src/test/resources/org/eolang/lints/packs/comment-is-too-wide/allows-multiline-good-comment.yaml
@@ -1,0 +1,33 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/comments/comment-is-too-wide.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # This is good line.
+  # This is good line too.
+  # This is good line as well.
+  # We are here!
+  [] > foo
+    52 > @

--- a/src/test/resources/org/eolang/lints/packs/comment-is-too-wide/catches-multiline-wide-comment.yaml
+++ b/src/test/resources/org/eolang/lints/packs/comment-is-too-wide/catches-multiline-wide-comment.yaml
@@ -1,0 +1,32 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/comments/comment-is-too-wide.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='3']
+input: |
+  # This is good line.
+  # This is a very long line that contains more than eighty characters and should be flagged by the lint as too wide.
+  [] > foo
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/comment-is-too-wide/catches-too-wide-comment.yaml
+++ b/src/test/resources/org/eolang/lints/packs/comment-is-too-wide/catches-too-wide-comment.yaml
@@ -1,0 +1,31 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/comments/comment-is-too-wide.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='2']
+input: |
+  # This is a very long comment that contains more than eighty characters and should be flagged by the lint as too wide.
+  [] > foo
+    42 > @


### PR DESCRIPTION
In this pull I've introduced new lint: `comment-is-too-wide`, that issues `warning` defect if comment line is wider than 80 characters.

closes #16
History:
- **feat(#16): comment-is-too-wide**
- **feat(#16): multiline test cases**
- **feat(#16): passes with multilines**
- **feat(#16): indents**
