### PR TITLE
feat(#46): atom-with-data lint

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/atom-with-data.xsl
+++ b/src/main/resources/org/eolang/lints/critical/atom-with-data.xsl
@@ -26,10 +26,10 @@ SOFTWARE.
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:apply-templates select="//o[@atom]" mode="with-data"/>
+      <xsl:apply-templates select="//o[@atom]" mode="atom"/>
     </defects>
   </xsl:template>
-  <xsl:template match="o" mode="with-data">
+  <xsl:template match="o" mode="atom">
     <xsl:variable name="data" select="normalize-space(string-join(text(), ''))"/>
     <xsl:if test="$data != ''">
       <defect>

--- a/src/main/resources/org/eolang/lints/critical/atom-with-data.xsl
+++ b/src/main/resources/org/eolang/lints/critical/atom-with-data.xsl
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="atom-with-data" version="2.0">
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:apply-templates select="//o[@atom]" mode="with-data"/>
+    </defects>
+  </xsl:template>
+  <xsl:template match="o" mode="with-data">
+    <xsl:variable name="data" select="normalize-space(string-join(text(), ''))"/>
+    <xsl:if test="$data != ''">
+      <defect>
+        <xsl:attribute name="line">
+          <xsl:value-of select="if (@line) then @line else '0'"/>
+        </xsl:attribute>
+        <xsl:attribute name="severity">critical</xsl:attribute>
+        <xsl:text>Atoms must not contain data, while this object contains "</xsl:text>
+        <xsl:value-of select="$data"/>
+        <xsl:text>"</xsl:text>
+      </defect>
+    </xsl:if>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/critical/atom-with-data.md
+++ b/src/main/resources/org/eolang/motives/critical/atom-with-data.md
@@ -1,0 +1,28 @@
+# Atom With Data
+
+Each atom, represented by `<o/>` containing `@atom`, in [XMIR], must not have
+the text data inside.
+
+Incorrect:
+
+```xml
+<program>
+  <objects>
+    <o atom="Foo">
+      A1-B2-C3-D4-E5
+    </o>
+  </objects>
+</program>
+```
+
+Correct:
+
+```xml
+<program>
+  <objects>
+    <o atom="Foo"/>
+  </objects>
+</program>
+```
+
+[XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html

--- a/src/test/resources/org/eolang/lints/packs/atom-with-data/allows-atom-with-nested-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/atom-with-data/allows-atom-with-nested-object.yaml
@@ -1,0 +1,34 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/atom-with-data.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o atom="Foo">
+        <o name="foo"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/atom-with-data/allows-atom-without-data.yaml
+++ b/src/test/resources/org/eolang/lints/packs/atom-with-data/allows-atom-without-data.yaml
@@ -1,0 +1,32 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/atom-with-data.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o atom="Foo"/>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/atom-with-data/catches-atom-with-data.yaml
+++ b/src/test/resources/org/eolang/lints/packs/atom-with-data/catches-atom-with-data.yaml
@@ -1,0 +1,34 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/atom-with-data.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=1]
+document: |
+  <program>
+    <objects>
+      <o atom="Foo">
+       A1-B2-C3-D4-E5
+      </o>
+    </objects>
+  </program>


### PR DESCRIPTION
In this pull I've introduced new lint: `atom-with-data`, that issues `critical` defect in case atom has data inside.

closes #46