### PR TITLE
feat(#62): atom-with-phi lint

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/atom-with-phi.xsl
+++ b/src/main/resources/org/eolang/lints/critical/atom-with-phi.xsl
@@ -27,7 +27,7 @@ SOFTWARE.
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:apply-templates select="//o[@atom][.//o[@name='@']]" mode="with-phi"/>
+      <xsl:apply-templates select="//o[@atom and o[@name='@']]" mode="with-phi"/>
     </defects>
   </xsl:template>
   <xsl:template match="o" mode="with-phi">
@@ -36,7 +36,7 @@ SOFTWARE.
         <xsl:value-of select="eo:lineno(@line)"/>
       </xsl:attribute>
       <xsl:attribute name="severity">critical</xsl:attribute>
-      <xsl:text>Atoms must not have '@' attribute "</xsl:text>
+      <xsl:text>Atom must not have '@' attribute "</xsl:text>
     </defect>
   </xsl:template>
 </xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/critical/atom-with-phi.xsl
+++ b/src/main/resources/org/eolang/lints/critical/atom-with-phi.xsl
@@ -36,7 +36,7 @@ SOFTWARE.
         <xsl:value-of select="eo:lineno(@line)"/>
       </xsl:attribute>
       <xsl:attribute name="severity">critical</xsl:attribute>
-      <xsl:text>Atoms must not have void '@' attribute "</xsl:text>
+      <xsl:text>Atoms must not have void '@' attribute</xsl:text>
     </defect>
   </xsl:template>
 </xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/critical/atom-with-phi.xsl
+++ b/src/main/resources/org/eolang/lints/critical/atom-with-phi.xsl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="atom-with-phi" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:apply-templates select="//o[@atom][.//o[@name='@']]" mode="with-phi"/>
+    </defects>
+  </xsl:template>
+  <xsl:template match="o" mode="with-phi">
+    <defect>
+      <xsl:attribute name="line">
+        <xsl:value-of select="eo:lineno(@line)"/>
+      </xsl:attribute>
+      <xsl:attribute name="severity">critical</xsl:attribute>
+      <xsl:text>Atoms must not have '@' attribute "</xsl:text>
+    </defect>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/critical/atom-with-phi.xsl
+++ b/src/main/resources/org/eolang/lints/critical/atom-with-phi.xsl
@@ -36,7 +36,7 @@ SOFTWARE.
         <xsl:value-of select="eo:lineno(@line)"/>
       </xsl:attribute>
       <xsl:attribute name="severity">critical</xsl:attribute>
-      <xsl:text>Atom must not have '@' attribute "</xsl:text>
+      <xsl:text>Atoms must not have void '@' attribute "</xsl:text>
     </defect>
   </xsl:template>
 </xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/critical/atom-with-phi.md
+++ b/src/main/resources/org/eolang/motives/critical/atom-with-phi.md
@@ -1,0 +1,17 @@
+# Atom With `@`
+
+Atoms must not have `@` attribute.
+
+Incorrect:
+
+```eo
+# Foo.
+[@] > foo /number
+```
+
+Correct:
+
+```eo
+# Foo.
+[] > foo /number
+```

--- a/src/test/resources/org/eolang/lints/packs/atom-with-phi/allows-atoms-without-phi.yaml
+++ b/src/test/resources/org/eolang/lints/packs/atom-with-phi/allows-atoms-without-phi.yaml
@@ -1,0 +1,29 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/atom-with-phi.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+input: |
+  # No comments.
+  [] > foo /number

--- a/src/test/resources/org/eolang/lints/packs/atom-with-phi/catches-atom-with-phi.yaml
+++ b/src/test/resources/org/eolang/lints/packs/atom-with-phi/catches-atom-with-phi.yaml
@@ -1,0 +1,30 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/atom-with-phi.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=1]
+  - /defects/defect[@line='2']
+input: |
+  # No comments.
+  [@] > foo /number


### PR DESCRIPTION
In this pull I've implemented new lint: `atom-with-phi`, that issues `critical` defect in case atom has `@` (`φ`) attribute

closes #62