### PR TITLE
feat(#144): Each Lint timings in benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -50,6 +50,17 @@ jobs:
             printf "\`\`\`text\n"
             cat target/lint-summary.txt
             printf "\n\n"
+            header=true
+            while IFS=, read -r id ms; do
+              if [[ "$id" != "id" ]]; then
+                if $header; then
+                  header=false
+                  continue
+                fi
+                printf "%s (%s ms)\n" "$(echo "$id" | tr -d '"')" "$(echo "$ms" | tr -d '"')"
+              fi
+            done < target/timings.csv
+            printf "\n\n"
             printf "\`\`\`\n\n"
             echo "The results were calculated in [this GHA job][benchmark-gha]"
             echo "on $(date +'%Y-%m-%d') at $(date +'%H:%M'),"

--- a/pom.xml
+++ b/pom.xml
@@ -156,11 +156,13 @@ SOFTWARE.
       <groupId>com.yegor256</groupId>
       <artifactId>tojos</artifactId>
       <version>0.18.4</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.opencsv</groupId>
       <artifactId>opencsv</artifactId>
       <version>5.9</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.yegor256</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,16 @@ SOFTWARE.
     </dependency>
     <dependency>
       <groupId>com.yegor256</groupId>
+      <artifactId>tojos</artifactId>
+      <version>0.18.4</version>
+    </dependency>
+    <dependency>
+      <groupId>com.opencsv</groupId>
+      <artifactId>opencsv</artifactId>
+      <version>5.9</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yegor256</groupId>
       <artifactId>mktmp</artifactId>
       <version>0.0.5</version>
       <scope>test</scope>

--- a/src/main/java/org/eolang/lints/Lint.java
+++ b/src/main/java/org/eolang/lints/Lint.java
@@ -35,6 +35,12 @@ import java.util.Collection;
 public interface Lint<T> {
 
     /**
+     * Name of the lint.
+     * @return Lint name
+     */
+    String name();
+
+    /**
      * Find and return defects.
      * @param entity The entity to analyze (could be {@link com.jcabi.xml.XML}
      *  or {@link java.nio.file.Path})

--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -93,6 +93,11 @@ final class LtByXsl implements Lint<XML> {
     }
 
     @Override
+    public String name() {
+        return this.rule;
+    }
+
+    @Override
     public Collection<Defect> defects(final XML xmir) {
         final XML report = this.sheet.transform(xmir);
         final Collection<Defect> defects = new LinkedList<>();

--- a/src/main/java/org/eolang/lints/Program.java
+++ b/src/main/java/org/eolang/lints/Program.java
@@ -92,7 +92,7 @@ public final class Program {
     }
 
     /**
-     * Find defects possible defects in the XM§IR file.
+     * Find defects possible defects in the XMIR file.
      * @return All defects found
      */
     public Collection<Defect> defects() throws IOException {

--- a/src/main/java/org/eolang/lints/comments/LtAsciiOnly.java
+++ b/src/main/java/org/eolang/lints/comments/LtAsciiOnly.java
@@ -81,6 +81,11 @@ public final class LtAsciiOnly implements Lint<XML> {
     }
 
     @Override
+    public String name() {
+        return "ascii-only";
+    }
+
+    @Override
     public String motive() throws Exception {
         return new TextOf(
             new ResourceOf("org/eolang/motives/comments/ascii-only.md")

--- a/src/main/java/org/eolang/lints/misc/LtTestNotVerb.java
+++ b/src/main/java/org/eolang/lints/misc/LtTestNotVerb.java
@@ -140,6 +140,11 @@ public final class LtTestNotVerb implements Lint<XML> {
         ).asString();
     }
 
+    @Override
+    public String name() {
+        return "unit-test-is-not-verb";
+    }
+
     /**
      * Prestructor for default properties.
      * @return Properties.

--- a/src/main/java/org/eolang/lints/units/LtUnitTestMissing.java
+++ b/src/main/java/org/eolang/lints/units/LtUnitTestMissing.java
@@ -63,6 +63,11 @@ public final class LtUnitTestMissing implements Lint<Map<String, XML>> {
     }
 
     @Override
+    public String name() {
+        return "unit-test-missing";
+    }
+
+    @Override
     public String motive() throws Exception {
         return "";
     }

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -66,12 +66,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *  other classes in size too, for instance smaller classes (standard program),
  *  large class (JNA pointer), x-large class, and xxl class. Don't forget to
  *  adjust lint-summary.txt file to capture all the measurements.
- * @todo #134:90min Capture all the lint timings in timings.csv.
- *  Currently, we just capture total time - amount of milliseconds was required
- *  to lint some XMIR. Would be helpful to get extended statistics - timings of
- *  each lint. Don't forget to include this information into lint-summary.txt.
- *  You can check how it was implemented in HONE:
- *  <a href="https://github.com/objectionary/hone-maven-plugin/blob/master/src/main/java/org/eolang/hone/Timings.java">Timings.java</a>.
  */
 @ExtendWith(MktmpResolver.class)
 final class ProgramTest {

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -260,6 +260,7 @@ final class ProgramTest {
 
     /**
      * Benchmarked program.
+     * @since 0.0.29
      */
     final class BcProgram {
 

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -304,6 +304,10 @@ final class ProgramTest {
         /**
          * Defects.
          * @return Defects
+         * @todo #144:35min Resolve code duplication with Program.java class.
+         *  Currently, BcProgram.java is duplication of Program.java. Let's make
+         *  it use the original Program.java, so they will stay synced. Don't forget
+         *  to remove this puzzle.
          */
         public Collection<Defect> defects() {
             try {

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -220,7 +220,7 @@ final class ProgramTest {
                 ).path();
                 final XML xmir = new XMLDocument(pre);
                 final long start = System.currentTimeMillis();
-                final Collection<Defect> defects = new BcProgram(xmir).defects();
+                final Collection<Defect> defects = new ProgramTest.BcProgram(xmir).defects();
                 final long msec = System.currentTimeMillis() - start;
                 final Path target = Paths.get("target");
                 Files.write(
@@ -256,7 +256,7 @@ final class ProgramTest {
      * Benchmarked program.
      * @since 0.0.29
      */
-    final class BcProgram {
+    private static final class BcProgram {
 
         /**
          * XMIR.


### PR DESCRIPTION
In this pull I've added `BcProgram` for measuring each lint timings for XMIR-generated program during the benchmark.

In the Benchmark results we will have the following:

```md
Input: com/sun/jna/Pointer.class
Size of .class: 22Kb (22Kb bytes)
Size of .xmir after disassemble: 1Mb (1Mb bytes, 29630 lines)
Lint time: 42s (42355 ms)

alias-too-long (112 ms)
alias-without-tail (11 ms)
broken-alias-first (522 ms)
broken-alias-second (11 ms)
duplicate-aliases (37 ms)
...
```

closes #144
History:
- **feat(#144): timings**
- **feat(#144): typo**
- **feat(#144): Lint#name()**
- **feat(#144): present timings.csv**
