### PR TITLE
bug(#296): compare `/program/@name` with packaged object path

### DIFF
--- a/src/main/resources/org/eolang/lints/names/object-does-not-match-filename.xsl
+++ b/src/main/resources/org/eolang/lints/names/object-does-not-match-filename.xsl
@@ -28,34 +28,36 @@ SOFTWARE.
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:variable name="package" select="/program/metas/meta[head='package'][1]"/>
   <xsl:variable name="program" select="/program/@name"/>
-  <xsl:variable name="filename" as="xs:string">
-    <xsl:choose>
-      <xsl:when test="$package">
-        <xsl:value-of select="substring-after($program, concat($package/tail/text(), '.'))"/>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:value-of select="$program"/>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:variable>
   <xsl:variable name="tested" select="/program/metas/meta[head='tests']"/>
   <xsl:template match="/">
     <defects>
       <xsl:if test="not($tested)">
-        <xsl:apply-templates select="/program/objects/o[@name != $filename]" mode="confused-name"/>
+        <xsl:apply-templates select="/program/objects/o" mode="live"/>
       </xsl:if>
     </defects>
   </xsl:template>
-  <xsl:template match="o" mode="confused-name">
-    <defect>
-      <xsl:attribute name="line">
-        <xsl:value-of select="eo:lineno(@line)"/>
-      </xsl:attribute>
-      <xsl:attribute name="severity">warning</xsl:attribute>
-      <xsl:text>Object </xsl:text>
-      <xsl:value-of select="eo:escape(@name)"/>
-      <xsl:text> does not match with filename </xsl:text>
-      <xsl:value-of select="eo:escape($filename)"/>
-    </defect>
+  <xsl:template match="o" mode="live">
+    <xsl:variable name="opath" as="xs:string">
+      <xsl:choose>
+        <xsl:when test="$package">
+          <xsl:value-of select="concat($package/tail/text(), '.', @name)"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="@name"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:if test="$program != $opath">
+      <defect>
+        <xsl:attribute name="line">
+          <xsl:value-of select="eo:lineno(@line)"/>
+        </xsl:attribute>
+        <xsl:attribute name="severity">warning</xsl:attribute>
+        <xsl:text>Object </xsl:text>
+        <xsl:value-of select="eo:escape($opath)"/>
+        <xsl:text> does not match with filename </xsl:text>
+        <xsl:value-of select="eo:escape($program)"/>
+      </defect>
+    </xsl:if>
   </xsl:template>
 </xsl:stylesheet>

--- a/src/test/resources/org/eolang/lints/packs/object-does-not-match-filename/catches-bad-packaged-name-with-correct-message.yaml
+++ b/src/test/resources/org/eolang/lints/packs/object-does-not-match-filename/catches-bad-packaged-name-with-correct-message.yaml
@@ -1,0 +1,41 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/names/object-does-not-match-filename.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+  - /defects/defect[@line='4']
+  - /defects/defect[1][normalize-space()='Object "main" does not match with filename "foo.x.main"']
+document: |
+  <program name="foo.x.main">
+    <metas>
+      <meta line="1">
+        <head>package</head>
+          <tail>f</tail>
+          <part>f</part>
+      </meta>
+    </metas>
+    <objects>
+      <o line="4" name="main" pos="0"/>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/object-does-not-match-filename/catches-multiple-packaged-names.yaml
+++ b/src/test/resources/org/eolang/lints/packs/object-does-not-match-filename/catches-multiple-packaged-names.yaml
@@ -23,9 +23,11 @@
 sheets:
   - /org/eolang/lints/names/object-does-not-match-filename.xsl
 asserts:
-  - /defects[count(defect[@severity='warning'])=1]
+  - /defects[count(defect[@severity='warning'])=2]
   - /defects/defect[@line='4']
+  - /defects/defect[@line='5']
   - /defects/defect[1][normalize-space()='Object "f.main" does not match with filename "foo.x.main"']
+  - /defects/defect[2][normalize-space()='Object "f.foo" does not match with filename "foo.x.main"']
 document: |
   <program name="foo.x.main">
     <metas>
@@ -37,5 +39,6 @@ document: |
     </metas>
     <objects>
       <o line="4" name="main" pos="0"/>
+      <o line="5" name="foo" pos="0"/>
     </objects>
   </program>


### PR DESCRIPTION
In this PR I've updated `object-does-not-match-filename` to compare full program name(`/program/@name`) with object name (counting packages too).

see #296
History:
- **bug(#296): test**
- **bug(#296): compare program with opath**
