### PR TITLE
bug(#267): `incorrect-test-object-name` allows numbers

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/incorrect-test-object-name.xsl
+++ b/src/main/resources/org/eolang/lints/misc/incorrect-test-object-name.xsl
@@ -30,7 +30,7 @@ SOFTWARE.
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="/program[metas/meta[head='tests']]/objects/o[@name]">
-        <xsl:variable name="regexp" select="'^[a-z][a-z]+(-[a-z][a-z]+)*$'"/>
+        <xsl:variable name="regexp" select="'^[a-z][a-z0-9]+(-[a-z0-9][a-z0-9]+)*$'"/>
         <xsl:if test="not(matches(@name, $regexp))">
           <defect>
             <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/incorrect-test-object-name/allows-numbers.yaml
+++ b/src/test/resources/org/eolang/lints/packs/incorrect-test-object-name/allows-numbers.yaml
@@ -23,11 +23,10 @@
 sheets:
   - /org/eolang/lints/misc/incorrect-test-object-name.xsl
 asserts:
-  - /defects[count(defect[@severity='warning'])=1]
-  - /defects/defect[@line='4']
+  - /defects[count(defect[@severity='warning'])=0]
 input: |
   +tests
 
   # Test.
-  [] > test123
-    42 > fooB
+  [] > foo-i32-if-out-of-bounds
+    42 > @


### PR DESCRIPTION
In this PR I've updated `incorrect-test-object-name` lint to not complain about numbers in the test object name.

Example: `foo-i32` should not provoke defects.

see #267