### PR TITLE
feat(#120): pos-bigger-than-line

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/pos-bigger-than-line.xsl
+++ b/src/main/resources/org/eolang/lints/critical/pos-bigger-than-line.xsl
@@ -25,13 +25,12 @@ SOFTWARE.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="pos-bigger-than-line" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:variable name="lines" select="tokenize(/program/listing, '&#10;')"/>
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="//o">
         <xsl:variable name="line" select="number(@line)"/>
-        <xsl:variable name="length" select="string-length(normalize-space($lines[$line]))"/>
-        <xsl:if test="@line and @pos&gt;$length">
+        <xsl:variable name="length" select="sum(//o[@line = $line and not(descendant::o)]/string-length(normalize-space(text())))"/>
+        <xsl:if test="@line and number(@pos)&gt;$length">
           <xsl:element name="defect">
             <xsl:attribute name="line">
               <xsl:value-of select="eo:lineno(@line)"/>

--- a/src/main/resources/org/eolang/lints/critical/pos-bigger-than-line.xsl
+++ b/src/main/resources/org/eolang/lints/critical/pos-bigger-than-line.xsl
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="pos-bigger-than-line" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[(@pos and @line) and (number(@pos)&gt;number(@line))]">
+        <xsl:element name="defect">
+          <xsl:attribute name="line">
+            <xsl:value-of select="eo:lineno(@line)"/>
+          </xsl:attribute>
+          <xsl:attribute name="severity">
+            <xsl:text>critical</xsl:text>
+          </xsl:attribute>
+          <xsl:text>The </xsl:text>
+          <xsl:choose>
+            <xsl:when test="@name">
+              <xsl:text>object </xsl:text>
+              <xsl:text>"</xsl:text>
+              <xsl:value-of select="@name"/>
+              <xsl:text>"</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:text>anonymous object</xsl:text>
+            </xsl:otherwise>
+          </xsl:choose>
+          <xsl:text> has '@pos' (</xsl:text>
+          <xsl:value-of select="@pos"/>
+          <xsl:text>), that is bigger than its '@line' (</xsl:text>
+          <xsl:value-of select="@line"/>
+          <xsl:text>)</xsl:text>
+        </xsl:element>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/critical/pos-bigger-than-line.xsl
+++ b/src/main/resources/org/eolang/lints/critical/pos-bigger-than-line.xsl
@@ -25,34 +25,39 @@ SOFTWARE.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="pos-bigger-than-line" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:variable name="lines" select="tokenize(/program/listing, '&#10;')"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[(@pos and @line) and (number(@pos)&gt;number(@line))]">
-        <xsl:element name="defect">
-          <xsl:attribute name="line">
-            <xsl:value-of select="eo:lineno(@line)"/>
-          </xsl:attribute>
-          <xsl:attribute name="severity">
-            <xsl:text>critical</xsl:text>
-          </xsl:attribute>
-          <xsl:text>The </xsl:text>
-          <xsl:choose>
-            <xsl:when test="@name">
-              <xsl:text>object </xsl:text>
-              <xsl:text>"</xsl:text>
-              <xsl:value-of select="@name"/>
-              <xsl:text>"</xsl:text>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:text>anonymous object</xsl:text>
-            </xsl:otherwise>
-          </xsl:choose>
-          <xsl:text> has '@pos' (</xsl:text>
-          <xsl:value-of select="@pos"/>
-          <xsl:text>), that is bigger than its '@line' (</xsl:text>
-          <xsl:value-of select="@line"/>
-          <xsl:text>)</xsl:text>
-        </xsl:element>
+      <xsl:for-each select="//o">
+        <xsl:variable name="line" select="number(@line)"/>
+        <xsl:variable name="length" select="string-length(normalize-space($lines[$line]))"/>
+        <xsl:if test="@line and @pos&gt;$length">
+          <xsl:element name="defect">
+            <xsl:attribute name="line">
+              <xsl:value-of select="eo:lineno(@line)"/>
+            </xsl:attribute>
+            <xsl:attribute name="severity">
+              <xsl:text>critical</xsl:text>
+            </xsl:attribute>
+            <xsl:text>The </xsl:text>
+            <xsl:choose>
+              <xsl:when test="@name">
+                <xsl:text>object </xsl:text>
+                <xsl:text>"</xsl:text>
+                <xsl:value-of select="@name"/>
+                <xsl:text>"</xsl:text>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:text>anonymous object</xsl:text>
+              </xsl:otherwise>
+            </xsl:choose>
+            <xsl:text> has '@pos' (</xsl:text>
+            <xsl:value-of select="@pos"/>
+            <xsl:text>), that is bigger than its line length (</xsl:text>
+            <xsl:value-of select="$length"/>
+            <xsl:text>)</xsl:text>
+          </xsl:element>
+        </xsl:if>
       </xsl:for-each>
     </defects>
   </xsl:template>

--- a/src/main/resources/org/eolang/motives/critical/pos-bigger-than-line.md
+++ b/src/main/resources/org/eolang/motives/critical/pos-bigger-than-line.md
@@ -15,7 +15,8 @@ Incorrect:
 </program>
 ```
 
-Since, line with `foo` object has length 7, while `@pos=10`.
+Since, line with `foo` object has length `7` (according to the `<listing/>`),
+while `@pos` points to the `10`.
 
 Correct:
 

--- a/src/main/resources/org/eolang/motives/critical/pos-bigger-than-line.md
+++ b/src/main/resources/org/eolang/motives/critical/pos-bigger-than-line.md
@@ -23,4 +23,4 @@ Correct:
 </program>
 ```
 
-[XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html 
+[XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html

--- a/src/main/resources/org/eolang/motives/critical/pos-bigger-than-line.md
+++ b/src/main/resources/org/eolang/motives/critical/pos-bigger-than-line.md
@@ -7,25 +7,28 @@ Incorrect:
 
 ```xml
 <program>
-  <listing># No comments.
-    [] &gt;foo</listing>
   <objects>
-    <o line="2" pos="10" name="foo"/>
+    <o line="2" pos="5" name="foo">
+      <o line="2" name="xyz">
+        <o line="2">data</o>
+      </o>
+    </o>
   </objects>
 </program>
 ```
 
-Since, line with `foo` object has length `7` (according to the `<listing/>`),
-while `@pos` points to the `10`.
+Since, line with `foo` object has length `4`, while `@pos` points to the `5`.
 
 Correct:
 
 ```xml
 <program>
-  <listing># No comments.
-    [] &gt;foo</listing>
   <objects>
-    <o line="2" pos="3" name="foo"/>
+    <o line="2" pos="2" name="foo">
+      <o line="2" name="xyz">
+        <o line="2">data</o>
+      </o>
+    </o>
   </objects>
 </program>
 ```

--- a/src/main/resources/org/eolang/motives/critical/pos-bigger-than-line.md
+++ b/src/main/resources/org/eolang/motives/critical/pos-bigger-than-line.md
@@ -1,0 +1,26 @@
+# `@pos` Bigger Than `@line`
+
+In [XMIR], each `<o/>` must have the value of it's `@pos` attribute not bigger
+than the value of it's `@line` attribute.
+
+Incorrect:
+
+```xml
+<program>
+  <objects>
+    <o line="3" pos="4" name="foo"/>
+  </objects>
+</program>
+```
+
+Correct:
+
+```xml
+<program>
+  <objects>
+    <o line="3" pos="3" name="foo"/>
+  </objects>
+</program>
+```
+
+[XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html 

--- a/src/main/resources/org/eolang/motives/critical/pos-bigger-than-line.md
+++ b/src/main/resources/org/eolang/motives/critical/pos-bigger-than-line.md
@@ -1,24 +1,30 @@
 # `@pos` Bigger Than `@line`
 
 In [XMIR], each `<o/>` must have the value of it's `@pos` attribute not bigger
-than the value of it's `@line` attribute.
+than the length of the `@line` it belongs to.
 
 Incorrect:
 
 ```xml
 <program>
+  <listing># No comments.
+    [] &gt;foo</listing>
   <objects>
-    <o line="3" pos="4" name="foo"/>
+    <o line="2" pos="10" name="foo"/>
   </objects>
 </program>
 ```
+
+Since, line with `foo` object has length 7, while `@pos=10`.
 
 Correct:
 
 ```xml
 <program>
+  <listing># No comments.
+    [] &gt;foo</listing>
   <objects>
-    <o line="3" pos="3" name="foo"/>
+    <o line="2" pos="3" name="foo"/>
   </objects>
 </program>
 ```

--- a/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/catches-broken-pos-in-nested-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/catches-broken-pos-in-nested-object.yaml
@@ -28,9 +28,9 @@ asserts:
 document: |
   <program>
     <objects>
-      <o line="2" pos="20" name="foo">
-        <o line="2" name="xyz">
-          <o line="2">data</o>
+      <o line="1" name="foo">
+        <o line="2" pos="5" name="xyz">
+          <o line="2">dat</o>
         </o>
       </o>
     </objects>

--- a/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/catches-pos-bigger-than-line.yaml
+++ b/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/catches-pos-bigger-than-line.yaml
@@ -24,10 +24,12 @@ sheets:
   - /org/eolang/lints/critical/pos-bigger-than-line.xsl
 asserts:
   - /defects[count(defect[@severity='critical'])=1]
-  - /defects/defect[@line='3']
+  - /defects/defect[@line='2']
 document: |
   <program>
+    <listing># No comments.
+  [] &gt;foo</listing>
     <objects>
-      <o line="3" pos="4" name="foo"/>
+      <o line="2" pos="20" name="foo"/>
     </objects>
   </program>

--- a/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/catches-pos-bigger-than-line.yaml
+++ b/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/catches-pos-bigger-than-line.yaml
@@ -1,0 +1,33 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/pos-bigger-than-line.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=1]
+  - /defects/defect[@line='3']
+document: |
+  <program>
+    <objects>
+      <o line="3" pos="4" name="foo"/>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/ignores-line-absence.yaml
+++ b/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/ignores-line-absence.yaml
@@ -26,7 +26,9 @@ asserts:
   - /defects[count(defect[@severity='critical'])=0]
 document: |
   <program>
+    <listing># No comments.
+  [] &gt;foo</listing>
     <objects>
-      <o pos="3" name="foo"/>
+      <o pos="15" name="foo"/>
     </objects>
   </program>

--- a/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/ignores-line-absence.yaml
+++ b/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/ignores-line-absence.yaml
@@ -1,0 +1,32 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/pos-bigger-than-line.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o pos="3" name="foo"/>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/ignores-line-absence.yaml
+++ b/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/ignores-line-absence.yaml
@@ -26,8 +26,6 @@ asserts:
   - /defects[count(defect[@severity='critical'])=0]
 document: |
   <program>
-    <listing># No comments.
-  [] &gt;foo</listing>
     <objects>
       <o pos="15" name="foo"/>
     </objects>

--- a/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/passes-good-pos-in-line.yaml
+++ b/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/passes-good-pos-in-line.yaml
@@ -1,0 +1,32 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/pos-bigger-than-line.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o line="3" pos="3" name="foo"/>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/passes-good-pos-in-line.yaml
+++ b/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/passes-good-pos-in-line.yaml
@@ -26,7 +26,9 @@ asserts:
   - /defects[count(defect[@severity='critical'])=0]
 document: |
   <program>
+    <listing># No comments.
+  [] &gt;foo</listing>
     <objects>
-      <o line="3" pos="3" name="foo"/>
+      <o line="2" pos="4" name="foo"/>
     </objects>
   </program>

--- a/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/passes-good-pos-in-line.yaml
+++ b/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/passes-good-pos-in-line.yaml
@@ -26,9 +26,11 @@ asserts:
   - /defects[count(defect[@severity='critical'])=0]
 document: |
   <program>
-    <listing># No comments.
-  [] &gt;foo</listing>
     <objects>
-      <o line="2" pos="4" name="foo"/>
+      <o line="2" pos="3" name="foo">
+        <o line="2" name="xyz">
+          <o line="2">data</o>
+        </o>
+      </o>
     </objects>
   </program>

--- a/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/passes-when-no-pos.yaml
+++ b/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/passes-when-no-pos.yaml
@@ -26,8 +26,6 @@ asserts:
   - /defects[count(defect[@severity='critical'])=0]
 document: |
   <program>
-    <listing># No comments.
-  [] &gt;foo</listing>
     <objects>
       <o line="2" name="foo"/>
     </objects>

--- a/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/passes-when-no-pos.yaml
+++ b/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/passes-when-no-pos.yaml
@@ -1,0 +1,32 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/pos-bigger-than-line.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o line="3" name="foo"/>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/passes-when-no-pos.yaml
+++ b/src/test/resources/org/eolang/lints/packs/pos-bigger-than-line/passes-when-no-pos.yaml
@@ -26,7 +26,9 @@ asserts:
   - /defects[count(defect[@severity='critical'])=0]
 document: |
   <program>
+    <listing># No comments.
+  [] &gt;foo</listing>
     <objects>
-      <o line="3" name="foo"/>
+      <o line="2" name="foo"/>
     </objects>
   </program>


### PR DESCRIPTION
In this pull I've introduced new lint: `pos-bigger-than-line`, that issues `critical` defect if `@pos` is bigger than `@line` attribute of the object in XMIR.

closes #120