### PR TITLE
feat(#115): pos-without-line

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/pos-without-line.xsl
+++ b/src/main/resources/org/eolang/lints/critical/pos-without-line.xsl
@@ -27,7 +27,7 @@ SOFTWARE.
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[@pos and not(number(@line))]">
+      <xsl:for-each select="//o[not(@line)]">
         <xsl:element name="defect">
           <xsl:attribute name="line">
             <xsl:value-of select="eo:lineno(@line)"/>

--- a/src/main/resources/org/eolang/lints/critical/pos-without-line.xsl
+++ b/src/main/resources/org/eolang/lints/critical/pos-without-line.xsl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="pos-without-line" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[@pos and not(number(@line))]">
+        <xsl:element name="defect">
+          <xsl:attribute name="line">
+            <xsl:value-of select="eo:lineno(@line)"/>
+          </xsl:attribute>
+          <xsl:attribute name="severity">
+            <xsl:text>critical</xsl:text>
+          </xsl:attribute>
+          <xsl:text>Object "</xsl:text>
+          <xsl:value-of select="@name"/>
+          <xsl:text>" have '@pos', but '@line' is absent</xsl:text>
+        </xsl:element>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/critical/pos-without-line.xsl
+++ b/src/main/resources/org/eolang/lints/critical/pos-without-line.xsl
@@ -27,7 +27,7 @@ SOFTWARE.
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[not(@line)]">
+      <xsl:for-each select="//o[@pos and not(@line)]">
         <xsl:element name="defect">
           <xsl:attribute name="line">
             <xsl:value-of select="eo:lineno(@line)"/>

--- a/src/main/resources/org/eolang/motives/critical/pos-without-line.md
+++ b/src/main/resources/org/eolang/motives/critical/pos-without-line.md
@@ -1,0 +1,26 @@
+# `@pos` Without `@line`
+
+In [XMIR], each `<o/>` that has `@pos` attribute, must have `@line` attribute
+as well.
+
+Incorrect:
+
+```xml
+<program>
+  <objects>
+    <o pos="3" name="foo"/>
+  </objects>
+</program>
+```
+
+Correct:
+
+```xml
+<program>
+  <objects>
+    <o line="2" pos="3" name="foo"/>
+  </objects>
+</program>
+```
+
+[XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html

--- a/src/test/resources/org/eolang/lints/packs/pos-without-line/allows-line-with-pos.yaml
+++ b/src/test/resources/org/eolang/lints/packs/pos-without-line/allows-line-with-pos.yaml
@@ -1,0 +1,32 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/pos-without-line.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o line="123" pos="3" name="foo"/>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/pos-without-line/allows-line-without-pos.yaml
+++ b/src/test/resources/org/eolang/lints/packs/pos-without-line/allows-line-without-pos.yaml
@@ -1,0 +1,32 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/pos-without-line.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o line="123" name="foo"/>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/pos-without-line/catches-pos-without-line.yaml
+++ b/src/test/resources/org/eolang/lints/packs/pos-without-line/catches-pos-without-line.yaml
@@ -1,0 +1,32 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/pos-without-line.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=1]
+document: |
+  <program>
+    <objects>
+      <o pos="3" name="foo"/>
+    </objects>
+  </program>


### PR DESCRIPTION
In this pull I've implemented new lint: `pos-without-line`, that issues `critical` defect in case `<o/>` has `@pos` without the `@line` attribute in XMIR.

closes #115