### PR TITLE
fix(#198): lint timings sorted by ms

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -57,10 +57,11 @@ jobs:
                   header=false
                   continue
                 fi
-                printf "%s (%s ms)\n" "$(echo "$id" | tr -d '"')" "$(echo "$ms" | tr -d '"')"
+                printf "%s,%s\n" "$(echo "$id" | tr -d '"')" "$(echo "$ms" | tr -d '"')"
               fi
-            done < target/timings.csv
-            printf "\n\n"
+            done < target/timings.csv | sort -t, -k2 -n -r | while IFS=, read -r id ms; do
+              printf "%s (%s ms)\n" "$id" "$ms"
+            done
             printf "\`\`\`\n\n"
             echo "The results were calculated in [this GHA job][benchmark-gha]"
             echo "on $(date +'%Y-%m-%d') at $(date +'%H:%M'),"


### PR DESCRIPTION
In this pull I've updated `benchmark.yml` to sort lint timings by `ms`, in the descending way.

closes #198