### PR TITLE
feat(#68): name-outside-of-abstract-object lint

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/name-outside-of-abstract-object.xsl
+++ b/src/main/resources/org/eolang/lints/critical/name-outside-of-abstract-object.xsl
@@ -26,7 +26,7 @@ SOFTWARE.
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:apply-templates select="//o[@name and not(../@abstract)]" mode="named"/>
+      <xsl:apply-templates select="//o[@name and ../@base]" mode="named"/>
     </defects>
   </xsl:template>
   <xsl:template match="o" mode="named">
@@ -35,7 +35,7 @@ SOFTWARE.
         <xsl:value-of select="if (@line) then @line else '0'"/>
       </xsl:attribute>
       <xsl:attribute name="severity">critical</xsl:attribute>
-      <xsl:text>The "@name" attribute may only be present if the parent of the object has @abstract attribute</xsl:text>
+      <xsl:text>The "@name" attribute may only be present if the parent of the object is abstract</xsl:text>
     </defect>
   </xsl:template>
 </xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/critical/name-outside-of-abstract-object.xsl
+++ b/src/main/resources/org/eolang/lints/critical/name-outside-of-abstract-object.xsl
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="name-outside-of-abstract-object" version="2.0">
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:apply-templates select="//o[@name and not(../@abstract)]" mode="named"/>
+    </defects>
+  </xsl:template>
+  <xsl:template match="o" mode="named">
+    <defect>
+      <xsl:attribute name="line">
+        <xsl:value-of select="if (@line) then @line else '0'"/>
+      </xsl:attribute>
+      <xsl:attribute name="severity">critical</xsl:attribute>
+      <xsl:text>The "@name" attribute may only be present if the parent of the object has @abstract attribute</xsl:text>
+    </defect>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/critical/name-outside-of-abstract-object.md
+++ b/src/main/resources/org/eolang/motives/critical/name-outside-of-abstract-object.md
@@ -1,0 +1,22 @@
+# `@name` Outside of Abstract Object
+
+The `@name` attribute may only be present in `<o/>` in [XMIR], only if the
+parent of the object has `@abstract` attribute.
+
+Incorrect:
+
+```xml
+<o base="foo">
+  <o name="bar"/>
+</o>
+```
+
+Correct:
+
+```xml
+<o abstract="">
+  <o name="bar"/>
+</o>
+```
+
+[XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html

--- a/src/main/resources/org/eolang/motives/critical/name-outside-of-abstract-object.md
+++ b/src/main/resources/org/eolang/motives/critical/name-outside-of-abstract-object.md
@@ -14,7 +14,7 @@ Incorrect:
 Correct:
 
 ```xml
-<o abstract="">
+<o>
   <o name="bar"/>
 </o>
 ```

--- a/src/test/resources/org/eolang/lints/packs/name-outside-of-abstract-object/allows-name-inside-abstract.yaml
+++ b/src/test/resources/org/eolang/lints/packs/name-outside-of-abstract-object/allows-name-inside-abstract.yaml
@@ -1,0 +1,34 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/name-outside-of-abstract-object.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o abstract="">
+        <o name="bar"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/name-outside-of-abstract-object/allows-name-inside-abstract.yaml
+++ b/src/test/resources/org/eolang/lints/packs/name-outside-of-abstract-object/allows-name-inside-abstract.yaml
@@ -27,7 +27,7 @@ asserts:
 document: |
   <program>
     <objects>
-      <o abstract="">
+      <o>
         <o name="bar"/>
       </o>
     </objects>

--- a/src/test/resources/org/eolang/lints/packs/name-outside-of-abstract-object/catches-name-inside-not-abstract.yaml
+++ b/src/test/resources/org/eolang/lints/packs/name-outside-of-abstract-object/catches-name-inside-not-abstract.yaml
@@ -1,0 +1,34 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/name-outside-of-abstract-object.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=1]
+document: |
+  <program>
+    <objects>
+      <o base="foo">
+        <o name="bar"/>
+      </o>
+    </objects>
+  </program>


### PR DESCRIPTION
In this pull I've introduced new lint: `name-outside-of-abstract`, that issues `critical` defect if `<o/>` has `@name` attribute, but his parent object is not abstract.

closes #68