### PR TITLE
feat(#322): `unlint-non-existing-defect` lint

### DIFF
--- a/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
+++ b/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
@@ -37,7 +37,8 @@ import org.cactoos.text.TextOf;
 
 /**
  * Lints.
- * @since 0.0.0
+ *
+ * @since 0.0.40
  */
 final class LtUnlintNonExistingDefect implements Lint<XML> {
 
@@ -76,7 +77,8 @@ final class LtUnlintNonExistingDefect implements Lint<XML> {
                         String.format(
                             "program/metas/meta[head='unlint' and tail='%s']/@line", unlint
                         )
-                        ).map(xnav -> xnav.text().get())
+                        )
+                        .map(xnav -> xnav.text().get())
                         .collect(Collectors.toList())
                         .forEach(
                             line ->

--- a/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
+++ b/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
@@ -1,0 +1,115 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.lints;
+
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XML;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.cactoos.list.ListOf;
+
+/**
+ * Lints.
+ * @since 0.0.0
+ */
+final class LtUnlintNonExistingDefect implements Lint<XML> {
+
+    /**
+     * Lints.
+     */
+    private final Iterable<Lint<XML>> lints;
+
+    /**
+     * Ctor.
+     *
+     * @param lnts Lints
+     */
+    LtUnlintNonExistingDefect(final Iterable<Lint<XML>> lnts) {
+        this.lints = lnts;
+    }
+
+    @Override
+    public String name() {
+        return "unlint-non-existing-defect";
+    }
+
+    @Override
+    public Collection<Defect> defects(final XML xmir) throws IOException {
+        final Collection<Defect> defects = new LinkedList<>();
+        final Collection<String> present = new ListOf<>();
+        this.lints.forEach(
+            lint -> {
+                try {
+                    present.addAll(
+                        lint.defects(xmir).stream()
+                            .map(Defect::rule)
+                            .collect(Collectors.toList())
+                    );
+                } catch (final IOException exception) {
+                    throw new IllegalStateException(exception);
+                }
+            }
+        );
+        final Xnav xml = new Xnav(xmir.inner());
+        final Set<String> unlints = xml.path("/program/metas/meta[head='unlint']/tail")
+            .map(xnav -> xnav.text().get())
+            .collect(Collectors.toSet());
+        unlints.stream()
+            .filter(unlint -> !present.contains(unlint))
+            .forEach(
+                unlint ->
+                    xml.path(
+                            String.format(
+                                "program/metas/meta[head='unlint' and tail='%s']/@line",
+                                unlint
+                            )
+                        ).map(xnav -> xnav.text().get())
+                        .collect(Collectors.toList())
+                        .forEach(
+                            line ->
+                                defects.add(
+                                    new Defect.Default(
+                                        this.name(),
+                                        Severity.WARNING,
+                                        xml.element("program").attribute("name").text().orElse("unknown"),
+                                        Integer.parseInt(line),
+                                        String.format(
+                                            "Unlinting rule '%s' doesn't make sense, since there are no defects with it",
+                                            unlint
+                                        )
+                                    )
+                                )
+                        )
+            );
+        return defects;
+    }
+
+    @Override
+    public String motive() throws IOException {
+        throw new UnsupportedOperationException("#motive()");
+    }
+}

--- a/src/main/java/org/eolang/lints/PkMono.java
+++ b/src/main/java/org/eolang/lints/PkMono.java
@@ -51,13 +51,10 @@ final class PkMono extends IterableEnvelope<Lint<XML>> {
      * All XML-based lints.
      */
     private static final Iterable<Lint<XML>> LINTS = new Shuffled<>(
-        new Mapped<Lint<XML>>(
-            LtUnlint::new,
-            new Joined<Lint<XML>>(
-                new PkByXsl(),
-                List.of(
-                    new LtAsciiOnly()
-                )
+        new Joined<Lint<XML>>(
+            new PkByXsl(),
+            List.of(
+                new LtAsciiOnly()
             )
         )
     );
@@ -67,16 +64,22 @@ final class PkMono extends IterableEnvelope<Lint<XML>> {
      */
     PkMono() {
         super(
-            new Joined<>(
-                PkMono.LINTS,
-                List.of(new LtUnlintNonExistingDefect(PkMono.LINTS)),
+            new Joined<Lint<XML>>(
+                new Mapped<Lint<XML>>(
+                    LtUnlint::new,
+                    new Joined<Lint<XML>>(
+                        PkMono.LINTS,
+                        List.of(new LtUnlintNonExistingDefect(PkMono.LINTS))
+                    )
+                ),
                 List.of(
                     new LtIncorrectUnlint(
                         new Mapped<>(
                             Lint::name,
-                            new Joined<Lint<?>>(
+                            new Joined<>(
                                 new PkWpa(),
-                                PkMono.LINTS
+                                PkMono.LINTS,
+                                List.of(new LtUnlintNonExistingDefect(PkMono.LINTS))
                             )
                         )
                     )

--- a/src/main/java/org/eolang/lints/PkMono.java
+++ b/src/main/java/org/eolang/lints/PkMono.java
@@ -67,8 +67,9 @@ final class PkMono extends IterableEnvelope<Lint<XML>> {
      */
     PkMono() {
         super(
-            new Joined<Lint<XML>>(
+            new Joined<>(
                 PkMono.LINTS,
+                List.of(new LtUnlintNonExistingDefect(PkMono.LINTS)),
                 List.of(
                     new LtIncorrectUnlint(
                         new Mapped<>(

--- a/src/main/resources/org/eolang/motives/misc/unlint-non-existing-defect.md
+++ b/src/main/resources/org/eolang/motives/misc/unlint-non-existing-defect.md
@@ -1,0 +1,23 @@
+# `+unlint` Of Non-Existing Defect
+
+Special `+unlint` meta should be used only to suppress an existing defects.
+
+Incorrect (since there is no duplicate metas):
+
+```eo
++unlint duplicate-metas
+
+[] > foo
+  42 > @
+```
+
+Correct:
+
+```eo
++unlint duplicate-metas
++architect jeff
++architect foo
+
+[] > foo
+  42 > @
+```

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -1,0 +1,126 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.lints;
+
+import java.io.IOException;
+import java.util.stream.Collectors;
+import org.cactoos.list.ListOf;
+import org.eolang.parser.EoSyntax;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link LtUnlintNonExistingDefect}.
+ *
+ * @since 0.0.0
+ */
+final class LtUnlintNonExistingDefectTest {
+
+    @Test
+    void reportsDefects() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are empty, but they should not",
+            new LtUnlintNonExistingDefect(
+                new ListOf<>(new LtAsciiOnly())
+            ).defects(
+                new EoSyntax(
+                    String.join(
+                        "\n",
+                        "+unlint ascii-only",
+                        "# first",
+                        "# second",
+                        "[] > bar"
+                    )
+                ).parsed()
+            ),
+            Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
+
+    @Test
+    void reportsDefectsForEachUnlintWithDifferentLines() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects should be reported for each line with unlint, but it's not",
+            new LtUnlintNonExistingDefect(
+                new ListOf<>(new LtAsciiOnly())
+            ).defects(
+                new EoSyntax(
+                    String.join(
+                        "\n",
+                        "+unlint ascii-only",
+                        "+unlint ascii-only",
+                        "# first",
+                        "# second",
+                        "[] > bar"
+                    )
+                ).parsed()
+            ).stream()
+                .map(Defect::line)
+                .collect(Collectors.toList()),
+            Matchers.equalTo(
+                new ListOf<>(1, 2)
+            )
+        );
+    }
+
+    @Test
+    void allowsUnlintingOfExistingDefects() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are not empty, but they should",
+            new LtUnlintNonExistingDefect(
+                new ListOf<>(new LtAsciiOnly())
+            ).defects(
+                new EoSyntax(
+                    String.join(
+                        "\n",
+                        "+unlint ascii-only",
+                        "# 程式分析是我的熱愛",
+                        "[] > bar"
+                    )
+                ).parsed()
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void allowsNoUnlints() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are not empty, but they should",
+            new LtUnlintNonExistingDefect(
+                new ListOf<>(new LtAsciiOnly())
+            ).defects(
+                new EoSyntax(
+                    String.join(
+                        "\n",
+                        "# тук-тук",
+                        "[] > bar"
+                    )
+                ).parsed()
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+}

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for {@link LtUnlintNonExistingDefect}.
  *
- * @since 0.0.0
+ * @since 0.0.40
  */
 final class LtUnlintNonExistingDefectTest {
 

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -105,6 +105,7 @@ final class ProgramTest {
                     new InputOf(
                         String.join(
                             "\n",
+                            "+unlint unlint-non-existing-defect",
                             "+unlint object-does-not-match-filename",
                             "+unlint empty-object",
                             "+unlint mandatory-home",

--- a/src/test/resources/org/eolang/lints/canonical.eo
+++ b/src/test/resources/org/eolang/lints/canonical.eo
@@ -23,7 +23,6 @@
 +architect yegor256@gmail.com
 +home https://www.eolang.org
 +package canonical
-+unlint empty-object
 +unlint object-does-not-match-filename
 +version 0.0.0
 


### PR DESCRIPTION
In this PR I've added new lint: `unlint-non-existing-defect`, that issues defects with warning severity, in case of usage of `+unlint` meta to suppress non-existing defects.

closes #322
History:
- **feat(#322): unlint-non-existing-defect**
- **feat(#322): clean for qulice**
