### PR TITLE
feat(#112): unit-test-without-live-file lint

### DIFF
--- a/src/main/java/org/eolang/lints/PkWpa.java
+++ b/src/main/java/org/eolang/lints/PkWpa.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.cactoos.iterable.IterableEnvelope;
 import org.cactoos.list.ListOf;
 import org.eolang.lints.units.LtUnitTestMissing;
+import org.eolang.lints.units.LtUnitTestWithoutLiveFile;
 
 /**
  * A collection of lints for Whole Program Analysis (WPA),
@@ -45,7 +46,8 @@ public final class PkWpa extends IterableEnvelope<Lint<Map<String, XML>>> {
     public PkWpa() {
         super(
             new ListOf<>(
-                new LtUnitTestMissing()
+                new LtUnitTestMissing(),
+                new LtUnitTestWithoutLiveFile()
             )
         );
     }

--- a/src/main/java/org/eolang/lints/units/LtUnitTestWithoutLiveFile.java
+++ b/src/main/java/org/eolang/lints/units/LtUnitTestWithoutLiveFile.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.lints.units;
+
+import com.jcabi.xml.XML;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Map;
+import org.eolang.lints.Defect;
+import org.eolang.lints.Lint;
+import org.eolang.lints.Severity;
+
+/**
+ * Unit test without live file.
+ *
+ * @since 0.0.30
+ */
+public final class LtUnitTestWithoutLiveFile implements Lint<Map<String, XML>> {
+
+    @Override
+    public String name() {
+        return "unit-test-without-live-file";
+    }
+
+    @Override
+    public Collection<Defect> defects(final Map<String, XML> pkg) {
+        final Collection<Defect> defects = new LinkedList<>();
+        for (final String name : pkg.keySet()) {
+            if (!name.endsWith("-test")) {
+                continue;
+            }
+            if (pkg.containsKey(name.replace("-test", ""))) {
+                continue;
+            }
+            defects.add(
+                new Defect.Default(
+                    this.name(),
+                    Severity.WARNING,
+                    name,
+                    0,
+                    String.format("Live .eo file was not found for %s", name)
+                )
+            );
+        }
+        return defects;
+    }
+
+    @Override
+    public String motive() throws Exception {
+        return "";
+    }
+}

--- a/src/main/java/org/eolang/lints/units/LtUnitTestWithoutLiveFile.java
+++ b/src/main/java/org/eolang/lints/units/LtUnitTestWithoutLiveFile.java
@@ -27,6 +27,8 @@ import com.jcabi.xml.XML;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Map;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.text.TextOf;
 import org.eolang.lints.Defect;
 import org.eolang.lints.Lint;
 import org.eolang.lints.Severity;
@@ -50,7 +52,8 @@ public final class LtUnitTestWithoutLiveFile implements Lint<Map<String, XML>> {
             if (!name.endsWith("-test")) {
                 continue;
             }
-            if (pkg.containsKey(name.replace("-test", ""))) {
+            final String live = name.replace("-test", "");
+            if (pkg.containsKey(live)) {
                 continue;
             }
             defects.add(
@@ -59,7 +62,9 @@ public final class LtUnitTestWithoutLiveFile implements Lint<Map<String, XML>> {
                     Severity.WARNING,
                     name,
                     0,
-                    String.format("Live .eo file was not found for %s", name)
+                    String.format(
+                        "Live .eo file '%s' was not found for '%s'", live, name
+                    )
                 )
             );
         }
@@ -68,6 +73,12 @@ public final class LtUnitTestWithoutLiveFile implements Lint<Map<String, XML>> {
 
     @Override
     public String motive() throws Exception {
-        return "";
+        return new TextOf(
+            new ResourceOf(
+                String.format(
+                    "org/eolang/motives/units/%s.md", this.name()
+                )
+            )
+        ).asString();
     }
 }

--- a/src/main/resources/org/eolang/motives/units/unit-test-without-live-file.md
+++ b/src/main/resources/org/eolang/motives/units/unit-test-without-live-file.md
@@ -1,0 +1,25 @@
+# Unit Test Without Live File
+
+Each test file must have the live file, with the same name.
+
+Incorrect:
+
+```text
+main/
+-----bar.eo
+-----...
+tests/
+-----foo-test.eo
+-----...
+```
+
+Correct:
+
+```text
+main/
+-----foo.eo
+-----...
+tests/
+-----foo-test.eo
+-----...
+```

--- a/src/test/java/org/eolang/lints/units/LtUnitTestWithoutLiveFileTest.java
+++ b/src/test/java/org/eolang/lints/units/LtUnitTestWithoutLiveFileTest.java
@@ -58,8 +58,8 @@ final class LtUnitTestWithoutLiveFileTest {
             "Defects are not emtpy, but they should",
             new LtUnitTestWithoutLiveFile().defects(
                 new MapOf<String, XML>(
-                    new MapEntry<>("foo-test", new XMLDocument("</program>")),
-                    new MapEntry<>("foo", new XMLDocument("</program>"))
+                    new MapEntry<>("foo-test", new XMLDocument("<program/>")),
+                    new MapEntry<>("foo", new XMLDocument("<program/>"))
                 )
             ),
             Matchers.emptyIterable()

--- a/src/test/java/org/eolang/lints/units/LtUnitTestWithoutLiveFileTest.java
+++ b/src/test/java/org/eolang/lints/units/LtUnitTestWithoutLiveFileTest.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.lints.units;
+
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import org.cactoos.map.MapEntry;
+import org.cactoos.map.MapOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link LtUnitTestWithoutLiveFile}.
+ *
+ * @since 0.0.30
+ */
+final class LtUnitTestWithoutLiveFileTest {
+
+    @Test
+    void catchesAbsenceOfLiveFile() {
+        MatcherAssert.assertThat(
+            "Defects are empty, but they should not",
+            new LtUnitTestWithoutLiveFile().defects(
+                new MapOf<String, XML>(
+                    new MapEntry<>("foo-test", new XMLDocument("<program/>")),
+                    new MapEntry<>("bar", new XMLDocument("<program/>"))
+                )
+            ),
+            Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
+
+    @Test
+    void acceptsValidPackage() {
+        MatcherAssert.assertThat(
+            "Defects are not emtpy, but they should",
+            new LtUnitTestWithoutLiveFile().defects(
+                new MapOf<String, XML>(
+                    new MapEntry<>("foo-test", new XMLDocument("</program>")),
+                    new MapEntry<>("foo", new XMLDocument("</program>"))
+                )
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+}


### PR DESCRIPTION
In this pull I've introduced new lint: `unit-test-without-live-file`, that issues `warning` defect in case unit test file does not match with live file, e.g. `foo-test -> bar`.

closes #112
History:
- **feat(#112): unit-test-without-live-file**
- **feat(#112): motive, valid xml**
- **feat(#112): wpa**
