### PR TITLE
feat(#216): Integrate `xnav` Library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,11 @@ SOFTWARE.
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>com.github.volodya-lombrozo</groupId>
+      <artifactId>xnav</artifactId>
+      <version>0.1.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.yegor256</groupId>
       <artifactId>tojos</artifactId>
       <version>0.18.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.github.volodya-lombrozo</groupId>
       <artifactId>xnav</artifactId>
-      <version>0.1.1</version>
+      <version>0.1.2</version>
     </dependency>
     <dependency>
       <groupId>com.yegor256</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.github.volodya-lombrozo</groupId>
       <artifactId>xnav</artifactId>
-      <version>0.1.0</version>
+      <version>0.1.1</version>
     </dependency>
     <dependency>
       <groupId>com.yegor256</groupId>

--- a/src/it/lints-it/src/test/java/org/eolang/lints/it/LintsItTest.java
+++ b/src/it/lints-it/src/test/java/org/eolang/lints/it/LintsItTest.java
@@ -34,7 +34,7 @@ final class LintsItTest {
     void lintsProgram() throws IOException {
         MatcherAssert.assertThat(
             "passes with no exceptions",
-            new Program(new XMLDocument("<program/>")).defects(),
+            new Program(new XMLDocument("<program name='it'/>")).defects(),
             Matchers.notNullValue()
         );
     }

--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.lints;
 
+import com.github.lombrozo.xnav.Filter;
 import com.github.lombrozo.xnav.Navigator;
 import com.jcabi.xml.ClasspathSources;
 import com.jcabi.xml.XML;
@@ -32,9 +33,11 @@ import com.jcabi.xml.XSLDocument;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.cactoos.Input;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.text.IoCheckedText;
@@ -178,7 +181,7 @@ final class LtByXsl implements Lint<XML> {
      */
     private static String findName(final XML program) {
         return new Navigator(program.inner())
-            .child("program")
+            .element("program")
             .attribute("name")
             .text()
             .orElse("unknown");
@@ -200,23 +203,30 @@ final class LtByXsl implements Lint<XML> {
      *  <a href="https://github.com/jcabi/jcabi-xml/issues/288">jcabi/jcabi-xml#288</a>.
      */
     private static Collection<XML> findDefects(final XML report) {
-        final NodeList nodes = report.inner().getChildNodes();
-        final int length = nodes.getLength();
-        final List<XML> defects = new ArrayList<>(0);
-        for (int index = 0; index < length; ++index) {
-            final Node element = nodes.item(index);
-            if ("defects".equals(element.getNodeName())) {
-                final NodeList dnodes;
-                dnodes = element.getChildNodes();
-                final int all = dnodes.getLength();
-                for (int idx = 0; idx < all; ++idx) {
-                    final Node defect = dnodes.item(idx);
-                    if ("defect".equals(defect.getNodeName())) {
-                        defects.add(new XMLDocument(defect.cloneNode(true)));
-                    }
-                }
-            }
-        }
-        return defects;
+        return new Navigator(report.inner())
+            .element("defects")
+            .elements(Filter.withName("defect"))
+            .map(Navigator::copy)
+            .map(Navigator::node)
+            .map(XMLDocument::new)
+            .collect(Collectors.toList());
+//        final NodeList nodes = report.inner().getChildNodes();
+//        final int length = nodes.getLength();
+//        final List<XML> defects = new ArrayList<>(0);
+//        for (int index = 0; index < length; ++index) {
+//            final Node element = nodes.item(index);
+//            if ("defects".equals(element.getNodeName())) {
+//                final NodeList dnodes;
+//                dnodes = element.getChildNodes();
+//                final int all = dnodes.getLength();
+//                for (int idx = 0; idx < all; ++idx) {
+//                    final Node defect = dnodes.item(idx);
+//                    if ("defect".equals(defect.getNodeName())) {
+//                        defects.add(new XMLDocument(defect.cloneNode(true)));
+//                    }
+//                }
+//            }
+//        }
+//        return defects;
     }
 }

--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -171,13 +171,6 @@ final class LtByXsl implements Lint<XML> {
      * Find the name of the program.
      * @param program XML program
      * @return Name of the program.
-     * @todo #199:30min Use {@link XML#xpath(String)} Method Instead.
-     *  This method is using a custom implementation to find the name of the program.
-     *  We should replace it with the {@link XML#xpath(String)} method to make the code cleaner.
-     *  You can use `program.xpath("/program/@name").stream().findFirst().orElse("unknown")`
-     *  to find the name.
-     *  This issue is blocked by
-     *  <a href="https://github.com/jcabi/jcabi-xml/issues/289">jcabi/jcabi-xml#289</a>.
      */
     private static String findName(final XML program) {
         return new Navigator(program.inner())
@@ -185,22 +178,12 @@ final class LtByXsl implements Lint<XML> {
             .attribute("name")
             .text()
             .orElse("unknown");
-//        return Optional.of(program.inner().getFirstChild())
-//            .map(Node::getAttributes).map(attrs -> attrs.getNamedItem("name"))
-//            .map(Node::getTextContent).orElse("unknown");
     }
 
     /**
      * Find defects in the report.
      * @param report XML report.
      * @return Collection of defects.
-     * @todo #199:30min Use {@link XML#nodes(String)} Method Instead.
-     *  This method is using a custom implementation to find defects in the
-     *  report. We should replace it with the {@link XML#nodes(String)} method
-     *  to make the code cleaner.
-     *  You can use `report.nodes("/defects/defect")` to find the defects.
-     *  This issue is blocked by
-     *  <a href="https://github.com/jcabi/jcabi-xml/issues/288">jcabi/jcabi-xml#288</a>.
      */
     private static Collection<XML> findDefects(final XML report) {
         return new Navigator(report.inner())
@@ -210,23 +193,5 @@ final class LtByXsl implements Lint<XML> {
             .map(Navigator::node)
             .map(XMLDocument::new)
             .collect(Collectors.toList());
-//        final NodeList nodes = report.inner().getChildNodes();
-//        final int length = nodes.getLength();
-//        final List<XML> defects = new ArrayList<>(0);
-//        for (int index = 0; index < length; ++index) {
-//            final Node element = nodes.item(index);
-//            if ("defects".equals(element.getNodeName())) {
-//                final NodeList dnodes;
-//                dnodes = element.getChildNodes();
-//                final int all = dnodes.getLength();
-//                for (int idx = 0; idx < all; ++idx) {
-//                    final Node defect = dnodes.item(idx);
-//                    if ("defect".equals(defect.getNodeName())) {
-//                        defects.add(new XMLDocument(defect.cloneNode(true)));
-//                    }
-//                }
-//            }
-//        }
-//        return defects;
     }
 }

--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -31,19 +31,14 @@ import com.jcabi.xml.XMLDocument;
 import com.jcabi.xml.XSL;
 import com.jcabi.xml.XSLDocument;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.cactoos.Input;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.text.IoCheckedText;
 import org.cactoos.text.TextOf;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 /**
  * Lint by XSL.

--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.lints;
 
+import com.github.lombrozo.xnav.Navigator;
 import com.jcabi.xml.ClasspathSources;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
@@ -176,9 +177,14 @@ final class LtByXsl implements Lint<XML> {
      *  <a href="https://github.com/jcabi/jcabi-xml/issues/289">jcabi/jcabi-xml#289</a>.
      */
     private static String findName(final XML program) {
-        return Optional.of(program.inner().getFirstChild())
-            .map(Node::getAttributes).map(attrs -> attrs.getNamedItem("name"))
-            .map(Node::getTextContent).orElse("unknown");
+        return new Navigator(program.inner())
+            .child("program")
+            .attribute("name")
+            .text()
+            .orElse("unknown");
+//        return Optional.of(program.inner().getFirstChild())
+//            .map(Node::getAttributes).map(attrs -> attrs.getNamedItem("name"))
+//            .map(Node::getTextContent).orElse("unknown");
     }
 
     /**

--- a/src/test/java/org/eolang/lints/PkByXslTest.java
+++ b/src/test/java/org/eolang/lints/PkByXslTest.java
@@ -45,7 +45,7 @@ final class PkByXslTest {
 
     @Test
     void passesOnSimpleXmir() throws IOException {
-        final XML xmir = new XMLDocument("<program/>");
+        final XML xmir = new XMLDocument("<program name='no-exceptions'/>");
         for (final Lint<XML> lint : new PkByXsl()) {
             MatcherAssert.assertThat(
                 "passes with no exceptions",

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -204,7 +204,7 @@ final class ProgramTest {
         Assertions.assertDoesNotThrow(
             () ->
                 new Program(
-                    new XMLDocument("<program/>")
+                    new XMLDocument("<program name='correct'/>")
                 ).defects(),
             "Exception was thrown, but it should not be"
         );


### PR DESCRIPTION
In this PR I use `xnav` library to navigate over XML document elements. This significantly simplifies the code.

Closes: #216, #217
