### PR TITLE
feat(#23): architect-duplicate-lint

### DIFF
--- a/src/main/resources/org/eolang/lints/metas/architect-duplicate.xsl
+++ b/src/main/resources/org/eolang/lints/metas/architect-duplicate.xsl
@@ -29,7 +29,7 @@ SOFTWARE.
       <xsl:if test="count(/program/metas/meta[head ='architect'])&gt;1">
         <xsl:element name="defect">
           <xsl:attribute name="line">
-            <xsl:text>0</xsl:text>
+            <xsl:value-of select="/program/metas/meta[head = 'architect'][2]/@line"/>
           </xsl:attribute>
           <xsl:attribute name="severity">
             <xsl:text>error</xsl:text>

--- a/src/main/resources/org/eolang/lints/metas/architect-duplicate.xsl
+++ b/src/main/resources/org/eolang/lints/metas/architect-duplicate.xsl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="architect-duplicate" version="2.0">
+  <xsl:output encoding="UTF-8"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:if test="count(/program/metas/meta[head ='architect'])&gt;1">
+        <xsl:element name="defect">
+          <xsl:attribute name="line">
+            <xsl:text>0</xsl:text>
+          </xsl:attribute>
+          <xsl:attribute name="severity">
+            <xsl:text>error</xsl:text>
+          </xsl:attribute>
+          <xsl:text>There are more than one +architect meta specified</xsl:text>
+        </xsl:element>
+      </xsl:if>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/metas/architect-duplicate.md
+++ b/src/main/resources/org/eolang/motives/metas/architect-duplicate.md
@@ -1,0 +1,22 @@
+# Architect Duplicate
+
+Each `.eo` file must have only one architect.
+
+Incorrect:
+
+```eo
++architect jeff@google.com
++architect ivan@google.com
+
+# Foo.
+[] > foo
+```
+
+Correct:
+
+```eo
++architect jeff@google.com
+
+# Foo.
+[] > foo
+```

--- a/src/test/resources/org/eolang/lints/packs/architect-duplicate/allows-single.yaml
+++ b/src/test/resources/org/eolang/lints/packs/architect-duplicate/allows-single.yaml
@@ -1,0 +1,31 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/metas/architect-duplicate.xsl
+asserts:
+  - /defects[count(defect[@severity='error'])=0]
+input: |
+  +architect jeff@google.com
+
+  # Foo.
+  [] > foo

--- a/src/test/resources/org/eolang/lints/packs/architect-duplicate/catches-duplicate.yaml
+++ b/src/test/resources/org/eolang/lints/packs/architect-duplicate/catches-duplicate.yaml
@@ -24,6 +24,7 @@ sheets:
   - /org/eolang/lints/metas/architect-duplicate.xsl
 asserts:
   - /defects[count(defect[@severity='error'])=1]
+  - /defects/defect[@line='2']
 input: |
   +architect jeff@google.com
   +architect ivan@google.com

--- a/src/test/resources/org/eolang/lints/packs/architect-duplicate/catches-duplicate.yaml
+++ b/src/test/resources/org/eolang/lints/packs/architect-duplicate/catches-duplicate.yaml
@@ -1,0 +1,32 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/metas/architect-duplicate.xsl
+asserts:
+  - /defects[count(defect[@severity='error'])=1]
+input: |
+  +architect jeff@google.com
+  +architect ivan@google.com
+
+  # Foo.
+  [] > foo


### PR DESCRIPTION
In this pull I've implemented new lint: `architect-duplicate`, that ensures that only one `+architect` meta is in use.

closes #23