### PR TITLE
feat(#343): POC: show defect context if `@line` attributes are empty

### DIFF
--- a/src/main/java/org/eolang/lints/Defect.java
+++ b/src/main/java/org/eolang/lints/Defect.java
@@ -77,6 +77,12 @@ public interface Defect {
     String version();
 
     /**
+     * Defect context.
+     * @return Context of the defect
+     */
+    String context();
+
+    /**
      * Default.
      *
      * @since 0.0.1
@@ -167,6 +173,11 @@ public interface Defect {
         @Override
         public String version() {
             return Manifests.read("Lints-Version");
+        }
+
+        @Override
+        public String context() {
+            return "Context is empty";
         }
     }
 

--- a/src/main/java/org/eolang/lints/DfContext.java
+++ b/src/main/java/org/eolang/lints/DfContext.java
@@ -25,7 +25,7 @@ package org.eolang.lints;
 
 /**
  * Defect with context.
- * @since 0.0.0
+ * @since 0.0.40
  */
 final class DfContext implements Defect {
 

--- a/src/main/java/org/eolang/lints/DfContext.java
+++ b/src/main/java/org/eolang/lints/DfContext.java
@@ -1,0 +1,95 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.lints;
+
+/**
+ * Defect with context.
+ * @since 0.0.0
+ */
+final class DfContext implements Defect {
+
+    /**
+     * Origin defect.
+     */
+    private final Defect origin;
+
+    /**
+     * Context.
+     */
+    private final String ctxt;
+
+    /**
+     * Ctor.
+     * @param orgn Origin defect
+     * @param context Context
+     */
+    DfContext(final Defect orgn, final String context) {
+        this.origin = orgn;
+        this.ctxt = context;
+    }
+
+    @Override
+    public String rule() {
+        return this.origin.rule();
+    }
+
+    @Override
+    public Severity severity() {
+        return this.origin.severity();
+    }
+
+    @Override
+    public String program() {
+        return this.origin.program();
+    }
+
+    @Override
+    public int line() {
+        return this.origin.line();
+    }
+
+    @Override
+    public String text() {
+        return this.origin.text();
+    }
+
+    @Override
+    public String version() {
+        return this.origin.version();
+    }
+
+    @Override
+    public String context() {
+        return this.ctxt.replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&#34;", "\"")
+            .replace("&#xA;", "\n")
+            .replace("&amp;", "&");
+    }
+
+    @Override
+    public String toString() {
+        return this.origin.toString();
+    }
+}

--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -125,7 +125,7 @@ final class LtByXsl implements Lint<XML> {
                         this.lineno(xml),
                         xml.text().get()
                     ),
-                    LtByXsl.context(xml)
+                    xml.attribute("context").text().orElse("")
                 )
             );
         }
@@ -168,10 +168,6 @@ final class LtByXsl implements Lint<XML> {
             );
         }
         return lineno;
-    }
-
-    private static String context(final Xnav defect) {
-        return defect.attribute("context").text().orElse("");
     }
 
     /**

--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -117,12 +117,15 @@ final class LtByXsl implements Lint<XML> {
                 );
             }
             defects.add(
-                new Defect.Default(
-                    this.rule,
-                    Severity.parsed(sever.get()),
-                    LtByXsl.findName(xmir),
-                    this.lineno(xml),
-                    xml.text().get()
+                new DfContext(
+                    new Defect.Default(
+                        this.rule,
+                        Severity.parsed(sever.get()),
+                        LtByXsl.findName(xmir),
+                        this.lineno(xml),
+                        xml.text().get()
+                    ),
+                    LtByXsl.context(xml)
                 )
             );
         }
@@ -165,6 +168,10 @@ final class LtByXsl implements Lint<XML> {
             );
         }
         return lineno;
+    }
+
+    private static String context(final Xnav defect) {
+        return defect.attribute("context").text().orElse("");
     }
 
     /**

--- a/src/main/resources/org/eolang/funcs/defect-context.xsl
+++ b/src/main/resources/org/eolang/funcs/defect-context.xsl
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2025 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="defect-context" version="2.0">
+  <xsl:function name="eo:defect-context" as="xs:string">
+    <xsl:param name="context"/>
+    <xsl:value-of select="substring(serialize($context, map{'method':'xml'}), 1, 300)"/>
+  </xsl:function>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/critical/application-duality.xsl
+++ b/src/main/resources/org/eolang/lints/critical/application-duality.xsl
@@ -25,6 +25,7 @@ SOFTWARE.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="application-duality" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
@@ -41,9 +42,15 @@ SOFTWARE.
         </xsl:variable>
         <xsl:if test="count($args/*) != count($args/*[@as]) and count($args/*) != count($args/*[not(@as)])">
           <defect>
+            <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">
-              <xsl:value-of select="eo:lineno(@line)"/>
+              <xsl:value-of select="$line"/>
             </xsl:attribute>
+            <xsl:if test="$line = '0'">
+                <xsl:attribute name="context">
+                  <xsl:value-of select="eo:defect-context(.)"/>
+                </xsl:attribute>
+            </xsl:if>
             <xsl:attribute name="severity">
               <xsl:text>critical</xsl:text>
             </xsl:attribute>

--- a/src/main/resources/org/eolang/lints/critical/application-duality.xsl
+++ b/src/main/resources/org/eolang/lints/critical/application-duality.xsl
@@ -47,9 +47,9 @@ SOFTWARE.
               <xsl:value-of select="$line"/>
             </xsl:attribute>
             <xsl:if test="$line = '0'">
-                <xsl:attribute name="context">
-                  <xsl:value-of select="eo:defect-context(.)"/>
-                </xsl:attribute>
+              <xsl:attribute name="context">
+                <xsl:value-of select="eo:defect-context(.)"/>
+              </xsl:attribute>
             </xsl:if>
             <xsl:attribute name="severity">
               <xsl:text>critical</xsl:text>

--- a/src/test/java/org/eolang/lints/DfContextTest.java
+++ b/src/test/java/org/eolang/lints/DfContextTest.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.lints;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link DfContext}.
+ *
+ * @since 0.0.40
+ */
+final class DfContextTest {
+
+    @Test
+    void printsContextAsXml() {
+        MatcherAssert.assertThat(
+            "XML does not match with expected",
+            new DfContext(
+                new Defect.Default(
+                    "foo",
+                    Severity.ERROR,
+                    "app.main",
+                    0,
+                    "Boom!"
+                ),
+                "&lt;o base=&#34;man&#34;&gt;&#xA;&lt;o as=&#34;name&#34; base=&#34;string&#34;/&gt;&#xA;&lt;o base=&#34;number&#34;/&gt;&#xA;&lt;/o&gt;"
+            ).context(),
+            Matchers.equalTo(
+                "<o base=\"man\">\n<o as=\"name\" base=\"string\"/>\n<o base=\"number\"/>\n</o>"
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -24,6 +24,7 @@
 package org.eolang.lints;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XMLDocument;
 import fixtures.LargeXmir;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -32,6 +33,7 @@ import java.nio.file.Paths;
 import java.util.Set;
 import java.util.stream.Collectors;
 import matchers.DefectsMatcher;
+import org.cactoos.io.ResourceOf;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 import org.eolang.jucs.ClasspathSource;
@@ -54,6 +56,7 @@ import org.junit.jupiter.params.ParameterizedTest;
  *
  * @since 0.0.1
  */
+@SuppressWarnings("PMD.TooManyMethods")
 final class LtByXslTest {
 
     @Test
@@ -230,6 +233,24 @@ final class LtByXslTest {
                 new LargeXmir().value()
             ),
             "Huge XMIR must pass in reasonable time. See the timeout value."
+        );
+    }
+
+    @Test
+    void cutsLargeContext() throws Exception {
+        new LtByXsl("critical/application-duality").defects(
+            new XMLDocument(
+                new ResourceOf(
+                    "org/eolang/lints/xmir-with-application-duality.xml"
+                ).stream()
+            )
+        ).forEach(
+            defect ->
+                MatcherAssert.assertThat(
+                    "Defect context size is too big",
+                    defect.context().length(),
+                    Matchers.lessThanOrEqualTo(300)
+                )
         );
     }
 }

--- a/src/test/resources/org/eolang/lints/packs/application-duality/prints-context-when-lines-empty.yaml
+++ b/src/test/resources/org/eolang/lints/packs/application-duality/prints-context-when-lines-empty.yaml
@@ -1,0 +1,35 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016-2025 Objectionary.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+---
+sheets:
+  - /org/eolang/lints/critical/application-duality.xsl
+asserts:
+  - /defects[count(defect[@context and @severity='critical'])=1]
+document: |
+  <program>
+    <objects>
+      <o base="man">
+        <o base="string" as="name"/>
+        <o base="number"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/xmir-with-application-duality.xml
+++ b/src/test/resources/org/eolang/lints/xmir-with-application-duality.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2025 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<program>
+  <objects>
+    <o base="jeo.frame">
+      <!-- Application duality here, since 2 objects have `@as` attribute, and 2 of them don't -->
+      <o base="jeo.int">
+        <o base="org.eolang.number">
+          <o base="Q.org.eolang.bytes">40-10-00-00-00-00-00-00</o>
+        </o>
+      </o>
+      <o base="jeo.int">
+        <o base="org.eolang.number">
+          <o base="Q.org.eolang.bytes">00-00-00-00-00-00-00-00</o>
+        </o>
+      </o>
+      <o as="a1bb6b1c-cd14-40e0-bb17-3b2727e8037d-215454445" base="jeo.seq.of0"/>
+      <o base="jeo.int">
+        <o base="org.eolang.number">
+          <o base="Q.org.eolang.bytes">3F-F0-00-00-00-00-00-00</o>
+        </o>
+      </o>
+      <o as="ff5f00a8-94a9-4cc3-9d55-a75fde44a5a1-674365733" base="jeo.seq.of1">
+        <o base="org.eolang.string">
+          <o base="Q.org.eolang.bytes">
+            6A-61-76-61-2F-69-6F-2F-49-4F-45-78-63-65-70-74-69-6F-6E
+          </o>
+        </o>
+      </o>
+    </o>
+  </objects>
+</program>


### PR DESCRIPTION
In this PR I've implemented Proof Of Concept of printing defect's context, if inspected XMIR doesn't have `@line` attributes inside.

see #343
History:
- **feat(#343): print first N chars**
- **feat(#343): poc**
