### PR TITLE
feat(#292): `void-attributes-not-higher-than-other`

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/void-attributes-not-higher-than-other.xsl
+++ b/src/main/resources/org/eolang/lints/critical/void-attributes-not-higher-than-other.xsl
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2025 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="void-attributes-not-higher-than-other" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:apply-templates select="//o"/>
+    </defects>
+  </xsl:template>
+  <xsl:template match="o">
+    <xsl:if test="@base='∅' and preceding-sibling::o[@base != '∅']">
+      <defect>
+        <xsl:attribute name="line">
+          <xsl:value-of select="eo:lineno(@line)"/>
+        </xsl:attribute>
+        <xsl:attribute name="severity">critical</xsl:attribute>
+        <xsl:text>Void attribute </xsl:text>
+        <xsl:value-of select="eo:escape(@name)"/>
+        <xsl:text> must be higher than any other non-void attribute</xsl:text>
+      </defect>
+    </xsl:if>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/critical/void-attributes-not-higher-than-other.xsl
+++ b/src/main/resources/org/eolang/lints/critical/void-attributes-not-higher-than-other.xsl
@@ -28,20 +28,18 @@ SOFTWARE.
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:apply-templates select="//o"/>
+      <xsl:apply-templates select="//o[@base='∅' and preceding-sibling::o[@base != '∅']]" mode="low-void"/>
     </defects>
   </xsl:template>
-  <xsl:template match="o">
-    <xsl:if test="@base='∅' and preceding-sibling::o[@base != '∅']">
-      <defect>
-        <xsl:attribute name="line">
-          <xsl:value-of select="eo:lineno(@line)"/>
-        </xsl:attribute>
-        <xsl:attribute name="severity">critical</xsl:attribute>
-        <xsl:text>Void attribute </xsl:text>
-        <xsl:value-of select="eo:escape(@name)"/>
-        <xsl:text> must be higher than any other non-void attribute</xsl:text>
-      </defect>
-    </xsl:if>
+  <xsl:template match="o" mode="low-void">
+    <defect>
+      <xsl:attribute name="line">
+        <xsl:value-of select="eo:lineno(@line)"/>
+      </xsl:attribute>
+      <xsl:attribute name="severity">critical</xsl:attribute>
+      <xsl:text>Void attribute </xsl:text>
+      <xsl:value-of select="eo:escape(@name)"/>
+      <xsl:text> must be higher than any other non-void attribute</xsl:text>
+    </defect>
   </xsl:template>
 </xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/critical/void-attributes-not-higher-than-other.md
+++ b/src/main/resources/org/eolang/motives/critical/void-attributes-not-higher-than-other.md
@@ -1,0 +1,26 @@
+# Void Attributes (`∅`) Not Higher Than Other
+
+In [XMIR], all void attributes must be placed on top of other non-void
+attributes.
+
+Incorrect:
+
+```xml
+<o name="foo">
+  <o base="∅" name="x"/>
+  <o base="Q.foo" name="z"/>
+  <o base="∅" name="y"/>
+</o>
+```
+
+Correct:
+
+```xml
+<o name="foo">
+  <o base="∅" name="x"/>
+  <o base="∅" name="y"/>
+  <o base="Q.foo" name="z"/>
+</o>
+```
+
+[XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html

--- a/src/test/resources/org/eolang/lints/packs/void-attributes-not-higher-than-other/allows-all-empty-attributes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/void-attributes-not-higher-than-other/allows-all-empty-attributes.yaml
@@ -1,0 +1,32 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/void-attributes-not-higher-than-other.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o name="foo"/>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/void-attributes-not-higher-than-other/allows-empty-void-attributes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/void-attributes-not-higher-than-other/allows-empty-void-attributes.yaml
@@ -1,0 +1,35 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/void-attributes-not-higher-than-other.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o name="foo">
+        <o base="Q.foo" name="x"/>
+        <o base="Q.foo" name="y"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/void-attributes-not-higher-than-other/allows-top-void-attributes-in-multiple-objects.yaml
+++ b/src/test/resources/org/eolang/lints/packs/void-attributes-not-higher-than-other/allows-top-void-attributes-in-multiple-objects.yaml
@@ -1,0 +1,41 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/void-attributes-not-higher-than-other.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o name="foo">
+        <o line="1" base="∅" name="x"/>
+        <o line="2" base="∅" name="y"/>
+        <o line="3" base="Q.foo" name="z"/>
+        <o line="4" base="Q.foo" name="t"/>
+      </o>
+      <o name="tab">
+        <o line="5" base="Q.d" name="a"/>
+        <o line="6" base="Q.x" name="b"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/void-attributes-not-higher-than-other/allows-void-attributes-at-top.yaml
+++ b/src/test/resources/org/eolang/lints/packs/void-attributes-not-higher-than-other/allows-void-attributes-at-top.yaml
@@ -1,0 +1,36 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/void-attributes-not-higher-than-other.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o name="foo">
+        <o base="∅" name="x"/>
+        <o base="∅" name="y"/>
+        <o base="Q.foo" name="z"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/void-attributes-not-higher-than-other/allows-void-attributes-higher-than-many-other.yaml
+++ b/src/test/resources/org/eolang/lints/packs/void-attributes-not-higher-than-other/allows-void-attributes-higher-than-many-other.yaml
@@ -1,0 +1,39 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/void-attributes-not-higher-than-other.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o name="foo">
+        <o line="1" base="∅" name="x"/>
+        <o line="2" base="∅" name="y"/>
+        <o line="3" base="Q.foo" name="z"/>
+        <o line="4" base="Q.foo" name="t"/>
+        <o line="5" base="Q.d" name="a"/>
+        <o line="6" base="Q.x" name="b"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/void-attributes-not-higher-than-other/catches-lower-void-attributes-in-multiple-objects.yaml
+++ b/src/test/resources/org/eolang/lints/packs/void-attributes-not-higher-than-other/catches-lower-void-attributes-in-multiple-objects.yaml
@@ -1,0 +1,43 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/void-attributes-not-higher-than-other.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=1]
+  - /defects/defect[@line='7']
+document: |
+  <program>
+    <objects>
+      <o name="foo">
+        <o line="1" base="∅" name="x"/>
+        <o line="2" base="∅" name="y"/>
+        <o line="3" base="Q.foo" name="z"/>
+        <o line="4" base="Q.foo" name="t"/>
+      </o>
+      <o name="tab">
+        <o line="5" base="Q.d" name="a"/>
+        <o line="6" base="Q.x" name="b"/>
+        <o line="7" base="∅" name="s"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/void-attributes-not-higher-than-other/catches-void-attributes-at-bottom.yaml
+++ b/src/test/resources/org/eolang/lints/packs/void-attributes-not-higher-than-other/catches-void-attributes-at-bottom.yaml
@@ -1,0 +1,38 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/void-attributes-not-higher-than-other.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=2]
+  - /defects/defect[@line='2']
+  - /defects/defect[@line='3']
+document: |
+  <program>
+    <objects>
+      <o name="foo">
+        <o line="1" base="Q.foo" name="z"/>
+        <o line="2" base="∅" name="x"/>
+        <o line="3" base="∅" name="y"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/void-attributes-not-higher-than-other/catches-void-attributes-lower-than-other.yaml
+++ b/src/test/resources/org/eolang/lints/packs/void-attributes-not-higher-than-other/catches-void-attributes-lower-than-other.yaml
@@ -1,0 +1,37 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/void-attributes-not-higher-than-other.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=1]
+  - /defects/defect[@line='1']
+document: |
+  <program>
+    <objects>
+      <o name="foo">
+        <o line="1" base="∅" name="x"/>
+        <o line="1" base="Q.foo" name="z"/>
+        <o line="1" base="∅" name="y"/>
+      </o>
+    </objects>
+  </program>


### PR DESCRIPTION
In this PR I've introduced `void-attributes-not-higher-than-other` lint, that issues defect with `critical` severity, if void attribute (`∅`) is located lower than sibling non-void attributes.

closes #292
