### PR TITLE
fix(#179): `Program#defects()` does not declare `IOException`

### DIFF
--- a/src/main/java/org/eolang/lints/Program.java
+++ b/src/main/java/org/eolang/lints/Program.java
@@ -95,7 +95,7 @@ public final class Program {
      * Find defects possible defects in the XM§IR file.
      * @return All defects found
      */
-    public Collection<Defect> defects() throws IOException {
+    public Collection<Defect> defects() {
         try {
             final Collection<Defect> messages = new ArrayList<>(0);
             for (final Lint<XML> lint : this.lints) {

--- a/src/main/java/org/eolang/lints/Programs.java
+++ b/src/main/java/org/eolang/lints/Programs.java
@@ -118,10 +118,21 @@ public final class Programs {
      * Find defects possible defects in the XMIR file.
      * @return All defects found
      */
-    public Collection<Defect> defects() throws IOException {
+    public Collection<Defect> defects() {
         final Collection<Defect> messages = new LinkedList<>();
         for (final Lint<Map<String, XML>> lint : this.lints) {
-            messages.addAll(lint.defects(this.pkg));
+            try {
+                messages.addAll(lint.defects(this.pkg));
+            } catch (final IOException exception) {
+                throw new IllegalStateException(
+                    String.format(
+                        "Failed to find defects in the '%s' package with '%s' lint",
+                        this.pkg,
+                        lint
+                    ),
+                    exception
+                );
+            }
         }
         return messages;
     }

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -194,7 +194,7 @@ final class ProgramTest {
     }
 
     @Test
-    void doesNotThrowIOException() {
+    void doesNotThrowIoException() {
         Assertions.assertDoesNotThrow(
             () ->
                 new Program(

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -45,6 +45,7 @@ import org.eolang.parser.EoSyntax;
 import org.eolang.parser.TrParsing;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -189,6 +190,17 @@ final class ProgramTest {
             String.format("no errors in canonical code in %s", xmir),
             new Program(xmir).defects(),
             Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void doesNotThrowIOException() {
+        Assertions.assertDoesNotThrow(
+            () ->
+                new Program(
+                    new XMLDocument("<program/>")
+                ).defects(),
+            "Exception was thrown, but it should not be"
         );
     }
 

--- a/src/test/java/org/eolang/lints/ProgramsTest.java
+++ b/src/test/java/org/eolang/lints/ProgramsTest.java
@@ -31,10 +31,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.cactoos.io.InputOf;
+import org.cactoos.list.ListOf;
 import org.cactoos.set.SetOf;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -81,6 +83,14 @@ final class ProgramsTest {
                 )
             ).size(),
             Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void doesNotThrowIoException() {
+        Assertions.assertDoesNotThrow(
+            () -> new Programs(new ListOf<>()).defects(),
+            "Exception was thrown, but it should not be"
         );
     }
 


### PR DESCRIPTION
In this pull I've removed declaration of `IOException` from `Program#defects()` in order to simplify the interaction with `Program.java` class.

ref #179
History:
- **fix(#179): IOException declaration off**
- **fix(#179): camel**
