### PR TITLE
bug(#357): fix unlints in canonical.eo

### DIFF
--- a/src/test/resources/org/eolang/lints/canonical.eo
+++ b/src/test/resources/org/eolang/lints/canonical.eo
@@ -23,7 +23,6 @@
 +architect yegor256@gmail.com
 +home https://www.eolang.org
 +package canonical
-+unlint object-does-not-match-filename
 +version 0.0.0
 
 # Times table, which is a canonical example of EO program.


### PR DESCRIPTION
In this PR i've removed an unlint of `object-does-not-match-filename` in `canonical.eo`, in order to fix the master branch, after [introducing `unlint-non-existing-defect` lint](https://github.com/objectionary/lints/commit/8d09f407d0b0a190144126f4b4e63fea7573e80b) and [breaking changes in `object-does-not-match-filename`](https://github.com/objectionary/lints/commit/7a53b4b526ab142607a396a72c3cb763c9fc4ddc).

closes #357