### PR TITLE
bug(#227): incorrect-alias scans second part of longer `+alias`

### DIFF
--- a/src/main/java/org/eolang/lints/critical/LtIncorrectAlias.java
+++ b/src/main/java/org/eolang/lints/critical/LtIncorrectAlias.java
@@ -53,7 +53,12 @@ public final class LtIncorrectAlias implements Lint<Map<String, XML>> {
                     if (xmir.nodes("/program/metas/meta[head='package']").size() != 1) {
                         continue;
                     }
-                    final String pointer = alias.xpath("text()").get(0);
+                    final String pointer;
+                    if (Boolean.parseBoolean(alias.xpath("contains(text(), ' ')").get(0))) {
+                        pointer = alias.xpath("substring-before(text(), ' ')").get(0);
+                    } else {
+                        pointer = alias.xpath("text()").get(0);
+                    }
                     final String lookup = String.format(
                         "%s/%s",
                         xmir.xpath("/program/metas/meta[head='package']/tail/text()").get(0),

--- a/src/test/java/org/eolang/lints/critical/LtIncorrectAliasTest.java
+++ b/src/test/java/org/eolang/lints/critical/LtIncorrectAliasTest.java
@@ -120,7 +120,7 @@ final class LtIncorrectAliasTest {
     }
 
     @Test
-    void allowsLongerAlias() throws IOException {
+    void scansSecondPartInLongerAlias() throws IOException {
         MatcherAssert.assertThat(
             "Defects aren't empty, but they should",
             new LtIncorrectAlias().defects(
@@ -134,7 +134,7 @@ final class LtIncorrectAliasTest {
                         ).parsed()
                     ),
                     new MapEntry<>(
-                        "foo/stdout", new XMLDocument("<program/>")
+                        "org/eolang/io/stdout", new XMLDocument("<program/>")
                     )
                 )
             ),

--- a/src/test/java/org/eolang/lints/critical/LtIncorrectAliasTest.java
+++ b/src/test/java/org/eolang/lints/critical/LtIncorrectAliasTest.java
@@ -120,6 +120,29 @@ final class LtIncorrectAliasTest {
     }
 
     @Test
+    void allowsLongerAlias() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects aren't empty, but they should",
+            new LtIncorrectAlias().defects(
+                new MapOf<String, XML>(
+                    new MapEntry<>(
+                        "longer-alias",
+                        new EoSyntax(
+                            new ResourceOf(
+                                "org/eolang/lints/critical/incorrect-alias/longer-alias.eo"
+                            )
+                        ).parsed()
+                    ),
+                    new MapEntry<>(
+                        "foo/stdout", new XMLDocument("<program/>")
+                    )
+                )
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
     @ExtendWith(MktmpResolver.class)
     void acceptsValidDirectory(@Mktmp final Path dir) throws IOException {
         Files.write(

--- a/src/test/java/org/eolang/lints/critical/LtIncorrectAliasTest.java
+++ b/src/test/java/org/eolang/lints/critical/LtIncorrectAliasTest.java
@@ -134,7 +134,7 @@ final class LtIncorrectAliasTest {
                         ).parsed()
                     ),
                     new MapEntry<>(
-                        "org/eolang/io/stdout", new XMLDocument("<program/>")
+                        "org/eolang/io/stdout", new XMLDocument("<program><objects/></program>")
                     )
                 )
             ),
@@ -157,6 +157,39 @@ final class LtIncorrectAliasTest {
         Files.write(dir.resolve("ttt/foo.xmir"), "<program/>".getBytes());
         Files.write(dir.resolve("bar-test.xmir"), "<program/>".getBytes());
         Files.write(dir.resolve("ttt/foo-test.xmir"), "<program/>".getBytes());
+        MatcherAssert.assertThat(
+            "Defects are not empty, but should be",
+            new Programs(dir).defects(),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    @ExtendWith(MktmpResolver.class)
+    void acceptsValidDirectoryWithLongerAlias(@Mktmp final Path dir) throws IOException {
+        Files.write(
+            dir.resolve("main.xmir"),
+            new EoSyntax(
+                new ResourceOf(
+                    "org/eolang/lints/critical/incorrect-alias/longer-alias.eo"
+                )
+            ).parsed().toString().getBytes()
+        );
+        Files.write(dir.resolve("main-test.xmir"), "<program><objects/></program>".getBytes());
+        Files.createDirectory(
+            Files.createDirectory(
+                Files.createDirectory(
+                    dir.resolve("org")
+                ).resolve("eolang")
+            ).resolve("io")
+        );
+        Files.write(
+            dir.resolve("org/eolang/io/stdout.xmir"), "<program><objects/></program>".getBytes()
+        );
+        Files.write(
+            dir.resolve("org/eolang/io/stdout-test.xmir"),
+            "<program><objects/></program>".getBytes()
+        );
         MatcherAssert.assertThat(
             "Defects are not empty, but should be",
             new Programs(dir).defects(),

--- a/src/test/resources/org/eolang/lints/critical/incorrect-alias/longer-alias.eo
+++ b/src/test/resources/org/eolang/lints/critical/incorrect-alias/longer-alias.eo
@@ -1,0 +1,28 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
++alias stdout org.eolang.io.stdout
++package foo
+
+[] > main
+  stdout > @
+    "hi!"


### PR DESCRIPTION
In this PR I've updated `incorrect-alias` lint to scan the second part of `+alias` meta, if it has the second part inside.

Example:

```eo
+alias stdout org.eolang.io.stdout
```

In this case, `org/eolang/io/stdout.xmir` will be scanned.

see #227
History:
- **bug(#227): allowsLongerAlias**
- **bug(#227): scans second**
- **bug(#227): acceptsValidDirectoryWithLongerAlias**
