### PR TITLE
feat(#111): one-high-level-object lint

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/one-high-level-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/one-high-level-object.xsl
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="one-high-level-object">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:variable name="program" select="/program/@name"/>
+  <xsl:variable name="tested" select="/program/metas/meta[head='tests']"/>
+  <xsl:variable name="objects" select="count(/program/objects/o)"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:if test="$objects&gt;1 and not($tested)">
+        <defect>
+          <xsl:attribute name="line">
+            <xsl:value-of select="eo:lineno(@line)"/>
+          </xsl:attribute>
+          <xsl:attribute name="severity">warning</xsl:attribute>
+          <xsl:text>Program "</xsl:text>
+          <xsl:value-of select="$program"/>
+          <xsl:text>" has </xsl:text>
+          <xsl:value-of select="$objects"/>
+          <xsl:text> objects, while only 1 is allowed</xsl:text>
+        </defect>
+      </xsl:if>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/misc/one-high-level-object.md
+++ b/src/main/resources/org/eolang/motives/misc/one-high-level-object.md
@@ -1,0 +1,27 @@
+# One High-Level Object
+
+Every `.eo` file must have only one high-level object inside.
+
+Incorrect:
+
+`app.eo`:
+
+```eo
+# Foo.
+[] > foo
+  42 > @
+
+# Bar.
+[] > bar
+  42 > @
+```
+
+Correct:
+
+`app.eo`:
+
+```eo
+# Foo.
+[] > foo
+  42 > @
+```

--- a/src/test/resources/org/eolang/lints/packs/one-high-level-object/allows-multiple-objects-in-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/one-high-level-object/allows-multiple-objects-in-tests.yaml
@@ -26,7 +26,7 @@ asserts:
   - /defects[count(defect[@severity='warning'])=0]
 input: |
   +tests
-  
+
   # Foo.
   [] > test-foo
     42 > @

--- a/src/test/resources/org/eolang/lints/packs/one-high-level-object/allows-multiple-objects-in-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/one-high-level-object/allows-multiple-objects-in-tests.yaml
@@ -1,0 +1,36 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/misc/one-high-level-object.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  +tests
+  
+  # Foo.
+  [] > test-foo
+    42 > @
+
+  # Bar.
+  [] > test-bar
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/one-high-level-object/allows-one-program-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/one-high-level-object/allows-one-program-object.yaml
@@ -1,0 +1,30 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/misc/one-high-level-object.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # Foo.
+  [] > foo
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/one-high-level-object/catches-multiple-program-objects.yaml
+++ b/src/test/resources/org/eolang/lints/packs/one-high-level-object/catches-multiple-program-objects.yaml
@@ -1,0 +1,34 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/misc/one-high-level-object.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+input: |
+  # Foo.
+  [] > foo
+    42 > @
+
+  # Bar.
+  [] > bar
+    42 > @


### PR DESCRIPTION
In this pull I've implemented new lint: `one-high-level-object`, that issues `warning` defect in case multiple high-level objects inside EO program.

closes #111