### PR TITLE
feat(#264): Xnav instead of `XML#xpath()` and `XML#nodes()`

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,37 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+name: shellcheck
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  shellcheck:
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ludeeus/action-shellcheck@master

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.github.volodya-lombrozo</groupId>
       <artifactId>xnav</artifactId>
-      <version>0.1.7</version>
+      <version>0.1.8</version>
     </dependency>
     <dependency>
       <groupId>org.apache.opennlp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.github.volodya-lombrozo</groupId>
       <artifactId>xnav</artifactId>
-      <version>0.1.9</version>
+      <version>0.1.10</version>
     </dependency>
     <dependency>
       <groupId>org.apache.opennlp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.github.volodya-lombrozo</groupId>
       <artifactId>xnav</artifactId>
-      <version>0.1.10</version
+      <version>0.1.10</version>
     </dependency>
     <dependency>
       <groupId>org.apache.opennlp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.github.volodya-lombrozo</groupId>
       <artifactId>xnav</artifactId>
-      <version>0.1.8</version>
+      <version>0.1.9</version>
     </dependency>
     <dependency>
       <groupId>org.apache.opennlp</groupId>

--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -28,7 +28,6 @@ import com.jcabi.xml.XML;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.stream.Collectors;
 
 /**
  * Lint that ignores linting if {@code +unlint} meta is present.
@@ -57,12 +56,12 @@ final class LtUnlint implements Lint<XML> {
 
     @Override
     public Collection<Defect> defects(final XML xmir) throws IOException {
-        final boolean suppress = !new Xnav(xmir.inner()).path(
+        final boolean suppress = new Xnav(xmir.inner()).path(
             String.format(
                 "/program/metas/meta[head='unlint' and tail='%s']",
                 this.origin.name()
             )
-        ).collect(Collectors.toList()).isEmpty();
+        ).findAny().isPresent();
         final Collection<Defect> defects = new ArrayList<>(0);
         if (!suppress) {
             defects.addAll(this.origin.defects(xmir));

--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -23,10 +23,12 @@
  */
 package org.eolang.lints;
 
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 /**
  * Lint that ignores linting if {@code +unlint} meta is present.
@@ -55,12 +57,12 @@ final class LtUnlint implements Lint<XML> {
 
     @Override
     public Collection<Defect> defects(final XML xmir) throws IOException {
-        final boolean suppress = !xmir.nodes(
+        final boolean suppress = !new Xnav(xmir.inner()).path(
             String.format(
                 "/program/metas/meta[head='unlint' and tail='%s']",
                 this.origin.name()
             )
-        ).isEmpty();
+        ).collect(Collectors.toList()).isEmpty();
         final Collection<Defect> defects = new ArrayList<>(0);
         if (!suppress) {
             defects.addAll(this.origin.defects(xmir));

--- a/src/main/java/org/eolang/lints/comments/LtAsciiOnly.java
+++ b/src/main/java/org/eolang/lints/comments/LtAsciiOnly.java
@@ -56,7 +56,8 @@ public final class LtAsciiOnly implements Lint<XML> {
     @Override
     public Collection<Defect> defects(final XML xmir) throws IOException {
         final Collection<Defect> defects = new LinkedList<>();
-        final List<Xnav> comments = new Xnav(xmir.inner())
+        final Xnav xml = new Xnav(xmir.inner());
+        final List<Xnav> comments = xml
             .path("/program/comments/comment").collect(Collectors.toList());
         for (final Xnav comment : comments) {
             final Optional<Character> abusive = comment.text().get().chars()
@@ -72,7 +73,7 @@ public final class LtAsciiOnly implements Lint<XML> {
                 new Defect.Default(
                     "ascii-only",
                     Severity.ERROR,
-                    xmir.xpath("/program/@name").stream().findFirst().orElse("unknown"),
+                    xml.element("program").attribute("name").text().orElse("unknown"),
                     Integer.parseInt(line),
                     String.format(
                         "Only ASCII characters are allowed in comments, while \"%s\" is used at the line no.%s at the position no.%s",

--- a/src/main/java/org/eolang/lints/comments/LtAsciiOnly.java
+++ b/src/main/java/org/eolang/lints/comments/LtAsciiOnly.java
@@ -23,11 +23,14 @@
  */
 package org.eolang.lints.comments;
 
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.text.IoCheckedText;
 import org.cactoos.text.TextOf;
@@ -53,15 +56,17 @@ public final class LtAsciiOnly implements Lint<XML> {
     @Override
     public Collection<Defect> defects(final XML xmir) throws IOException {
         final Collection<Defect> defects = new LinkedList<>();
-        for (final XML comment : xmir.nodes("/program/comments/comment")) {
-            final Optional<Character> abusive = comment.xpath("text()").get(0).chars()
+        final List<Xnav> comments = new Xnav(xmir.inner())
+            .path("/program/comments/comment").collect(Collectors.toList());
+        for (final Xnav comment : comments) {
+            final Optional<Character> abusive = comment.text().get().chars()
                 .filter(chr -> chr < 32 || chr > 127)
                 .mapToObj(chr -> (char) chr)
                 .findFirst();
             if (!abusive.isPresent()) {
                 continue;
             }
-            final String line = comment.xpath("@line").get(0);
+            final String line = comment.attribute("line").text().orElse("0");
             final Character chr = abusive.get();
             defects.add(
                 new Defect.Default(
@@ -73,7 +78,7 @@ public final class LtAsciiOnly implements Lint<XML> {
                         "Only ASCII characters are allowed in comments, while \"%s\" is used at the line no.%s at the position no.%s",
                         chr,
                         line,
-                        comment.xpath("text()").get(0).indexOf(chr) + 1
+                        comment.text().get().indexOf(chr) + 1
                     )
                 )
             );

--- a/src/main/java/org/eolang/lints/comments/LtAsciiOnly.java
+++ b/src/main/java/org/eolang/lints/comments/LtAsciiOnly.java
@@ -57,8 +57,8 @@ public final class LtAsciiOnly implements Lint<XML> {
     public Collection<Defect> defects(final XML xmir) throws IOException {
         final Collection<Defect> defects = new LinkedList<>();
         final Xnav xml = new Xnav(xmir.inner());
-        final List<Xnav> comments = xml
-            .path("/program/comments/comment").collect(Collectors.toList());
+        final List<Xnav> comments = xml.path("/program/comments/comment")
+            .collect(Collectors.toList());
         for (final Xnav comment : comments) {
             final Optional<Character> abusive = comment.text().get().chars()
                 .filter(chr -> chr < 32 || chr > 127)

--- a/src/main/java/org/eolang/lints/critical/LtIncorrectAlias.java
+++ b/src/main/java/org/eolang/lints/critical/LtIncorrectAlias.java
@@ -57,11 +57,12 @@ public final class LtIncorrectAlias implements Lint<Map<String, XML>> {
         final Collection<Defect> defects = new LinkedList<>();
         pkg.values().forEach(
             xmir -> {
-                final Xnav program = new Xnav(xmir.inner()).element("program");
-                for (final XML alias : xmir.nodes("/program/metas/meta[head='alias']")) {
-                    final Xnav xml = new Xnav(alias.inner());
-                    final String pointer = xml.element("tail").text().get();
-                    final List<Xnav> parts = xml.elements(Filter.withName("part"))
+                final Xnav xml = new Xnav(xmir.inner());
+                final List<Xnav> aliased = xml.path("/program/metas/meta[head='alias']")
+                    .collect(Collectors.toList());
+                for (final Xnav alias : aliased) {
+                    final String pointer = alias.element("tail").text().get();
+                    final List<Xnav> parts = alias.elements(Filter.withName("part"))
                         .collect(Collectors.toList());
                     final String lookup = parts.get(parts.size() - 1).text().get().substring(2);
                     if (!pkg.containsKey(lookup)) {
@@ -69,9 +70,9 @@ public final class LtIncorrectAlias implements Lint<Map<String, XML>> {
                             new Defect.Default(
                                 "incorrect-alias",
                                 Severity.CRITICAL,
-                                program.attribute("name").text().orElse("unknown"),
+                                xml.element("program").attribute("name").text().orElse("unknown"),
                                 Integer.parseInt(
-                                    xml.attribute("line").text().orElse("0")
+                                    alias.attribute("line").text().orElse("0")
                                 ),
                                 Logger.format(
                                     "Alias \"%s\" points to \"%s\", but it's not in scope (%d): %[list]s",

--- a/src/main/java/org/eolang/lints/errors/LtAtomIsNotUnique.java
+++ b/src/main/java/org/eolang/lints/errors/LtAtomIsNotUnique.java
@@ -164,8 +164,8 @@ public final class LtAtomIsNotUnique implements Lint<Map<String, XML>> {
             Severity.ERROR,
             xml.element("program").attribute("name").text().orElse("unknown"),
             Integer.parseInt(
-                xml.path(String.format("//o[@atom and @name='%s']", LtAtomIsNotUnique.oname(fqn)))
-                    .map(o -> o.attribute("line").text().get())
+                xml.path(String.format("//o[@atom and @name='%s']/@line", LtAtomIsNotUnique.oname(fqn)))
+                    .map(o -> o.text().get())
                     .collect(Collectors.toList()).get(0)
             ),
             String.format(
@@ -188,8 +188,8 @@ public final class LtAtomIsNotUnique implements Lint<Map<String, XML>> {
             xml.path("/program/metas/meta[head='package']")
                 .collect(Collectors.toList()).size() == 1
         ) {
-            final String pack = xml.path("/program/metas/meta[head='package']")
-                .map(o -> o.element("tail").text().get())
+            final String pack = xml.path("/program/metas/meta[head='package']/tail")
+                .map(o -> o.text().get())
                 .findFirst().get();
             result = fqns.stream().map(fqn -> String.format("%s.%s", pack, fqn))
                 .collect(Collectors.toList());

--- a/src/main/java/org/eolang/lints/errors/LtAtomIsNotUnique.java
+++ b/src/main/java/org/eolang/lints/errors/LtAtomIsNotUnique.java
@@ -164,7 +164,9 @@ public final class LtAtomIsNotUnique implements Lint<Map<String, XML>> {
             Severity.ERROR,
             xml.element("program").attribute("name").text().orElse("unknown"),
             Integer.parseInt(
-                xml.path(String.format("//o[@atom and @name='%s']/@line", LtAtomIsNotUnique.oname(fqn)))
+                xml.path(
+                    String.format("//o[@atom and @name='%s']/@line", LtAtomIsNotUnique.oname(fqn))
+                    )
                     .map(o -> o.text().get())
                     .collect(Collectors.toList()).get(0)
             ),

--- a/src/main/java/org/eolang/lints/errors/LtAtomIsNotUnique.java
+++ b/src/main/java/org/eolang/lints/errors/LtAtomIsNotUnique.java
@@ -187,8 +187,7 @@ public final class LtAtomIsNotUnique implements Lint<Map<String, XML>> {
             .map(o -> o.attribute("fqn").text().get())
             .collect(Collectors.toList());
         if (
-            xml.path("/program/metas/meta[head='package']")
-                .collect(Collectors.toList()).size() == 1
+            xml.path("/program/metas/meta[head='package']").count() == 1L
         ) {
             final String pack = xml.path("/program/metas/meta[head='package']/tail")
                 .map(o -> o.text().get())

--- a/src/main/java/org/eolang/lints/errors/LtAtomIsNotUnique.java
+++ b/src/main/java/org/eolang/lints/errors/LtAtomIsNotUnique.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.lints.errors;
 
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XSL;
 import com.jcabi.xml.XSLDocument;
@@ -146,8 +147,7 @@ public final class LtAtomIsNotUnique implements Lint<Map<String, XML>> {
         return new Defect.Default(
             this.name(),
             Severity.ERROR,
-            xmir.xpath("/program/@name").stream()
-                .findFirst().orElse("unknown"),
+            new Xnav(xmir.inner()).element("program").attribute("name").text().orElse("unknown"),
             Integer.parseInt(
                 xmir.xpath(
                     String.format(
@@ -164,7 +164,7 @@ public final class LtAtomIsNotUnique implements Lint<Map<String, XML>> {
         return new Defect.Default(
             this.name(),
             Severity.ERROR,
-            xmir.xpath("/program/@name").stream().findFirst().orElse("unknown"),
+            new Xnav(xmir.inner()).element("program").attribute("name").text().orElse("unknown"),
             Integer.parseInt(
                 xmir.xpath(
                     String.format(
@@ -175,11 +175,22 @@ public final class LtAtomIsNotUnique implements Lint<Map<String, XML>> {
             ),
             String.format(
                 "Atom with FQN \"%s\" is duplicated, original was found in \"%s\"",
-                fqn, original.xpath("/program/@name").stream().findFirst().orElse("unknown")
+                fqn,
+                new Xnav(original.inner()).element("program").attribute("name").text().orElse("unknown")
             )
         );
     }
 
+    /**
+     * Atom FQNs.
+     * @param xmir XMIR
+     * @return List of atom FQNs
+     * @todo #264:35min Replace `XML#xpath()` method with `Xnav#path()`.
+     *  Currently, `Xnav#path()` does not work with XPath correctly, once it
+     *  will be implemented, we should replace all our XPaths with that method.
+     *  See <a herf="https://github.com/volodya-lombrozo/xnav/issues/48">this</a>
+     *  for more details.
+     */
     private static List<String> fqns(final XML xmir) {
         final List<String> result;
         final List<String> fqns = xmir.xpath("//o[@fqn]/@fqn");

--- a/src/main/java/org/eolang/lints/errors/LtAtomIsNotUnique.java
+++ b/src/main/java/org/eolang/lints/errors/LtAtomIsNotUnique.java
@@ -179,16 +179,6 @@ public final class LtAtomIsNotUnique implements Lint<Map<String, XML>> {
         );
     }
 
-    /**
-     * Atom FQNs.
-     * @param xml Navigation XML
-     * @return List of atom FQNs
-     * @todo #264:35min Replace `XML#xpath()` method with `Xnav#path()`.
-     *  Currently, `Xnav#path()` does not work with XPath correctly, once it
-     *  will be implemented, we should replace all our XPaths with that method.
-     *  See <a herf="https://github.com/volodya-lombrozo/xnav/issues/48">this</a>
-     *  for more details.
-     */
     private static List<String> fqns(final Xnav xml) {
         final List<String> result;
         final List<String> fqns = xml.path("//o[@fqn]")

--- a/src/main/java/org/eolang/lints/errors/LtAtomIsNotUnique.java
+++ b/src/main/java/org/eolang/lints/errors/LtAtomIsNotUnique.java
@@ -176,7 +176,11 @@ public final class LtAtomIsNotUnique implements Lint<Map<String, XML>> {
             String.format(
                 "Atom with FQN \"%s\" is duplicated, original was found in \"%s\"",
                 fqn,
-                new Xnav(original.inner()).element("program").attribute("name").text().orElse("unknown")
+                new Xnav(original.inner())
+                    .element("program")
+                    .attribute("name")
+                    .text()
+                    .orElse("unknown")
             )
         );
     }

--- a/src/main/java/org/eolang/lints/errors/LtObjectIsNotUnique.java
+++ b/src/main/java/org/eolang/lints/errors/LtObjectIsNotUnique.java
@@ -135,8 +135,8 @@ public final class LtObjectIsNotUnique implements Lint<Map<String, XML>> {
 
     private static boolean containsDuplicate(final XML original, final XML oth, final String name) {
         return LtObjectIsNotUnique.programObjects(original).containsKey(name)
-            && LtObjectIsNotUnique.packageName(new Xnav(oth.inner()))
-            .equals(LtObjectIsNotUnique.packageName(new Xnav(original.inner())));
+            && LtObjectIsNotUnique.packageName(oth)
+            .equals(LtObjectIsNotUnique.packageName(original));
     }
 
     private static Map<String, String> programObjects(final XML xmir) {
@@ -158,11 +158,10 @@ public final class LtObjectIsNotUnique implements Lint<Map<String, XML>> {
             );
     }
 
-    private static String packageName(final Xnav xml) {
+    private static String packageName(final XML xmir) {
         final String name;
-        if (xml.path("/program/metas/meta[head='package']").collect(Collectors.toList()).size() == 1) {
-            name = xml.path("/program/metas/meta[head='package']/tail/text()").findFirst().get().text().get();
-//            name = xmir.xpath("/program/metas/meta[head='package']/tail/text()").get(0);
+        if (xmir.nodes("/program/metas/meta[head='package']").size() == 1) {
+            name = xmir.xpath("/program/metas/meta[head='package']/tail/text()").get(0);
         } else {
             name = "";
         }

--- a/src/main/java/org/eolang/lints/errors/LtObjectIsNotUnique.java
+++ b/src/main/java/org/eolang/lints/errors/LtObjectIsNotUnique.java
@@ -137,8 +137,8 @@ public final class LtObjectIsNotUnique implements Lint<Map<String, XML>> {
                 Collectors.toMap(
                     names::get,
                     pos ->
-                        xml.path(String.format("/program/objects/o[%d]/@line", pos + 1))
-                            .findFirst().get().text().orElse("o"),
+                        xml.path(String.format("/program/objects/o[%d]", pos + 1))
+                            .findFirst().get().attribute("line").text().orElse("0"),
                     (existing, replacement) -> replacement
                 )
             );

--- a/src/main/java/org/eolang/lints/errors/LtObjectIsNotUnique.java
+++ b/src/main/java/org/eolang/lints/errors/LtObjectIsNotUnique.java
@@ -136,7 +136,7 @@ public final class LtObjectIsNotUnique implements Lint<Map<String, XML>> {
                     names::get,
                     pos ->
                         xml.path(String.format("/program/objects/o[%d]/@line", pos + 1))
-                            .findFirst().get().text().orElse("0"),
+                            .findFirst().flatMap(Xnav::text).orElse("0"),
                     (existing, replacement) -> replacement
                 )
             );

--- a/src/main/java/org/eolang/lints/errors/LtObjectIsNotUnique.java
+++ b/src/main/java/org/eolang/lints/errors/LtObjectIsNotUnique.java
@@ -135,8 +135,8 @@ public final class LtObjectIsNotUnique implements Lint<Map<String, XML>> {
 
     private static boolean containsDuplicate(final XML original, final XML oth, final String name) {
         return LtObjectIsNotUnique.programObjects(original).containsKey(name)
-            && LtObjectIsNotUnique.packageName(oth)
-            .equals(LtObjectIsNotUnique.packageName(original));
+            && LtObjectIsNotUnique.packageName(new Xnav(oth.inner()))
+            .equals(LtObjectIsNotUnique.packageName(new Xnav(original.inner())));
     }
 
     private static Map<String, String> programObjects(final XML xmir) {
@@ -158,10 +158,11 @@ public final class LtObjectIsNotUnique implements Lint<Map<String, XML>> {
             );
     }
 
-    private static String packageName(final XML xmir) {
+    private static String packageName(final Xnav xml) {
         final String name;
-        if (xmir.nodes("/program/metas/meta[head='package']").size() == 1) {
-            name = xmir.xpath("/program/metas/meta[head='package']/tail/text()").get(0);
+        if (xml.path("/program/metas/meta[head='package']").collect(Collectors.toList()).size() == 1) {
+            name = xml.path("/program/metas/meta[head='package']/tail/text()").findFirst().get().text().get();
+//            name = xmir.xpath("/program/metas/meta[head='package']/tail/text()").get(0);
         } else {
             name = "";
         }

--- a/src/main/java/org/eolang/lints/errors/LtObjectIsNotUnique.java
+++ b/src/main/java/org/eolang/lints/errors/LtObjectIsNotUnique.java
@@ -46,6 +46,21 @@ import org.eolang.lints.Severity;
  * Object is not unique.
  *
  * @since 0.0.30
+ * @todo #264:35min Check program source with xnav instead of `XML#xpath()`.
+ *  Check the following line in `defects()`:
+ *  <pre>
+ *  {@code
+ *  final String src = xmir.xpath("/program/@name").stream().findFirst().orElse("unknown");
+ *  }
+ *  </pre>
+ *  It should be substituted with xnav usage:
+ *  <pre>
+ *  {@code
+ *  final String src = xml.element("program").attribute("name").text().orElse("unknown");
+ *  }
+ *  </pre>
+ *  We should replaced it after <a href="https://github.com/volodya-lombrozo/xnav/issues/49#issuecomment-2636521337">this</a>
+ *  issue will be resolved.
  */
 public final class LtObjectIsNotUnique implements Lint<Map<String, XML>> {
 
@@ -58,8 +73,7 @@ public final class LtObjectIsNotUnique implements Lint<Map<String, XML>> {
     public Collection<Defect> defects(final Map<String, XML> pkg) {
         final Collection<Defect> defects = new LinkedList<>();
         for (final XML xmir : pkg.values()) {
-            final Xnav xml = new Xnav(xmir.inner());
-            final String src = xml.element("program").attribute("name").text().orElse("unknown");
+            final String src = xmir.xpath("/program/@name").stream().findFirst().orElse("unknown");
             if (xmir.nodes("/program/objects/o").isEmpty()) {
                 continue;
             }
@@ -81,7 +95,10 @@ public final class LtObjectIsNotUnique implements Lint<Map<String, XML>> {
                             new Defect.Default(
                                 this.name(),
                                 Severity.ERROR,
-                                second.element("program").attribute("name").text().orElse("unknown"),
+                                second.element("program")
+                                    .attribute("name")
+                                    .text()
+                                    .orElse("unknown"),
                                 Integer.parseInt(object.getValue()),
                                 String.format(
                                     "The object name \"%s\" is not unique, original object was found in \"%s\"",

--- a/src/main/java/org/eolang/lints/errors/LtObjectIsNotUnique.java
+++ b/src/main/java/org/eolang/lints/errors/LtObjectIsNotUnique.java
@@ -46,21 +46,6 @@ import org.eolang.lints.Severity;
  * Object is not unique.
  *
  * @since 0.0.30
- * @todo #264:35min Check program source with xnav instead of `XML#xpath()`.
- *  Check the following line in `defects()`:
- *  <pre>
- *  {@code
- *  final String src = xmir.xpath("/program/@name").stream().findFirst().orElse("unknown");
- *  }
- *  </pre>
- *  It should be substituted with xnav usage:
- *  <pre>
- *  {@code
- *  final String src = xml.element("program").attribute("name").text().orElse("unknown");
- *  }
- *  </pre>
- *  We should replaced it after <a href="https://github.com/volodya-lombrozo/xnav/issues/49#issuecomment-2636521337">this</a>
- *  issue will be resolved.
  */
 public final class LtObjectIsNotUnique implements Lint<Map<String, XML>> {
 

--- a/src/main/java/org/eolang/lints/errors/LtObjectIsNotUnique.java
+++ b/src/main/java/org/eolang/lints/errors/LtObjectIsNotUnique.java
@@ -73,8 +73,9 @@ public final class LtObjectIsNotUnique implements Lint<Map<String, XML>> {
     public Collection<Defect> defects(final Map<String, XML> pkg) {
         final Collection<Defect> defects = new LinkedList<>();
         for (final XML xmir : pkg.values()) {
-            final String src = xmir.xpath("/program/@name").stream().findFirst().orElse("unknown");
-            if (xmir.nodes("/program/objects/o").isEmpty()) {
+            final Xnav xml = new Xnav(xmir.inner());
+            final String src = xml.element("program").attribute("name").text().orElse("unknown");
+            if (LtObjectIsNotUnique.objectsAreEmpty(xml)) {
                 continue;
             }
             for (final XML oth : pkg.values()) {
@@ -82,7 +83,7 @@ public final class LtObjectIsNotUnique implements Lint<Map<String, XML>> {
                 if (Objects.equals(oth, xmir)) {
                     continue;
                 }
-                if (oth.nodes("/program/objects/o").isEmpty()) {
+                if (LtObjectIsNotUnique.objectsAreEmpty(second)) {
                     continue;
                 }
                 LtObjectIsNotUnique.programObjects(oth).entrySet().stream()
@@ -123,6 +124,13 @@ public final class LtObjectIsNotUnique implements Lint<Map<String, XML>> {
                 )
             )
         ).asString();
+    }
+
+    private static boolean objectsAreEmpty(final Xnav xml) {
+        return xml.element("program")
+            .element("objects")
+            .elements(Filter.withName("o"))
+            .collect(Collectors.toList()).isEmpty();
     }
 
     private static boolean containsDuplicate(final XML original, final XML oth, final String name) {

--- a/src/main/java/org/eolang/lints/misc/LtTestNotVerb.java
+++ b/src/main/java/org/eolang/lints/misc/LtTestNotVerb.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.lints.misc;
 
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import java.io.IOException;
 import java.net.URI;
@@ -94,7 +95,8 @@ public final class LtTestNotVerb implements Lint<XML> {
     public Collection<Defect> defects(final XML xmir) throws IOException {
         final Collection<Defect> defects = new LinkedList<>();
         for (final XML object : xmir.nodes("/program[metas/meta[head='tests']]/objects/o[@name]")) {
-            final String name = object.xpath("@name").get(0);
+            final Xnav xml = new Xnav(object.inner());
+            final String name = xml.attribute("name").text().get();
             final String first = new ListOf<>(
                 this.model.tag(
                     Stream
@@ -111,8 +113,11 @@ public final class LtTestNotVerb implements Lint<XML> {
                     new Defect.Default(
                         "unit-test-is-not-verb",
                         Severity.WARNING,
-                        xmir.xpath("/program/@name").stream().findFirst().orElse("unknown"),
-                        Integer.parseInt(object.xpath("@line").get(0)),
+                        new Xnav(xmir.inner())
+                            .element("program")
+                            .attribute("name")
+                            .text().orElse("unknown"),
+                        Integer.parseInt(xml.attribute("line").text().orElse("0")),
                         String.format(
                             "Test object name: \"%s\" doesn't start with verb in singular form",
                             name

--- a/src/test/java/org/eolang/lints/errors/LtObjectIsNotUniqueTest.java
+++ b/src/test/java/org/eolang/lints/errors/LtObjectIsNotUniqueTest.java
@@ -24,6 +24,7 @@
 package org.eolang.lints.errors;
 
 import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
 import fixtures.ParsedEo;
 import matchers.DefectMatcher;
 import org.cactoos.map.MapEntry;
@@ -31,6 +32,7 @@ import org.cactoos.map.MapOf;
 import org.eolang.lints.Defect;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -160,6 +162,21 @@ final class LtObjectIsNotUniqueTest {
                 )
             ),
             Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void doesNotThrowExceptionOnEmptyXmir() {
+        Assertions.assertDoesNotThrow(
+            () -> new LtObjectIsNotUnique().defects(
+                new MapOf<>(
+                    new MapEntry<>(
+                        "empty",
+                        new XMLDocument("<program/>")
+                    )
+                )
+            ),
+            () -> "Exception was thrown, but it should not"
         );
     }
 }

--- a/src/test/java/org/eolang/lints/misc/LtTestNotVerbTest.java
+++ b/src/test/java/org/eolang/lints/misc/LtTestNotVerbTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @since 0.0.22
  */
-final class LtTestIsNotVerbTest {
+final class LtTestNotVerbTest {
 
     @Test
     @ExtendWith(MayBeSlow.class)


### PR DESCRIPTION
In this PR I've substituted the usage of `XML#xpath()` and `XML#nodes()` in favor of `Xnav` library.

closes #264
History:
- **feat(#264): xnav in LtAsciiOnly**
- **feat(#264): xnav in LtTestNotVerb**
- **feat(#264): xnav in LtObjectIsNotUnique**
- **feat(#264): xnav in LtByXsl**
- **feat(#264): puzzle**
