### PR TITLE
bug(#237): incorrect-version allows maven convention

### DIFF
--- a/src/main/resources/org/eolang/lints/metas/incorrect-version.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-version.xsl
@@ -30,7 +30,7 @@ SOFTWARE.
       <xsl:for-each select="/program/metas/meta">
         <xsl:variable name="meta-head" select="head"/>
         <xsl:variable name="meta-tail" select="tail"/>
-        <xsl:if test="$meta-head='version' and not(matches($meta-tail, '^\d+\.\d+\.\d+(-[a-zA-Z0-9-]+)?$|^\d+\.\d+(-[a-zA-Z0-9-]+)$'))">
+        <xsl:if test="$meta-head='version' and not(matches($meta-tail, '^\d+\.\d+\.\d+(-[a-zA-Z0-9-]+)?$|^\d+\.\d+-SNAPSHOT$'))">
           <xsl:element name="defect">
             <xsl:attribute name="line">
               <xsl:value-of select="eo:lineno(@line)"/>

--- a/src/main/resources/org/eolang/lints/metas/incorrect-version.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-version.xsl
@@ -30,7 +30,7 @@ SOFTWARE.
       <xsl:for-each select="/program/metas/meta">
         <xsl:variable name="meta-head" select="head"/>
         <xsl:variable name="meta-tail" select="tail"/>
-        <xsl:if test="$meta-head='version' and not(matches($meta-tail, '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)?(\+[a-zA-Z0-9]+)?$'))">
+        <xsl:if test="$meta-head='version' and not(matches($meta-tail, '^\d+\.\d+\.\d+(-[a-zA-Z0-9-]+)?$|^\d+\.\d+(-[a-zA-Z0-9-]+)$'))">
           <xsl:element name="defect">
             <xsl:attribute name="line">
               <xsl:value-of select="eo:lineno(@line)"/>

--- a/src/test/resources/org/eolang/lints/packs/incorrect-version/allows-good-versions.yaml
+++ b/src/test/resources/org/eolang/lints/packs/incorrect-version/allows-good-versions.yaml
@@ -23,30 +23,13 @@
 sheets:
   - /org/eolang/lints/metas/incorrect-version.xsl
 asserts:
-  - /defects[count(defect[@severity='warning'])=11]
-  - /defects/defect[@line='1']
-  - /defects/defect[@line='2']
-  - /defects/defect[@line='3']
-  - /defects/defect[@line='4']
-  - /defects/defect[@line='5']
-  - /defects/defect[@line='6']
-  - /defects/defect[@line='7']
-  - /defects/defect[@line='8']
-  - /defects/defect[@line='9']
-  - /defects/defect[@line='10']
-  - /defects/defect[@line='11']
+  - /defects[count(defect[@severity='warning'])=0]
 input: |
-  +version alpha
-  +version 1.0.0-alpha.beta
-  +version привет, друг!
-  +version привет, как дела?
-  +version 你好，伙计
-  +version 0.0
-  +version 123
-  +version 1. 1 .1
-  +version 1.1.alpha
-  +version 1-alpha
-  +version alpha.1.1
+  +version 0.0.0
+  +version 0.2.1
+  +version 42.0.555555
+  +version 0.0.1-alpha
+  +version 0.0.1-beta-1
 
   # No comments.
   [x] > foo

--- a/src/test/resources/org/eolang/lints/packs/incorrect-version/allows-maven-convention.yaml
+++ b/src/test/resources/org/eolang/lints/packs/incorrect-version/allows-maven-convention.yaml
@@ -23,31 +23,10 @@
 sheets:
   - /org/eolang/lints/metas/incorrect-version.xsl
 asserts:
-  - /defects[count(defect[@severity='warning'])=11]
-  - /defects/defect[@line='1']
-  - /defects/defect[@line='2']
-  - /defects/defect[@line='3']
-  - /defects/defect[@line='4']
-  - /defects/defect[@line='5']
-  - /defects/defect[@line='6']
-  - /defects/defect[@line='7']
-  - /defects/defect[@line='8']
-  - /defects/defect[@line='9']
-  - /defects/defect[@line='10']
-  - /defects/defect[@line='11']
+  - /defects[count(defect[@severity='warning'])=0]
 input: |
-  +version alpha
-  +version 1.0.0-alpha.beta
-  +version привет, друг!
-  +version привет, как дела?
-  +version 你好，伙计
-  +version 0.0
-  +version 123
-  +version 1. 1 .1
-  +version 1.1.alpha
-  +version 1-alpha
-  +version alpha.1.1
+  +version 1.0-SNAPSHOT
 
   # No comments.
   [x] > foo
-    x.div in.nextInt > @
+    41 > @

--- a/src/test/resources/org/eolang/lints/packs/incorrect-version/catches-bad-maven-convention.yaml
+++ b/src/test/resources/org/eolang/lints/packs/incorrect-version/catches-bad-maven-convention.yaml
@@ -23,10 +23,12 @@
 sheets:
   - /org/eolang/lints/metas/incorrect-version.xsl
 asserts:
-  - /defects[count(defect[@severity='warning'])=1]
+  - /defects[count(defect[@severity='warning'])=2]
   - /defects/defect[@line='1']
+  - /defects/defect[@line='2']
 input: |
   +version x.z-SNAPSHOT
+  +version 1.1-hello
 
   # No comments.
   [x] > foo

--- a/src/test/resources/org/eolang/lints/packs/incorrect-version/catches-bad-maven-convention.yaml
+++ b/src/test/resources/org/eolang/lints/packs/incorrect-version/catches-bad-maven-convention.yaml
@@ -23,31 +23,11 @@
 sheets:
   - /org/eolang/lints/metas/incorrect-version.xsl
 asserts:
-  - /defects[count(defect[@severity='warning'])=11]
+  - /defects[count(defect[@severity='warning'])=1]
   - /defects/defect[@line='1']
-  - /defects/defect[@line='2']
-  - /defects/defect[@line='3']
-  - /defects/defect[@line='4']
-  - /defects/defect[@line='5']
-  - /defects/defect[@line='6']
-  - /defects/defect[@line='7']
-  - /defects/defect[@line='8']
-  - /defects/defect[@line='9']
-  - /defects/defect[@line='10']
-  - /defects/defect[@line='11']
 input: |
-  +version alpha
-  +version 1.0.0-alpha.beta
-  +version привет, друг!
-  +version привет, как дела?
-  +version 你好，伙计
-  +version 0.0
-  +version 123
-  +version 1. 1 .1
-  +version 1.1.alpha
-  +version 1-alpha
-  +version alpha.1.1
+  +version x.z-SNAPSHOT
 
   # No comments.
   [x] > foo
-    x.div in.nextInt > @
+    41 > @


### PR DESCRIPTION
In this PR I've updated `incorrect-version` lint to allow maven convention, e.g.: `1.0-SNAPSHOT` if specified in `+version` meta.

see #237