### PR TITLE
bug(#272): `incorrect-test-object-name` allows one-letter-parts

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/incorrect-test-object-name.xsl
+++ b/src/main/resources/org/eolang/lints/misc/incorrect-test-object-name.xsl
@@ -30,7 +30,7 @@ SOFTWARE.
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="/program[metas/meta[head='tests']]/objects/o[@name]">
-        <xsl:variable name="regexp" select="'^[a-z][a-z0-9]+(-[a-z0-9][a-z0-9]+)*$'"/>
+        <xsl:variable name="regexp" select="'^[a-z][a-z0-9]*(-[a-z0-9]+)*$'"/>
         <xsl:if test="not(matches(@name, $regexp))">
           <defect>
             <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/incorrect-test-object-name/allows-many-one-letter-parts.yaml
+++ b/src/test/resources/org/eolang/lints/packs/incorrect-test-object-name/allows-many-one-letter-parts.yaml
@@ -1,0 +1,32 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/misc/incorrect-test-object-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  +tests
+
+  # Test.
+  [] > f-o-o
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/incorrect-test-object-name/allows-one-letter-in-first.yaml
+++ b/src/test/resources/org/eolang/lints/packs/incorrect-test-object-name/allows-one-letter-in-first.yaml
@@ -1,0 +1,32 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/misc/incorrect-test-object-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  +tests
+
+  # Test.
+  [] > e-tests-ln-one-is-one
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/incorrect-test-object-name/allows-one-letter-parts-with-numbers-inside.yaml
+++ b/src/test/resources/org/eolang/lints/packs/incorrect-test-object-name/allows-one-letter-parts-with-numbers-inside.yaml
@@ -1,0 +1,32 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/misc/incorrect-test-object-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  +tests
+
+  # Test.
+  [] > f-1-runs-from-0-km
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/incorrect-test-object-name/allows-one-letter-parts.yaml
+++ b/src/test/resources/org/eolang/lints/packs/incorrect-test-object-name/allows-one-letter-parts.yaml
@@ -23,11 +23,10 @@
 sheets:
   - /org/eolang/lints/misc/incorrect-test-object-name.xsl
 asserts:
-  - /defects[count(defect[@severity='warning'])=1]
-  - /defects/defect[@line='4']
+  - /defects[count(defect[@severity='warning'])=0]
 input: |
   +tests
 
   # Test.
-  [] > t
-    42 > foo
+  [] > tests-ln-of-e-one-is-one
+    42 > @


### PR DESCRIPTION
In this PR I've updated regexp in `incorrect-test-object-name` lint, to allow one-letter-parts in test name.

see #272