### PR TITLE
bug(#268): allow vertical-bound-method in application-duality

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/application-duality.xsl
+++ b/src/main/resources/org/eolang/lints/critical/application-duality.xsl
@@ -22,14 +22,24 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="application-duality" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:eo="https://www.eolang.org" id="application-duality" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="//o[@base]">
-        <xsl:if test="count(o) != count(o[@as]) and count(o) != count(o[not(@as)])">
+        <xsl:variable name="violates" as="xs:boolean">
+          <xsl:choose>
+            <xsl:when test="starts-with(@base, '.')">
+              <xsl:value-of select="count(o[position() > 1 and not(starts-with(@base, '.'))]) != count(o[@as]) and count(o[position() > 1 and not(starts-with(@base, '.'))]) != count(o[not(@as)])"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="count(o) != count(o[@as]) and count(o) != count(o[not(@as)])"/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:variable>
+        <xsl:if test="$violates">
           <defect>
             <xsl:attribute name="line">
               <xsl:value-of select="eo:lineno(@line)"/>

--- a/src/main/resources/org/eolang/lints/critical/application-duality.xsl
+++ b/src/main/resources/org/eolang/lints/critical/application-duality.xsl
@@ -32,7 +32,7 @@ SOFTWARE.
         <xsl:variable name="violates" as="xs:boolean">
           <xsl:choose>
             <xsl:when test="starts-with(@base, '.')">
-              <xsl:value-of select="count(o[position() > 1 and not(starts-with(@base, '.'))]) != count(o[@as]) and count(o[position() > 1 and not(starts-with(@base, '.'))]) != count(o[not(@as)])"/>
+              <xsl:value-of select="count(o[@as]) != 0 and count(o[position() > 1 and not(starts-with(@base, '.'))]) != count(o[@as]) and count(o[position() > 1 and not(starts-with(@base, '.'))]) != count(o[not(@as)])"/>
             </xsl:when>
             <xsl:otherwise>
               <xsl:value-of select="count(o) != count(o[@as]) and count(o) != count(o[not(@as)])"/>

--- a/src/test/resources/org/eolang/lints/packs/application-duality/allows-compact-vertical-bound-method.yaml
+++ b/src/test/resources/org/eolang/lints/packs/application-duality/allows-compact-vertical-bound-method.yaml
@@ -1,0 +1,34 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/application-duality.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+input: |
+  # Compact vertical bound method.
+  [] > vertical-bound-method
+    eq. > @
+      true.if
+        "second":1
+        "first".as-bytes:0
+      "first"

--- a/src/test/resources/org/eolang/lints/packs/application-duality/allows-horizontal-bound-method.yaml
+++ b/src/test/resources/org/eolang/lints/packs/application-duality/allows-horizontal-bound-method.yaml
@@ -25,7 +25,7 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='critical'])=0]
 input: |
-  # Compact vertical bound method.
+  # Horizontal bound method.
   [] > vertical-bound-method
     eq. > @
       true.if

--- a/src/test/resources/org/eolang/lints/packs/application-duality/allows-vertical-bound-method.yaml
+++ b/src/test/resources/org/eolang/lints/packs/application-duality/allows-vertical-bound-method.yaml
@@ -1,0 +1,36 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/application-duality.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+input: |
+  # Vertical bound method with an application.
+  [] > vertical-bound-method
+    eq. > @
+      if.
+        true
+        "second":1
+        "first"
+        .as-bytes:0
+      "first"


### PR DESCRIPTION
In this PR I've updated `application-duality` lint to handle `@as` references in vertical and horizontal method bounds.

see #268
History:
- **bug(#268): skip first**
- **bug(#268): count(as) not 0**
