### PR TITLE
feat(#259): `inconsistent-args` lint

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 
 version = 1

--- a/src/main/java/org/eolang/lints/DfContext.java
+++ b/src/main/java/org/eolang/lints/DfContext.java
@@ -1,25 +1,6 @@
 /*
- * The MIT License (MIT)
- *
- * Copyright (c) 2016-2025 Objectionary.com
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included
- * in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
  */
 package org.eolang.lints;
 

--- a/src/main/java/org/eolang/lints/LtInconsistentArgs.java
+++ b/src/main/java/org/eolang/lints/LtInconsistentArgs.java
@@ -21,6 +21,11 @@ import org.cactoos.text.UncheckedText;
  * Lint for checking arguments inconsistency provided to the objects.
  *
  * @since 0.0.41
+ * @todo #259:60min Optimize performance of inconsistent arguments finding.
+ *  Instead of re-collecting objects in nested loops, we should merge all objects
+ *  from all programs into single XMIR under '<objects/>' element. After objects
+ *  are merged, we can iterate over all the objects there only once, and find
+ *  inconsistencies.
  */
 final class LtInconsistentArgs implements Lint<Map<String, XML>> {
 

--- a/src/main/java/org/eolang/lints/LtInconsistentArgs.java
+++ b/src/main/java/org/eolang/lints/LtInconsistentArgs.java
@@ -39,27 +39,24 @@ final class LtInconsistentArgs implements Lint<Map<String, XML>> {
                 if (counts.stream().distinct().count() != 1L) {
                     final List<Xnav> programs = bases.get(base);
                     programs.forEach(
-                        program ->
-                            program.path(
-                                String.format("//o[@base='%s']", base)
-                                )
-                                .map(o -> Integer.parseInt(o.attribute("line").text().orElse("0")))
-                                .forEach(
-                                    line ->
-                                        defects.add(
-                                            new Defect.Default(
-                                                this.name(),
-                                                Severity.WARNING,
-                                                program.element("program").attribute("name")
-                                                    .text().orElse("unknown"),
-                                                line,
-                                                String.format(
-                                                    "Object '%s' has arguments inconsistency",
-                                                    base
-                                                )
+                        program -> program.path(String.format("//o[@base='%s']", base))
+                            .map(o -> Integer.parseInt(o.attribute("line").text().orElse("0")))
+                            .forEach(
+                                line ->
+                                    defects.add(
+                                        new Defect.Default(
+                                            this.name(),
+                                            Severity.WARNING,
+                                            program.element("program").attribute("name")
+                                                .text().orElse("unknown"),
+                                            line,
+                                            String.format(
+                                                "Object '%s' has arguments inconsistency",
+                                                base
                                             )
                                         )
-                                )
+                                    )
+                            )
                     );
                 }
             }

--- a/src/main/java/org/eolang/lints/LtInconsistentArgs.java
+++ b/src/main/java/org/eolang/lints/LtInconsistentArgs.java
@@ -62,7 +62,7 @@ public final class LtInconsistentArgs implements Lint<Map<String, XML>> {
                                                 .text().orElse("unknown"),
                                             line,
                                             String.format(
-                                                "Object '%s' has arguments inconsistency: different number of arguments were passed in %s",
+                                                "Object '%s' has arguments inconsistency: different number of arguments found in %s",
                                                 base,
                                                 LtInconsistentArgs.oppositeRefs(
                                                     program, base, lines, line

--- a/src/main/java/org/eolang/lints/LtInconsistentArgs.java
+++ b/src/main/java/org/eolang/lints/LtInconsistentArgs.java
@@ -1,0 +1,104 @@
+package org.eolang.lints;
+
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XML;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Lint for checking arguments inconsistency provided to the objects.
+ *
+ * @since 0.0.41
+ */
+public final class LtInconsistentArgs implements Lint<Map<String, XML>> {
+
+    @Override
+    public String name() {
+        return "inconsistent-args";
+    }
+
+    @Override
+    public Collection<Defect> defects(final Map<String, XML> pkg) throws IOException {
+        final List<Defect> defects = new LinkedList<>();
+//        final Map<String, List<Integer>> whole = new HashMap<>();
+        pkg.values().forEach(
+            xmir -> {
+                final Map<String, List<Integer>> local = new HashMap<>(0);
+                final Xnav program = new Xnav(xmir.inner());
+                program.path("//o[@base]").forEach(
+                    base -> {
+                        final int args = base.node().getChildNodes().getLength();
+                        local.computeIfAbsent(
+                            base.attribute("base").text().get(),
+                            k -> new ArrayList<>()
+                        ).add(args);
+                    }
+                );
+                local.forEach(
+                    (base, counts) -> {
+                        if (counts.stream().distinct().count() != 1L) {
+                            program.path(
+                                    String.format(
+                                        "//o[@base='%s']",
+                                        base
+                                    )
+                                )
+                                .map(o -> Integer.parseInt(o.attribute("line").text().orElse("0")))
+                                .forEach(
+                                    line -> defects.add(
+                                        new Defect.Default(
+                                            this.name(),
+                                            Severity.WARNING,
+                                            program.element("program").attribute("name")
+                                                .text().orElse("unknown"),
+                                            line,
+                                            String.format(
+                                                "Object '%s' has arguments inconsistency",
+                                                base
+                                            )
+                                        )
+                                    )
+                                );
+                        }
+                    }
+                );
+            }
+        );
+//        whole.forEach(
+//            new BiConsumer<String, List<Integer>>() {
+//                @Override
+//                public void accept(final String base, final List<Integer> counts) {
+//                    if (counts.stream().distinct().count() != 1L) {
+//                        defects.add(
+//                            new Defect.Default(
+//                                LtInconsistentArgs.this.name(),
+//                                Severity.WARNING,
+//                                "",
+//                                0,
+//                                String.format(
+//                                    "Object '%s' has arguments inconsistency",
+//                                    base
+//                                )
+//                            )
+//                        );
+//                    }
+//                }
+//            }
+//        );
+        return defects;
+    }
+
+    @Override
+    public String motive() throws IOException {
+        throw new UnsupportedOperationException("#motive()");
+    }
+}

--- a/src/main/java/org/eolang/lints/LtInconsistentArgs.java
+++ b/src/main/java/org/eolang/lints/LtInconsistentArgs.java
@@ -1,22 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.lints;
 
 import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.list.ListOf;
+import org.cactoos.text.TextOf;
+import org.cactoos.text.UncheckedText;
 
 /**
  * Lint for checking arguments inconsistency provided to the objects.
  *
  * @since 0.0.41
  */
-public final class LtInconsistentArgs implements Lint<Map<String, XML>> {
+final class LtInconsistentArgs implements Lint<Map<String, XML>> {
 
     @Override
     public String name() {
@@ -25,8 +50,57 @@ public final class LtInconsistentArgs implements Lint<Map<String, XML>> {
 
     @Override
     public Collection<Defect> defects(final Map<String, XML> pkg) throws IOException {
-        final List<Defect> defects = new LinkedList<>();
-        final Map<Xnav, Map<String, List<Integer>>> whole = new HashMap<>(0);
+        final Collection<Defect> defects = new LinkedList<>();
+        final Map<Xnav, Map<String, List<Integer>>> whole = LtInconsistentArgs.scanUsages(pkg);
+        final Map<String, List<Xnav>> inverted = LtInconsistentArgs.basesOccurrences(whole);
+        LtInconsistentArgs.mergedPrograms(whole).forEach(
+            (base, counts) -> {
+                if (counts.stream().distinct().count() != 1L) {
+                    final List<Xnav> programs = inverted.get(base);
+                    programs.forEach(
+                        program ->
+                            program.path(
+                                String.format("//o[@base='%s']", base)
+                                )
+                                .map(o -> Integer.parseInt(o.attribute("line").text().orElse("0")))
+                                .forEach(
+                                    line ->
+                                        defects.add(
+                                            new Defect.Default(
+                                                this.name(),
+                                                Severity.WARNING,
+                                                program.element("program").attribute("name")
+                                                    .text().orElse("unknown"),
+                                                line,
+                                                String.format(
+                                                    "Object '%s' has arguments inconsistency",
+                                                    base
+                                                )
+                                            )
+                                        )
+                                )
+                    );
+                }
+            }
+        );
+        return defects;
+    }
+
+    @Override
+    public String motive() throws IOException {
+        return new UncheckedText(
+            new TextOf(
+                new ResourceOf(
+                    String.format(
+                        "org/eolang/motives/misc/%s.md", this.name()
+                    )
+                )
+            )
+        ).asString();
+    }
+
+    private static Map<Xnav, Map<String, List<Integer>>> scanUsages(final Map<String, XML> pkg) {
+        final Map<Xnav, Map<String, List<Integer>>> usages = new HashMap<>(0);
         pkg.values().forEach(
             xmir -> {
                 final Map<String, List<Integer>> local = new HashMap<>(0);
@@ -36,87 +110,41 @@ public final class LtInconsistentArgs implements Lint<Map<String, XML>> {
                         final int args = base.node().getChildNodes().getLength();
                         local.computeIfAbsent(
                             base.attribute("base").text().get(),
-                            k -> new ArrayList<>()
+                            k -> new ListOf<>()
                         ).add(args);
                     }
                 );
-                whole.put(program, local);
+                usages.put(program, local);
             }
         );
-        final Map<String, List<Integer>> merged = new HashMap<>(0);
-        for (final Map<String, List<Integer>> localized : whole.values()) {
-            for (final Map.Entry<String, List<Integer>> entry : localized.entrySet()) {
-                merged.computeIfAbsent(entry.getKey(), k -> new ArrayList<>())
-                    .addAll(entry.getValue());
-            }
-        }
-        final Map<String, List<Xnav>> inverted = new HashMap<>(0);
-        for (final Map.Entry<Xnav, Map<String, List<Integer>>> entry : whole.entrySet()) {
-            final Xnav program = entry.getKey();
-            for (final Map.Entry<String, List<Integer>> local : entry.getValue().entrySet()) {
-                final String base = local.getKey();
-                inverted.computeIfAbsent(base, k -> new ArrayList<>()).add(program);
-            }
-        }
-        merged.forEach(
-            (base, counts) -> {
-                if (counts.stream().distinct().count() != 1L) {
-                    final List<Xnav> programs = inverted.get(base);
-                    programs.forEach(
-                        program -> {
-                            final List<Integer> lines = program.path(String.format("//o[@base='%s']", base))
-                                .map(o -> Integer.parseInt(o.attribute("line").text().orElse("0")))
-                                .collect(Collectors.toList());
-                            lines.forEach(
-                                line ->
-                                    defects.add(
-                                        new Defect.Default(
-                                            this.name(),
-                                            Severity.WARNING,
-                                            program.element("program").attribute("name")
-                                                .text().orElse("unknown"),
-                                            line,
-                                            String.format("Object '%s' has arguments inconsistency", base)
-                                        )
-                                    )
-                            );
-                        }
-                    );
-                }
-            }
-        );
-
-        return defects;
+        return usages;
     }
 
-    @Override
-    public String motive() throws IOException {
-        throw new UnsupportedOperationException("#motive()");
-    }
-
-    private static String oppositeRefs(
-        final Xnav program,
-        final String base,
-        final List<Integer> lines,
-        final Integer problematic
+    private static Map<String, List<Integer>> mergedPrograms(
+        final Map<Xnav, Map<String, List<Integer>>> whole
     ) {
-        final String source = program.element("program").attribute("name").text()
-            .orElse("unknown");
-        final StringBuilder out = new StringBuilder(0);
-        lines.forEach(
-            line -> {
-                if (!line.equals(problematic)) {
-                    out.append(
-                        String.format(
-                            "%s:%s:%d",
-                            source,
-                            base,
-                            line
-                        )
-                    );
-                }
-            }
+        final Map<String, List<Integer>> merged = new HashMap<>(0);
+        whole.forEach(
+            (xnav, localized) ->
+                localized.forEach(
+                    (base, counts) ->
+                        merged.computeIfAbsent(base, k -> new ListOf<>()).addAll(counts)
+                )
         );
-        return out.toString();
+        return merged;
+    }
+
+    private static Map<String, List<Xnav>> basesOccurrences(
+        final Map<Xnav, Map<String, List<Integer>>> whole
+    ) {
+        final Map<String, List<Xnav>> result = new HashMap<>(0);
+        whole.forEach(
+            (program, local) ->
+                local.forEach(
+                    (base, value) ->
+                        result.computeIfAbsent(base, k -> new ListOf<>()).add(program)
+                )
+        );
+        return result;
     }
 }

--- a/src/main/java/org/eolang/lints/LtInconsistentArgs.java
+++ b/src/main/java/org/eolang/lints/LtInconsistentArgs.java
@@ -52,11 +52,11 @@ final class LtInconsistentArgs implements Lint<Map<String, XML>> {
     public Collection<Defect> defects(final Map<String, XML> pkg) throws IOException {
         final Collection<Defect> defects = new LinkedList<>();
         final Map<Xnav, Map<String, List<Integer>>> whole = LtInconsistentArgs.scanUsages(pkg);
-        final Map<String, List<Xnav>> inverted = LtInconsistentArgs.basesOccurrences(whole);
+        final Map<String, List<Xnav>> bases = LtInconsistentArgs.baseOccurrences(whole);
         LtInconsistentArgs.mergedPrograms(whole).forEach(
             (base, counts) -> {
                 if (counts.stream().distinct().count() != 1L) {
-                    final List<Xnav> programs = inverted.get(base);
+                    final List<Xnav> programs = bases.get(base);
                     programs.forEach(
                         program ->
                             program.path(
@@ -99,6 +99,11 @@ final class LtInconsistentArgs implements Lint<Map<String, XML>> {
         ).asString();
     }
 
+    /**
+     * Scan all usages across package.
+     * @param pkg Package with programs
+     * @return Map of all object usages: program is the key, object name, arguments is the value.
+     */
     private static Map<Xnav, Map<String, List<Integer>>> scanUsages(final Map<String, XML> pkg) {
         final Map<Xnav, Map<String, List<Integer>>> usages = new HashMap<>(0);
         pkg.values().forEach(
@@ -120,6 +125,11 @@ final class LtInconsistentArgs implements Lint<Map<String, XML>> {
         return usages;
     }
 
+    /**
+     * Merge all object usages into single map.
+     * @param whole All object usages across all programs
+     * @return Merged object usages as a map
+     */
     private static Map<String, List<Integer>> mergedPrograms(
         final Map<Xnav, Map<String, List<Integer>>> whole
     ) {
@@ -134,7 +144,12 @@ final class LtInconsistentArgs implements Lint<Map<String, XML>> {
         return merged;
     }
 
-    private static Map<String, List<Xnav>> basesOccurrences(
+    /**
+     * Object occurrences across all programs, grouped by object base attribute.
+     * @param whole All object usages across all programs.
+     * @return Grouped base occurrences in the programs.
+     */
+    private static Map<String, List<Xnav>> baseOccurrences(
         final Map<Xnav, Map<String, List<Integer>>> whole
     ) {
         final Map<String, List<Xnav>> result = new HashMap<>(0);

--- a/src/main/java/org/eolang/lints/LtInconsistentArgs.java
+++ b/src/main/java/org/eolang/lints/LtInconsistentArgs.java
@@ -1,25 +1,6 @@
 /*
- * The MIT License (MIT)
- *
- * Copyright (c) 2016-2025 Objectionary.com
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included
- * in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
  */
 package org.eolang.lints;
 

--- a/src/main/resources/org/eolang/funcs/defect-context.xsl
+++ b/src/main/resources/org/eolang/funcs/defect-context.xsl
@@ -1,26 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-The MIT License (MIT)
-
-Copyright (c) 2016-2025 Objectionary.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="defect-context" version="2.0">
   <xsl:function name="eo:defect-context" as="xs:string">

--- a/src/main/resources/org/eolang/motives/misc/inconsistent-args.md
+++ b/src/main/resources/org/eolang/motives/misc/inconsistent-args.md
@@ -1,0 +1,22 @@
+# Inconsistent Args
+
+Objects with the same `@base` should have the same amount of arguments passed
+in it.
+
+Incorrect:
+
+```eo
+# Foo.
+[] > foo
+  bar 42 > x
+  bar 1 2 3 > y
+```
+
+Correct:
+
+```eo
+# Foo.
+[] > foo
+  bar 42 > x
+  bar 1 > y
+```

--- a/src/test/java/org/eolang/lints/DfContextTest.java
+++ b/src/test/java/org/eolang/lints/DfContextTest.java
@@ -1,25 +1,6 @@
 /*
- * The MIT License (MIT)
- *
- * Copyright (c) 2016-2025 Objectionary.com
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included
- * in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
  */
 package org.eolang.lints;
 

--- a/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
+++ b/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
@@ -156,4 +156,41 @@ final class LtInconsistentArgsTest {
             Matchers.emptyIterable()
         );
     }
+
+    @Test
+    void catchesInconsistencyAcrossProgramsWithAlias() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are not caught across multiple programs, but they should",
+            new LtInconsistentArgs().defects(
+                new MapOf<String, XML>(
+                    new MapEntry<>(
+                        "text-fqn",
+                        new EoSyntax(
+                            "text-fqn",
+                            String.join(
+                                "\n",
+                                "# App",
+                                "[] > app",
+                                "  Q.org.eolang.txt.text \"f\" \"y\" > x"
+                            )
+                        ).parsed()
+                    ),
+                    new MapEntry<>(
+                        "text-alias",
+                        new EoSyntax(
+                            "text-alias",
+                            String.join(
+                                "\n",
+                                "+alias org.eolang.txt.text",
+                                "# Main",
+                                "[] > main",
+                                "  text \"f\" > y"
+                            )
+                        ).parsed()
+                    )
+                )
+            ),
+            Matchers.hasSize(2)
+        );
+    }
 }

--- a/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
+++ b/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
@@ -46,7 +46,7 @@ final class LtInconsistentArgsTest {
             new LtInconsistentArgs().defects(
                 new MapOf<>(
                     new MapEntry<>(
-                        "foo",
+                        "app",
                         new EoSyntax(
                             String.join(
                                 "\n",

--- a/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
+++ b/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for {@link LtInconsistentArgs}.
  *
- * @since 0.41.0
+ * @since 0.0.41
  */
 final class LtInconsistentArgsTest {
 

--- a/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
+++ b/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
@@ -1,5 +1,6 @@
 package org.eolang.lints;
 
+import com.jcabi.xml.XML;
 import java.io.IOException;
 import org.cactoos.map.MapEntry;
 import org.cactoos.map.MapOf;
@@ -54,6 +55,74 @@ final class LtInconsistentArgsTest {
                                 "[] > app",
                                 "  foo 42 > x",
                                 "  foo 52 > spb"
+                            )
+                        ).parsed()
+                    )
+                )
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void catchesInconsistencyAcrossPrograms() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are not caught across multiple programs, but they should",
+            new LtInconsistentArgs().defects(
+                new MapOf<String, XML>(
+                    new MapEntry<>(
+                        "app",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# App",
+                                "[] > app",
+                                "  f 42 > x"
+                            )
+                        ).parsed()
+                    ),
+                    new MapEntry<>(
+                        "main",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# Main",
+                                "[] > main",
+                                "  f 42 52 > x"
+                            )
+                        ).parsed()
+                    )
+                )
+            ),
+            Matchers.hasSize(2)
+        );
+    }
+
+    @Test
+    void allowsConsistentArgumentsAcrossPrograms() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are not empty, but they should",
+            new LtInconsistentArgs().defects(
+                new MapOf<String, XML>(
+                    new MapEntry<>(
+                        "fizz",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# Fizz",
+                                "[] > fizz",
+                                "  f 42 > x"
+                            )
+                        ).parsed()
+                    ),
+                    new MapEntry<>(
+                        "buzz",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# Buzz",
+                                "[a] > main",
+                                "  f a > x"
                             )
                         ).parsed()
                     )

--- a/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
+++ b/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
@@ -35,7 +35,7 @@ final class LtInconsistentArgsTest {
                     )
                 )
             ),
-            Matchers.hasSize(Matchers.greaterThan(0))
+            Matchers.hasSize(2)
         );
     }
 }

--- a/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
+++ b/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.lints;
 
 import com.jcabi.xml.XML;

--- a/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
+++ b/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
@@ -73,6 +73,7 @@ final class LtInconsistentArgsTest {
                     new MapEntry<>(
                         "app",
                         new EoSyntax(
+                            "f-one-arg",
                             String.join(
                                 "\n",
                                 "# App",
@@ -84,11 +85,12 @@ final class LtInconsistentArgsTest {
                     new MapEntry<>(
                         "main",
                         new EoSyntax(
+                            "f-three-arg",
                             String.join(
                                 "\n",
                                 "# Main",
                                 "[] > main",
-                                "  f 42 52 > x"
+                                "  f 1 2 3 > y"
                             )
                         ).parsed()
                     )

--- a/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
+++ b/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
@@ -160,7 +160,7 @@ final class LtInconsistentArgsTest {
     @Test
     void catchesInconsistencyAcrossProgramsWithAlias() throws IOException {
         MatcherAssert.assertThat(
-            "Defects are not caught across multiple programs, but they should",
+            "Defects are not caught across multiple programs with alias, but they should",
             new LtInconsistentArgs().defects(
                 new MapOf<String, XML>(
                     new MapEntry<>(

--- a/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
+++ b/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
@@ -38,4 +38,28 @@ final class LtInconsistentArgsTest {
             Matchers.hasSize(2)
         );
     }
+
+    @Test
+    void allowsConsistentArgumentsPassing() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are not empty, but they should",
+            new LtInconsistentArgs().defects(
+                new MapOf<>(
+                    new MapEntry<>(
+                        "foo",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# This is app",
+                                "[] > app",
+                                "  foo 42 > x",
+                                "  foo 52 > spb"
+                            )
+                        ).parsed()
+                    )
+                )
+            ),
+            Matchers.emptyIterable()
+        );
+    }
 }

--- a/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
+++ b/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
@@ -1,25 +1,6 @@
 /*
- * The MIT License (MIT)
- *
- * Copyright (c) 2016-2025 Objectionary.com
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included
- * in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
  */
 package org.eolang.lints;
 

--- a/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
+++ b/src/test/java/org/eolang/lints/LtInconsistentArgsTest.java
@@ -1,0 +1,41 @@
+package org.eolang.lints;
+
+import java.io.IOException;
+import org.cactoos.map.MapEntry;
+import org.cactoos.map.MapOf;
+import org.eolang.parser.EoSyntax;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link LtInconsistentArgs}.
+ *
+ * @since 0.41.0
+ */
+final class LtInconsistentArgsTest {
+
+    @Test
+    void catchesArgumentsInconsistency() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are empty, but they should not",
+            new LtInconsistentArgs().defects(
+                new MapOf<>(
+                    new MapEntry<>(
+                        "foo",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# Foo",
+                                "[] > foo",
+                                "  bar 42 > x",
+                                "  bar 1 2 3 > y"
+                            )
+                        ).parsed()
+                    )
+                )
+            ),
+            Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
+}

--- a/src/test/resources/org/eolang/lints/packs/application-duality/prints-context-when-lines-empty.yaml
+++ b/src/test/resources/org/eolang/lints/packs/application-duality/prints-context-when-lines-empty.yaml
@@ -1,24 +1,5 @@
-# The MIT License (MIT)
-#
-# Copyright (c) 2016-2025 Objectionary.com
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
 ---
 sheets:
   - /org/eolang/lints/critical/application-duality.xsl

--- a/src/test/resources/org/eolang/lints/xmir-with-application-duality.xml
+++ b/src/test/resources/org/eolang/lints/xmir-with-application-duality.xml
@@ -1,26 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-The MIT License (MIT)
-
-Copyright (c) 2016-2025 Objectionary.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
 -->
 <program>
   <objects>


### PR DESCRIPTION
In this PR I've introduced new lint: `inconsistent-args`, that reports `warning`-s for objects with the same `@base`, but with different number of arguments passed in it in the scope of all programs under analysis.

closes #259
History:
- **feat(#259): test**
- **feat(#259): report localized**
- **feat(#259): opposite refs**
- **feat(#259): allows test**
- **feat(#259): typo**
- **feat(#259): typo**
- **feat(#259): multiple programs**
- **feat(#259): whole merge, invert, report**
- **feat(#259): clean for qulice**
