### PR TITLE
bug(#209): XMIR links in `Program`, `Programs`, `Defect` JavaDoc

### DIFF
--- a/src/main/java/org/eolang/lints/Defect.java
+++ b/src/main/java/org/eolang/lints/Defect.java
@@ -27,7 +27,14 @@ import com.jcabi.manifests.Manifests;
 
 /**
  * A single defect found.
- *
+ * Defect is a node in the XMIR under `/program/defects`, that describes the
+ * issue with EO/XMIR source code. Defect contain the message that addresses
+ * source code and points to the problem in it. Some defects report the problems
+ * on XMIR format itself, consider to check resources on XMIR in order to get
+ * understanding how intermediate representation of EO is structured in XML format.
+ * @see <a href="https://news.eolang.org/2022-11-25-xmir-guide.html">XMIR guide</a>
+ * @see <a href="https://www.eolang.org/XMIR.html">XMIR specification</a>
+ * @see <a href="https://www.eolang.org/XMIR.xsd">XMIR schema</a>
  * @since 0.0.1
  */
 public interface Defect {

--- a/src/main/java/org/eolang/lints/Program.java
+++ b/src/main/java/org/eolang/lints/Program.java
@@ -94,6 +94,9 @@ public final class Program {
     /**
      * Find defects possible defects in the XMIR file.
      * @return All defects found
+     * @see <a href="https://news.eolang.org/2022-11-25-xmir-guide.html">XMIR guide</a>
+     * @see <a href="https://www.eolang.org/XMIR.html">XMIR specification</a>
+     * @see <a href="https://www.eolang.org/XMIR.xsd">XMIR schema</a>
      */
     public Collection<Defect> defects() {
         try {

--- a/src/main/java/org/eolang/lints/Programs.java
+++ b/src/main/java/org/eolang/lints/Programs.java
@@ -117,6 +117,9 @@ public final class Programs {
     /**
      * Find defects possible defects in the XMIR file.
      * @return All defects found
+     * @see <a href="https://news.eolang.org/2022-11-25-xmir-guide.html">XMIR guide</a>
+     * @see <a href="https://www.eolang.org/XMIR.html">XMIR specification</a>
+     * @see <a href="https://www.eolang.org/XMIR.xsd">XMIR schema</a>
      */
     public Collection<Defect> defects() {
         final Collection<Defect> messages = new LinkedList<>();


### PR DESCRIPTION
In this pull I've updated JavaDocs of `Program.java`, `Programs.java`, `Defect.java`, now they mention XMIR, and resources about it.

see #209