### PR TITLE
bug(#212): puzzle for windows timeouts

### DIFF
--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -20,4 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-junit.jupiter.execution.timeout.test.method.default = 3s
+# @todo #107:45min Configure default timeout for tests running on windows to 10s and 3s on other platforms.
+#  Currently, it fails with the 3s timeout on windows platform. Let's try to configure
+#  test default timeout exclusively for windows, and keep 3s for other platforms.
+junit.jupiter.execution.timeout.test.method.default = 10s


### PR DESCRIPTION
In this pull I've updated default test JUnit timeout from `3s` to `10s` in order to keep windows builds green.

closes #212