### PR TITLE
feat(#226): test case for one-letter-names in `incorrect-package`

### DIFF
--- a/src/test/resources/org/eolang/lints/packs/incorrect-package/allows-one-letter-names.yaml
+++ b/src/test/resources/org/eolang/lints/packs/incorrect-package/allows-one-letter-names.yaml
@@ -26,6 +26,8 @@ asserts:
   - /defects[count(defect[@severity='warning'])=0]
 input: |
   +package a.b.c
+  +package X.Y.Z
+  +package F.o.O
 
   # Test.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/incorrect-package/allows-one-letter-names.yaml
+++ b/src/test/resources/org/eolang/lints/packs/incorrect-package/allows-one-letter-names.yaml
@@ -1,0 +1,31 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/metas/incorrect-package.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  +package a.b.c
+
+  # Test.
+  [] > foo


### PR DESCRIPTION
In this pull I've added new test case for `incorrect-package`, that covers allowance of one-letter names, e.g.: `a.b.c`. The 
described issue was fixed after `incorrect-package` allows FQN-compliant names (see: #211).

closes #226