### PR TITLE
bug(#208): incorrect-package accepts `fqn`

### DIFF
--- a/src/main/resources/org/eolang/lints/metas/incorrect-package.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-package.xsl
@@ -48,3 +48,4 @@ SOFTWARE.
     </defects>
   </xsl:template>
 </xsl:stylesheet>
+

--- a/src/main/resources/org/eolang/lints/metas/incorrect-package.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-package.xsl
@@ -48,4 +48,3 @@ SOFTWARE.
     </defects>
   </xsl:template>
 </xsl:stylesheet>
-

--- a/src/main/resources/org/eolang/lints/metas/incorrect-package.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-package.xsl
@@ -31,7 +31,7 @@ SOFTWARE.
         <xsl:variable name="meta-head" select="head"/>
         <xsl:variable name="meta-tail" select="tail"/>
         <xsl:variable name="first" select="normalize-space(substring-before(concat($meta-tail, ' '), ' '))"/>
-        <xsl:if test="$meta-head='package' and not(matches($first, '^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]+)*$'))">
+        <xsl:if test="$meta-head='package' and not(matches($first, '^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*|\$[a-z][a-z0-9_]*)*$'))">
           <xsl:element name="defect">
             <xsl:attribute name="line">
               <xsl:value-of select="eo:lineno(@line)"/>

--- a/src/main/resources/org/eolang/lints/metas/incorrect-package.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-package.xsl
@@ -31,8 +31,8 @@ SOFTWARE.
         <xsl:variable name="meta-head" select="head"/>
         <xsl:variable name="meta-tail" select="tail"/>
         <xsl:variable name="first" select="normalize-space(substring-before(concat($meta-tail, ' '), ' '))"/>
-        <xsl:if test="$meta-head='package' and not(matches($first, '^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*|\$[a-z][a-z0-9_]*)*$'))">
-          <xsl:element name="defect">
+        <xsl:if test="$meta-head='package' and not(matches($first, '^[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+|\$[a-zA-Z0-9_]*)*$|[\p{L}\p{M}\p{N}_]+(\.[\p{L}\p{M}\p{N}_]+)*$'))">
+        <xsl:element name="defect">
             <xsl:attribute name="line">
               <xsl:value-of select="eo:lineno(@line)"/>
             </xsl:attribute>

--- a/src/main/resources/org/eolang/lints/metas/incorrect-package.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-package.xsl
@@ -32,7 +32,7 @@ SOFTWARE.
         <xsl:variable name="meta-tail" select="tail"/>
         <xsl:variable name="first" select="normalize-space(substring-before(concat($meta-tail, ' '), ' '))"/>
         <xsl:if test="$meta-head='package' and not(matches($first, '^[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+|\$[a-zA-Z0-9_]*)*$|[\p{L}\p{M}\p{N}_]+(\.[\p{L}\p{M}\p{N}_]+)*$'))">
-        <xsl:element name="defect">
+          <xsl:element name="defect">
             <xsl:attribute name="line">
               <xsl:value-of select="eo:lineno(@line)"/>
             </xsl:attribute>

--- a/src/test/resources/org/eolang/lints/packs/incorrect-package/allows-package-with-dollars.yaml
+++ b/src/test/resources/org/eolang/lints/packs/incorrect-package/allows-package-with-dollars.yaml
@@ -1,0 +1,32 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/metas/incorrect-package.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  +package j$org.j$eolang.j$jeo
+  +package com.foo$bar
+
+  # Test.
+  [] > foo

--- a/src/test/resources/org/eolang/lints/packs/incorrect-package/allows-package-with-fqn.yaml
+++ b/src/test/resources/org/eolang/lints/packs/incorrect-package/allows-package-with-fqn.yaml
@@ -25,8 +25,15 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='warning'])=0]
 input: |
+  +package hello.world
+  +package hello.world123
+  +package foo.бар
+  +package test_xyz
   +package j$org.j$eolang.j$jeo
   +package com.foo$bar
+  +package universe@obj
+  +package c.d-test.x-yz
+  +package a.b-привет.c-大家好
 
   # Test.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/incorrect-package/allows-uppercase-letters-in-package.yaml
+++ b/src/test/resources/org/eolang/lints/packs/incorrect-package/allows-uppercase-letters-in-package.yaml
@@ -23,10 +23,11 @@
 sheets:
   - /org/eolang/lints/metas/incorrect-package.xsl
 asserts:
-  - /defects[count(defect[@severity='warning'])=2]
+  - /defects[count(defect[@severity='warning'])=0]
 input: |
-  +package test.
-  +package привет, как дела?
+  +package Foo
+  +package Hello.WorLd
+  +package baR.XYZ
 
-  # Foo.
+  # Test.
   [] > foo


### PR DESCRIPTION
In this pull I've updated `incorrect-package` lint to support FQN names.
see #208