### PR TITLE
feat(#49): package-without-tail lint

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/package-without-tail.xsl
+++ b/src/main/resources/org/eolang/lints/critical/package-without-tail.xsl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="package-without-tail" version="2.0">
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:if test="/program/metas/meta[head = 'package' and tail = '']">
+        <xsl:element name="defect">
+          <xsl:attribute name="line">
+            <xsl:text>0</xsl:text>
+          </xsl:attribute>
+          <xsl:attribute name="severity">
+            <xsl:text>critical</xsl:text>
+          </xsl:attribute>
+          <xsl:text>The +package meta must have a tail</xsl:text>
+        </xsl:element>
+      </xsl:if>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/critical/package-without-tail.xsl
+++ b/src/main/resources/org/eolang/lints/critical/package-without-tail.xsl
@@ -26,17 +26,15 @@ SOFTWARE.
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:if test="/program/metas/meta[head = 'package' and tail = '']">
-        <xsl:element name="defect">
+      <xsl:for-each select="/program/metas/meta[head = 'package' and tail = '']">
+        <defect>
           <xsl:attribute name="line">
-            <xsl:text>0</xsl:text>
+            <xsl:value-of select="@line"/>
           </xsl:attribute>
-          <xsl:attribute name="severity">
-            <xsl:text>critical</xsl:text>
-          </xsl:attribute>
+          <xsl:attribute name="severity">critical</xsl:attribute>
           <xsl:text>The +package meta must have a tail</xsl:text>
-        </xsl:element>
-      </xsl:if>
+        </defect>
+      </xsl:for-each>
     </defects>
   </xsl:template>
 </xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/critical/package-without-tail.md
+++ b/src/main/resources/org/eolang/motives/critical/package-without-tail.md
@@ -1,0 +1,21 @@
+# `+package` Without Tail
+
+Special `+package` meta must have a tail.
+
+Incorrect:
+
+```eo
++package
+
+# Foo.
+[] > foo
+```
+
+Correct:
+
+```eo
++package foo
+
+# Foo.
+[] > foo
+```

--- a/src/test/resources/org/eolang/lints/packs/package-without-tail/allows-package-with-tail.yaml
+++ b/src/test/resources/org/eolang/lints/packs/package-without-tail/allows-package-with-tail.yaml
@@ -1,0 +1,31 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/package-without-tail.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+input: |
+  +package foo
+
+  # Foo.
+  [] > foo

--- a/src/test/resources/org/eolang/lints/packs/package-without-tail/catches-empty-tail.yaml
+++ b/src/test/resources/org/eolang/lints/packs/package-without-tail/catches-empty-tail.yaml
@@ -1,0 +1,31 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/package-without-tail.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=1]
+input: |
+  +package
+
+  # Foo.
+  [] > foo


### PR DESCRIPTION
In this pull, I've introduced new lint: `package-without-tail` that issues `critical` defect if `+package` meta is used without a tail.

closes #49