### PR TITLE
feat(#319): `.without(name)` to disable lints programmatically

### DIFF
--- a/src/main/java/org/eolang/lints/Program.java
+++ b/src/main/java/org/eolang/lints/Program.java
@@ -99,10 +99,11 @@ public final class Program {
      * @return Program analysis without specific name
      */
     public Program without(final String... names) {
+        final Collection<String> listed = new ListOf<>(names);
         return new Program(
             this.xmir,
             new Filtered<>(
-                this.lints, lint -> () -> !new ListOf<>(names).contains(lint.name())
+                this.lints, lint -> () -> !listed.contains(lint.name())
             )
         );
     }

--- a/src/main/java/org/eolang/lints/Program.java
+++ b/src/main/java/org/eolang/lints/Program.java
@@ -30,6 +30,9 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import org.cactoos.Func;
+import org.cactoos.Scalar;
+import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.Sticky;
 import org.cactoos.iterable.Synced;
 
@@ -89,6 +92,21 @@ public final class Program {
     Program(final XML xml, final Iterable<Lint<XML>> list) {
         this.xmir = xml;
         this.lints = list;
+    }
+
+    /**
+     * Program without lint.
+     * @param name Lint name
+     * @return Program analysis without specific name.
+     */
+    public Program without(final String name) {
+        return new Program(
+            this.xmir,
+            new Filtered<>(
+                this.lints,
+                lint -> () -> !lint.name().equals(name)
+            )
+        );
     }
 
     /**

--- a/src/main/java/org/eolang/lints/Program.java
+++ b/src/main/java/org/eolang/lints/Program.java
@@ -30,8 +30,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import org.cactoos.Func;
-import org.cactoos.Scalar;
 import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.Sticky;
 import org.cactoos.iterable.Synced;
@@ -104,8 +102,7 @@ public final class Program {
         return new Program(
             this.xmir,
             new Filtered<>(
-                this.lints,
-                lint -> () -> !new ListOf<>(names).contains(lint.name())
+                this.lints, lint -> () -> !new ListOf<>(names).contains(lint.name())
             )
         );
     }

--- a/src/main/java/org/eolang/lints/Program.java
+++ b/src/main/java/org/eolang/lints/Program.java
@@ -30,8 +30,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import org.cactoos.Func;
-import org.cactoos.Scalar;
 import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.Sticky;
 import org.cactoos.iterable.Synced;
@@ -97,15 +95,12 @@ public final class Program {
     /**
      * Program without lint.
      * @param name Lint name
-     * @return Program analysis without specific name.
+     * @return Program analysis without specific name
      */
     public Program without(final String name) {
         return new Program(
             this.xmir,
-            new Filtered<>(
-                this.lints,
-                lint -> () -> !lint.name().equals(name)
-            )
+            new Filtered<>(this.lints, lint -> () -> !lint.name().equals(name))
         );
     }
 

--- a/src/main/java/org/eolang/lints/Program.java
+++ b/src/main/java/org/eolang/lints/Program.java
@@ -30,9 +30,12 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import org.cactoos.Func;
+import org.cactoos.Scalar;
 import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.Sticky;
 import org.cactoos.iterable.Synced;
+import org.cactoos.list.ListOf;
 
 /**
  * A single XMIR program to analyze.
@@ -93,14 +96,17 @@ public final class Program {
     }
 
     /**
-     * Program without lint.
-     * @param name Lint name
+     * Program with disabled lints.
+     * @param names Lint names
      * @return Program analysis without specific name
      */
-    public Program without(final String name) {
+    public Program without(final String... names) {
         return new Program(
             this.xmir,
-            new Filtered<>(this.lints, lint -> () -> !lint.name().equals(name))
+            new Filtered<>(
+                this.lints,
+                lint -> () -> !new ListOf<>(names).contains(lint.name())
+            )
         );
     }
 

--- a/src/main/java/org/eolang/lints/Programs.java
+++ b/src/main/java/org/eolang/lints/Programs.java
@@ -121,10 +121,11 @@ public final class Programs {
      * @return Program analysis without specifics names
      */
     public Programs without(final String... names) {
+        final Collection<String> listed = new ListOf<>(names);
         return new Programs(
             this.pkg,
             new Filtered<>(
-                this.lints, lint -> () -> !new ListOf<>(names).contains(lint.name())
+                this.lints, lint -> () -> !listed.contains(lint.name())
             )
         );
     }

--- a/src/main/java/org/eolang/lints/Programs.java
+++ b/src/main/java/org/eolang/lints/Programs.java
@@ -37,6 +37,7 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.Sticky;
 import org.cactoos.list.ListOf;
 import org.cactoos.list.Synced;
@@ -112,6 +113,18 @@ public final class Programs {
     Programs(final Map<String, XML> map, final Iterable<Lint<Map<String, XML>>> list) {
         this.pkg = Collections.unmodifiableMap(map);
         this.lints = list;
+    }
+
+    /**
+     * Programs without lint.
+     * @param name Lint name
+     * @return Program analysis without specifics name
+     */
+    public Programs without(final String name) {
+        return new Programs(
+            this.pkg,
+            new Filtered<>(this.lints, lint -> () -> !lint.name().equals(name))
+        );
     }
 
     /**

--- a/src/main/java/org/eolang/lints/Programs.java
+++ b/src/main/java/org/eolang/lints/Programs.java
@@ -116,14 +116,16 @@ public final class Programs {
     }
 
     /**
-     * Programs without lint.
-     * @param name Lint name
-     * @return Program analysis without specifics name
+     * Programs with disabled lints.
+     * @param names Lint names
+     * @return Program analysis without specifics names
      */
-    public Programs without(final String name) {
+    public Programs without(final String... names) {
         return new Programs(
             this.pkg,
-            new Filtered<>(this.lints, lint -> () -> !lint.name().equals(name))
+            new Filtered<>(
+                this.lints, lint -> () -> !new ListOf<>(names).contains(lint.name())
+            )
         );
     }
 

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -42,10 +42,15 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.cactoos.io.InputOf;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.iterable.Sticky;
 import org.cactoos.iterable.Synced;
+import org.cactoos.list.ListOf;
 import org.cactoos.scalar.Unchecked;
 import org.cactoos.set.SetOf;
 import org.eolang.parser.EoSyntax;
@@ -227,6 +232,22 @@ final class ProgramTest {
                     new XMLDocument("<program name='correct'/>")
                 ).defects(),
             "Exception was thrown, but it should not be"
+        );
+    }
+
+    @Test
+    void createsProgramWithoutSomeLints() throws IOException {
+        final String skipped = "ascii-only";
+        MatcherAssert.assertThat(
+            "Defects are not empty, but should be",
+            new Program(
+                new EoSyntax(
+                    "# привет\n# как дела?\n[] > foo\n"
+                ).parsed()
+            ).without(skipped).defects().stream()
+                .filter(defect -> defect.rule().equals(skipped))
+                .collect(Collectors.toList()),
+            Matchers.emptyIterable()
         );
     }
 

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -42,15 +42,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.cactoos.io.InputOf;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.iterable.Sticky;
 import org.cactoos.iterable.Synced;
-import org.cactoos.list.ListOf;
 import org.cactoos.scalar.Unchecked;
 import org.cactoos.set.SetOf;
 import org.eolang.parser.EoSyntax;
@@ -239,7 +235,7 @@ final class ProgramTest {
     void createsProgramWithoutSomeLints() throws IOException {
         final String skipped = "ascii-only";
         MatcherAssert.assertThat(
-            "Defects are not empty, but should be",
+            "Defects for skipped lint are not empty, but should be",
             new Program(
                 new EoSyntax(
                     "# привет\n# как дела?\n[] > foo\n"

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -232,7 +232,7 @@ final class ProgramTest {
     }
 
     @Test
-    void createsProgramWithoutSomeLints() throws IOException {
+    void createsProgramWithoutOneLint() throws IOException {
         final String disabled = "ascii-only";
         MatcherAssert.assertThat(
             "Defects for disabled lint are not empty, but should be",
@@ -243,6 +243,28 @@ final class ProgramTest {
             ).without(disabled).defects().stream()
                 .filter(defect -> defect.rule().equals(disabled))
                 .collect(Collectors.toList()),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void createsProgramWithoutMultipleLints() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects for disabled lints are not empty, but should be",
+            new Program(
+                new EoSyntax(
+                    "# привет\n# как дела?\n[] > foo\n"
+                ).parsed()
+            ).without(
+                "ascii-only",
+                "object-does-not-match-filename",
+                "comment-not-capitalized",
+                "empty-object",
+                "mandatory-home",
+                "mandatory-version",
+                "mandatory-package",
+                "comment-too-short"
+            ).defects(),
             Matchers.emptyIterable()
         );
     }

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -233,15 +233,15 @@ final class ProgramTest {
 
     @Test
     void createsProgramWithoutSomeLints() throws IOException {
-        final String skipped = "ascii-only";
+        final String disabled = "ascii-only";
         MatcherAssert.assertThat(
-            "Defects for skipped lint are not empty, but should be",
+            "Defects for disabled lint are not empty, but should be",
             new Program(
                 new EoSyntax(
                     "# привет\n# как дела?\n[] > foo\n"
                 ).parsed()
-            ).without(skipped).defects().stream()
-                .filter(defect -> defect.rule().equals(skipped))
+            ).without(disabled).defects().stream()
+                .filter(defect -> defect.rule().equals(disabled))
                 .collect(Collectors.toList()),
             Matchers.emptyIterable()
         );

--- a/src/test/java/org/eolang/lints/ProgramsTest.java
+++ b/src/test/java/org/eolang/lints/ProgramsTest.java
@@ -115,7 +115,7 @@ final class ProgramsTest {
     }
 
     @Test
-    void createsProgramsWithoutSomeLints(@Mktmp final Path dir) throws IOException {
+    void createsProgramsWithoutOneLint(@Mktmp final Path dir) throws IOException {
         final String disabled = "unit-test-missing";
         MatcherAssert.assertThat(
             "Defects for disabled lint are not empty, but should be",
@@ -128,6 +128,26 @@ final class ProgramsTest {
             ).without(disabled).defects().stream()
                 .filter(defect -> defect.rule().equals(disabled))
                 .collect(Collectors.toList()),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void createsProgramsWithoutMultipleLints(@Mktmp final Path dir) throws IOException {
+        MatcherAssert.assertThat(
+            "Defects for disabled lint are not empty, but should be",
+            new Programs(
+                this.withProgram(
+                    dir,
+                    "bar.xmir",
+                    "# first.\n# second.\n[] > bar\n"
+                ),
+                this.withProgram(
+                    dir,
+                    "foo-test.xmir",
+                    "# first.\n# second.\n[] > x\n"
+                )
+            ).without("unit-test-missing", "unit-test-without-live-file").defects(),
             Matchers.emptyIterable()
         );
     }

--- a/src/test/java/org/eolang/lints/ProgramsTest.java
+++ b/src/test/java/org/eolang/lints/ProgramsTest.java
@@ -116,17 +116,17 @@ final class ProgramsTest {
 
     @Test
     void createsProgramsWithoutSomeLints(@Mktmp final Path dir) throws IOException {
-        final String skipped = "unit-test-missing";
+        final String disabled = "unit-test-missing";
         MatcherAssert.assertThat(
-            "Defects for skipped lint are not empty, but should be",
+            "Defects for disabled lint are not empty, but should be",
             new Programs(
                 this.withProgram(
                     dir,
                     "bar.xmir",
                     "# first.\n# second.\n[] > bar\n"
                 )
-            ).without(skipped).defects().stream()
-                .filter(defect -> defect.rule().equals(skipped))
+            ).without(disabled).defects().stream()
+                .filter(defect -> defect.rule().equals(disabled))
                 .collect(Collectors.toList()),
             Matchers.emptyIterable()
         );

--- a/src/test/java/org/eolang/lints/ProgramsTest.java
+++ b/src/test/java/org/eolang/lints/ProgramsTest.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Collectors;
 import matchers.DefectMatcher;
 import org.cactoos.list.ListOf;
 import org.cactoos.set.SetOf;
@@ -110,6 +111,24 @@ final class ProgramsTest {
         Assertions.assertDoesNotThrow(
             () -> new Programs(new ListOf<>()).defects(),
             "Exception was thrown, but it should not be"
+        );
+    }
+
+    @Test
+    void createsProgramsWithoutSomeLints(@Mktmp final Path dir) throws IOException {
+        final String skipped = "unit-test-missing";
+        MatcherAssert.assertThat(
+            "Defects for skipped lint are not empty, but should be",
+            new Programs(
+                this.withProgram(
+                    dir,
+                    "bar.xmir",
+                    "# first.\n# second.\n[] > bar\n"
+                )
+            ).without(skipped).defects().stream()
+                .filter(defect -> defect.rule().equals(skipped))
+                .collect(Collectors.toList()),
+            Matchers.emptyIterable()
         );
     }
 


### PR DESCRIPTION
In this PR I've added method `#without(name)` to `Program` and `Programs`, that excludes lints by supplied name.

closes #319
History:
- **feat(#319): Program.without()**
- **feat(#319): Programs**
- **feat(#319): disabled**
