### PR TITLE
bug(#307): check for `LtUnlint` in `PkMono`

### DIFF
--- a/src/main/java/org/eolang/lints/PkByXsl.java
+++ b/src/main/java/org/eolang/lints/PkByXsl.java
@@ -70,7 +70,7 @@ final class PkByXsl extends IterableEnvelope<Lint<XML>> {
         try {
             return new Shuffled<Lint<XML>>(
                 new Mapped<>(
-                    res -> new LtUnlint(
+                    res ->
                         new LtByXsl(
                             new InputOf(res.getInputStream()),
                             new InputOf(
@@ -80,8 +80,7 @@ final class PkByXsl extends IterableEnvelope<Lint<XML>> {
                                     ).replaceAll("eolang/motives")
                                 ).replaceAll(".md")
                             )
-                        )
-                    ),
+                        ),
                     Arrays.asList(
                         new PathMatchingResourcePatternResolver().getResources(
                             "classpath*:org/eolang/lints/**/*.xsl"

--- a/src/main/java/org/eolang/lints/PkMono.java
+++ b/src/main/java/org/eolang/lints/PkMono.java
@@ -26,6 +26,7 @@ package org.eolang.lints;
 import com.jcabi.xml.XML;
 import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
+import org.cactoos.Func;
 import org.cactoos.iterable.IterableEnvelope;
 import org.cactoos.iterable.Joined;
 import org.cactoos.iterable.Mapped;
@@ -51,10 +52,13 @@ final class PkMono extends IterableEnvelope<Lint<XML>> {
      * All XML-based lints.
      */
     private static final Iterable<Lint<XML>> LINTS = new Shuffled<>(
-        new Joined<Lint<XML>>(
-            new PkByXsl(),
-            List.of(
-                new LtUnlint(new LtAsciiOnly())
+        new Mapped<Lint<XML>>(
+            LtUnlint::new,
+            new Joined<Lint<XML>>(
+                new PkByXsl(),
+                List.of(
+                    new LtAsciiOnly()
+                )
             )
         )
     );

--- a/src/main/java/org/eolang/lints/PkMono.java
+++ b/src/main/java/org/eolang/lints/PkMono.java
@@ -26,7 +26,6 @@ package org.eolang.lints;
 import com.jcabi.xml.XML;
 import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
-import org.cactoos.Func;
 import org.cactoos.iterable.IterableEnvelope;
 import org.cactoos.iterable.Joined;
 import org.cactoos.iterable.Mapped;

--- a/src/main/java/org/eolang/lints/PkMono.java
+++ b/src/main/java/org/eolang/lints/PkMono.java
@@ -54,7 +54,7 @@ final class PkMono extends IterableEnvelope<Lint<XML>> {
         new Joined<Lint<XML>>(
             new PkByXsl(),
             List.of(
-                new LtAsciiOnly()
+                new LtUnlint(new LtAsciiOnly())
             )
         )
     );

--- a/src/test/java/org/eolang/lints/PkMonoTest.java
+++ b/src/test/java/org/eolang/lints/PkMonoTest.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.lints;
 
+import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
@@ -30,6 +31,7 @@ import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import com.yegor256.Together;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.cactoos.list.ListOf;
@@ -38,6 +40,7 @@ import org.cactoos.set.SetOf;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
@@ -74,6 +77,23 @@ final class PkMonoTest {
                 defect -> "ascii-only".equals(defect.rule())
             ).collect(Collectors.toList()),
             Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void checksThatLintsCanBeUnlinted() {
+        new PkMono().forEach(
+            lint -> {
+                final Class<? extends Lint> clazz = lint.getClass();
+                MatcherAssert.assertThat(
+                    String.format(
+                        "Lint '%s' can not be unlinted, since it not wrapped by LtUnlint",
+                        lint.name()
+                    ),
+                    clazz.equals(LtUnlint.class) || clazz.equals(LtIncorrectUnlint.class),
+                    new IsEqual<>(true)
+                );
+            }
         );
     }
 

--- a/src/test/java/org/eolang/lints/PkMonoTest.java
+++ b/src/test/java/org/eolang/lints/PkMonoTest.java
@@ -23,16 +23,11 @@
  */
 package org.eolang.lints;
 
-import com.jcabi.xml.XML;
-import com.jcabi.xml.XMLDocument;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import com.yegor256.Together;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.cactoos.list.ListOf;
 import org.cactoos.scalar.LengthOf;
@@ -85,17 +80,16 @@ final class PkMonoTest {
         new ListOf<>(new PkMono()).stream()
             .filter(lint -> !lint.getClass().equals(LtIncorrectUnlint.class))
             .collect(Collectors.toList()).forEach(
-            lint -> {
-                MatcherAssert.assertThat(
-                    String.format(
-                        "Lint '%s' can not be unlinted, since its not wrapped by LtUnlint",
-                        lint.name()
-                    ),
-                    lint.getClass().equals(LtUnlint.class),
-                    new IsEqual<>(true)
-                );
-            }
-        );
+                lint ->
+                    MatcherAssert.assertThat(
+                        String.format(
+                            "Lint '%s' can not be unlinted, since its not wrapped by LtUnlint",
+                            lint.name()
+                        ),
+                        lint.getClass().equals(LtUnlint.class),
+                        new IsEqual<>(true)
+                    )
+            );
     }
 
     @Test

--- a/src/test/java/org/eolang/lints/PkMonoTest.java
+++ b/src/test/java/org/eolang/lints/PkMonoTest.java
@@ -23,12 +23,19 @@
  */
 package org.eolang.lints;
 
+import com.jcabi.xml.XMLDocument;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import com.yegor256.Together;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.cactoos.list.ListOf;
 import org.cactoos.scalar.LengthOf;
 import org.cactoos.set.SetOf;
+import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.RepeatedTest;
@@ -51,6 +58,22 @@ final class PkMonoTest {
                 )
             ).size(),
             Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void allowsUnlint() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects found, though they were unlinted",
+            new Program(
+                new EoSyntax(
+                    "+unlint ascii-only\n # привет\n# как дела?\n[] > foo\n"
+                ).parsed(),
+                new PkMono()
+            ).defects().stream().filter(
+                defect -> "ascii-only".equals(defect.rule())
+            ).collect(Collectors.toList()),
+            Matchers.emptyIterable()
         );
     }
 

--- a/src/test/java/org/eolang/lints/PkMonoTest.java
+++ b/src/test/java/org/eolang/lints/PkMonoTest.java
@@ -82,15 +82,16 @@ final class PkMonoTest {
 
     @Test
     void checksThatLintsCanBeUnlinted() {
-        new PkMono().forEach(
+        new ListOf<>(new PkMono()).stream()
+            .filter(lint -> !lint.getClass().equals(LtIncorrectUnlint.class))
+            .collect(Collectors.toList()).forEach(
             lint -> {
-                final Class<? extends Lint> clazz = lint.getClass();
                 MatcherAssert.assertThat(
                     String.format(
-                        "Lint '%s' can not be unlinted, since it not wrapped by LtUnlint",
+                        "Lint '%s' can not be unlinted, since its not wrapped by LtUnlint",
                         lint.name()
                     ),
-                    clazz.equals(LtUnlint.class) || clazz.equals(LtIncorrectUnlint.class),
+                    lint.getClass().equals(LtUnlint.class),
                     new IsEqual<>(true)
                 );
             }


### PR DESCRIPTION
In this PR I've wrapped lints in `PkMono` with `LtUnlint`. Besides that, I added tests that check that each lint can be unlinted.

closes #307
History:
- **bug(#307): +LtUnlint**
- **bug(#307): can be unlinted**
- **bug(#307): filter LtIncorrectUnlint**
- **bug(#307): clean for qulice**
