### PR TITLE
feat(#248): application-duality

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/application-duality.xsl
+++ b/src/main/resources/org/eolang/lints/critical/application-duality.xsl
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="application-duality" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o">
+        <xsl:if test="count(o) != count(o[@as]) and count(o) != count(o[not(@as)]) and not(o/o)">
+          <defect>
+            <xsl:attribute name="line">
+              <xsl:value-of select="eo:lineno(@line)"/>
+            </xsl:attribute>
+            <xsl:attribute name="severity">
+              <xsl:text>critical</xsl:text>
+            </xsl:attribute>
+            <xsl:text>The </xsl:text>
+            <xsl:choose>
+              <xsl:when test="@name">
+                <xsl:text>object </xsl:text>
+                <xsl:text>"</xsl:text>
+                <xsl:value-of select="@name"/>
+                <xsl:text>"</xsl:text>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:text>anonymous object</xsl:text>
+              </xsl:otherwise>
+            </xsl:choose>
+            <xsl:text> has duality in the application, which is prohibited</xsl:text>
+          </defect>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/critical/application-duality.xsl
+++ b/src/main/resources/org/eolang/lints/critical/application-duality.xsl
@@ -24,6 +24,7 @@ SOFTWARE.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="application-duality" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
@@ -40,9 +41,7 @@ SOFTWARE.
             <xsl:choose>
               <xsl:when test="@name">
                 <xsl:text>object </xsl:text>
-                <xsl:text>"</xsl:text>
-                <xsl:value-of select="@name"/>
-                <xsl:text>"</xsl:text>
+                <xsl:value-of select="eo:escape(@name)"/>
               </xsl:when>
               <xsl:otherwise>
                 <xsl:text>anonymous object</xsl:text>

--- a/src/main/resources/org/eolang/lints/critical/application-duality.xsl
+++ b/src/main/resources/org/eolang/lints/critical/application-duality.xsl
@@ -27,8 +27,8 @@ SOFTWARE.
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o">
-        <xsl:if test="count(o) != count(o[@as]) and count(o) != count(o[not(@as)]) and not(o/o)">
+      <xsl:for-each select="//o[@base]">
+        <xsl:if test="count(o) != count(o[@as]) and count(o) != count(o[not(@as)])">
           <defect>
             <xsl:attribute name="line">
               <xsl:value-of select="eo:lineno(@line)"/>

--- a/src/main/resources/org/eolang/motives/critical/application-duality.md
+++ b/src/main/resources/org/eolang/motives/critical/application-duality.md
@@ -1,0 +1,33 @@
+# Application Duality
+
+In EO, it is not supported to have an application with and without binding at
+the same time, so it is prohibited in the [XMIR] too.
+
+Incorrect:
+
+```xml
+<o base="man">
+  <o base="string" as="name"/>
+  <o base="number"/>
+</o>
+```
+
+Correct:
+
+```xml
+<o base="man">
+  <o base="string" as="name"/>
+  <o base="number" as="age"/>
+</o>
+```
+
+Or
+
+```xml
+<o base="man">
+  <o base="string"/>
+  <o base="number"/>
+</o>
+```
+
+[XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html

--- a/src/test/resources/org/eolang/lints/packs/application-duality/allows-application-with-single-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/application-duality/allows-application-with-single-object.yaml
@@ -1,0 +1,34 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/application-duality.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o line="2" base="man">
+        <o base="string" as="name"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/application-duality/allows-application-without-as-attr.yaml
+++ b/src/test/resources/org/eolang/lints/packs/application-duality/allows-application-without-as-attr.yaml
@@ -1,0 +1,35 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/application-duality.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o line="2" base="man">
+        <o base="string"/>
+        <o base="number"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/application-duality/allows-full-application-with-nested-objects.yaml
+++ b/src/test/resources/org/eolang/lints/packs/application-duality/allows-full-application-with-nested-objects.yaml
@@ -1,0 +1,38 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/application-duality.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o line="2" base="man">
+        <o base="string" as="name"/>
+        <o line="3" base="car" as="transport">
+          <o base="string" as="model"/>
+          <o base="number" as="hpw"/>
+        </o>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/application-duality/allows-full-application.yaml
+++ b/src/test/resources/org/eolang/lints/packs/application-duality/allows-full-application.yaml
@@ -1,0 +1,35 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/application-duality.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o line="2" base="man">
+        <o base="string" as="name"/>
+        <o base="number" as="acc"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/application-duality/catches-dual-application.yaml
+++ b/src/test/resources/org/eolang/lints/packs/application-duality/catches-dual-application.yaml
@@ -1,0 +1,36 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/application-duality.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=1]
+  - /defects/defect[@line='2']
+document: |
+  <program>
+    <objects>
+      <o line="2" base="man">
+        <o base="string" as="name"/>
+        <o base="number"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/application-duality/catches-duality-in-nested-objects.yaml
+++ b/src/test/resources/org/eolang/lints/packs/application-duality/catches-duality-in-nested-objects.yaml
@@ -1,0 +1,39 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/application-duality.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=1]
+  - /defects/defect[@line='3']
+document: |
+  <program>
+    <objects>
+      <o line="2" base="man">
+        <o base="string" as="name"/>
+        <o line="3" base="car">
+          <o base="string" as="model"/>
+          <o base="number"/>
+        </o>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/application-duality/catches-many-dual-objects.yaml
+++ b/src/test/resources/org/eolang/lints/packs/application-duality/catches-many-dual-objects.yaml
@@ -1,0 +1,38 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2024 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/application-duality.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=1]
+  - /defects/defect[@line='2']
+document: |
+  <program>
+    <objects>
+      <o line="2" base="man">
+        <o base="string" as="name"/>
+        <o base="number" as="acc"/>
+        <o base="string"/>
+        <o base="number"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/application-duality/ignores-abstract-objects.yaml
+++ b/src/test/resources/org/eolang/lints/packs/application-duality/ignores-abstract-objects.yaml
@@ -23,18 +23,13 @@
 sheets:
   - /org/eolang/lints/critical/application-duality.xsl
 asserts:
-  - /defects[count(defect[@severity='critical'])=2]
-  - /defects/defect[@line='2']
-  - /defects/defect[@line='3']
+  - /defects[count(defect[@severity='critical'])=0]
 document: |
   <program>
     <objects>
-      <o line="2" base="man">
+      <o line="2" name="man">
         <o base="string" as="name"/>
-        <o line="3" base="car">
-          <o base="string" as="model"/>
-          <o base="number"/>
-        </o>
+        <o base="number"/>
       </o>
     </objects>
   </program>


### PR DESCRIPTION
In this PR I've implemented `application-duality` lint that issues `critical` defect if object has an application with duality (`@as` attributes presence is mixed).

closes #248
History:
- **feat(#248): application-duality**
- **feat(#248): motive, more tests**
