### PR TITLE
feat(#354): `mandatory-spdx` lint

### DIFF
--- a/src/main/resources/org/eolang/lints/metas/mandatory-spdx.xsl
+++ b/src/main/resources/org/eolang/lints/metas/mandatory-spdx.xsl
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="mandatory-spdx" version="2.0">
+  <xsl:output encoding="UTF-8"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:if test="count(/program/metas/meta[head ='spdx'])=0">
+        <xsl:element name="defect">
+          <xsl:attribute name="line">
+            <xsl:value-of select="0"/>
+          </xsl:attribute>
+          <xsl:attribute name="severity">
+            <xsl:text>warning</xsl:text>
+          </xsl:attribute>
+          <xsl:text>The +spdx meta is mandatory, but is absent</xsl:text>
+        </xsl:element>
+      </xsl:if>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/metas/unknown-metas.xsl
+++ b/src/main/resources/org/eolang/lints/metas/unknown-metas.xsl
@@ -11,7 +11,7 @@
     <defects>
       <xsl:for-each select="/program/metas/meta">
         <xsl:variable name="meta-head" select="head"/>
-        <xsl:variable name="predefined" select="('package', 'alias', 'version', 'tests', 'rt', 'architect', 'home', 'unlint', 'probe')"/>
+        <xsl:variable name="predefined" select="('package', 'alias', 'version', 'tests', 'rt', 'architect', 'home', 'unlint', 'probe', 'spdx')"/>
         <xsl:if test="not($meta-head = $predefined)">
           <xsl:element name="defect">
             <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/motives/metas/mandatory-spdx.md
+++ b/src/main/resources/org/eolang/motives/metas/mandatory-spdx.md
@@ -1,0 +1,19 @@
+# Mandatory `+spdx`
+
+Special meta `+spdx` should be present in each `.eo` program.
+
+Incorrect:
+
+```eo
+# Foo.
+[] > foo
+```
+
+Correct:
+
+```eo
++spdx SPDX-License-Identifier: MIT
+
+# Foo.
+[] > foo
+```

--- a/src/test/java/matchers/GrammarMatcher.java
+++ b/src/test/java/matchers/GrammarMatcher.java
@@ -45,7 +45,7 @@ public final class GrammarMatcher extends BaseMatcher<String> {
         for (final Rule rule : tool.getAllActiveRules()) {
             if (rule instanceof SpellingCheckRule) {
                 ((SpellingCheckRule) rule).addIgnoreTokens(
-                    Arrays.asList("decoratee", "eolang")
+                    Arrays.asList("decoratee", "eolang", "spdx")
                 );
             }
         }

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -49,6 +49,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *  other classes in size too, for instance smaller classes (standard program),
  *  large class (JNA pointer), x-large class, and xxl class. Don't forget to
  *  adjust lint-summary.txt file to capture all the measurements.
+ * @todo #354:30min Normalize SPDX strings in EO test programs.
+ *  Instead of using `String.format()` to compose SPDX parts, we should inline it.
+ *  We using it now, since <a href="https://github.com/fsfe/reuse-tool/issues/92">this</a>
+ *  issue exists with reuse lint tool. Don't forget to normalize strings in all test
+ *  programs, created as Java strings.
  */
 @ExtendWith(MktmpResolver.class)
 final class ProgramTest {
@@ -62,8 +67,10 @@ final class ProgramTest {
                     "com.example.foo",
                     String.join(
                         "\n",
-                        "+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com",
-                        "+spdx SPDX-License-Identifier: MIT",
+                        "+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com",
+                        String.format(
+                            "+spdx SPDX-%s", "License-Identifier: MIT"
+                        ),
                         "+home https://www.eolang.org",
                         "+package com.example",
                         "+version 0.0.0",

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -63,14 +63,13 @@ final class ProgramTest {
                     "com.example.foo",
                     String.join(
                         "\n",
+                        "+home https://www.eolang.org",
+                        "+package com.example",
+                        "+version 0.0.0",
                         // REUSE-IgnoreStart
                         "+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com",
                         "+spdx SPDX-License-Identifier: MIT",
                         // REUSE-IgnoreEnd
-                        "+home https://www.eolang.org",
-                        "+package com.example",
-                        "+version 0.0.0",
-                        "+unlint unsorted-metas",
                         "",
                         "# This is just a test object with no functionality.",
                         "[] > foo",

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -49,11 +49,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *  other classes in size too, for instance smaller classes (standard program),
  *  large class (JNA pointer), x-large class, and xxl class. Don't forget to
  *  adjust lint-summary.txt file to capture all the measurements.
- * @todo #354:30min Normalize SPDX strings in EO test programs.
- *  Instead of using `String.format()` to compose SPDX parts, we should inline it.
- *  We using it now, since <a href="https://github.com/fsfe/reuse-tool/issues/92">this</a>
- *  issue exists with reuse lint tool. Don't forget to normalize strings in all test
- *  programs, created as Java strings.
+ * @checkstyle MethodBodyCommentsCheck (50 lines)
  */
 @ExtendWith(MktmpResolver.class)
 final class ProgramTest {
@@ -67,10 +63,10 @@ final class ProgramTest {
                     "com.example.foo",
                     String.join(
                         "\n",
+                        // REUSE-IgnoreStart
                         "+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com",
-                        String.format(
-                            "+spdx SPDX-%s", "License-Identifier: MIT"
-                        ),
+                        "+spdx SPDX-License-Identifier: MIT",
+                        // REUSE-IgnoreEnd
                         "+home https://www.eolang.org",
                         "+package com.example",
                         "+version 0.0.0",

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -62,9 +62,12 @@ final class ProgramTest {
                     "com.example.foo",
                     String.join(
                         "\n",
+                        "+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com",
+                        "+spdx SPDX-License-Identifier: MIT",
                         "+home https://www.eolang.org",
                         "+package com.example",
                         "+version 0.0.0",
+                        "+unlint unsorted-metas",
                         "",
                         "# This is just a test object with no functionality.",
                         "[] > foo",
@@ -94,6 +97,7 @@ final class ProgramTest {
                             "+unlint mandatory-version",
                             "+unlint comment-too-short",
                             "+unlint unsorted-metas",
+                            "+unlint mandatory-spdx",
                             "# Test.",
                             "[] > foo"
                         )
@@ -246,7 +250,8 @@ final class ProgramTest {
                 "mandatory-home",
                 "mandatory-version",
                 "mandatory-package",
-                "comment-too-short"
+                "comment-too-short",
+                "mandatory-spdx"
             ).defects(),
             Matchers.emptyIterable()
         );

--- a/src/test/resources/org/eolang/lints/canonical.eo
+++ b/src/test/resources/org/eolang/lints/canonical.eo
@@ -1,10 +1,10 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://www.eolang.org
 +package canonical
 +version 0.0.0
++unlint unsorted-metas
 
 # Times table, which is a canonical example of EO program.
 [args] > canonical

--- a/src/test/resources/org/eolang/lints/canonical.eo
+++ b/src/test/resources/org/eolang/lints/canonical.eo
@@ -1,10 +1,9 @@
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
 +architect yegor256@gmail.com
 +home https://www.eolang.org
 +package canonical
 +version 0.0.0
-+unlint unsorted-metas
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Times table, which is a canonical example of EO program.
 [args] > canonical

--- a/src/test/resources/org/eolang/lints/packs/mandatory-spdx/catches-missing-spdx.yaml
+++ b/src/test/resources/org/eolang/lints/packs/mandatory-spdx/catches-missing-spdx.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/mandatory-spdx.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+input: |
+  +architect jeff@google.com
+
+  # No comments.
+  [] > f

--- a/src/test/resources/org/eolang/lints/packs/mandatory-spdx/passes-on-spdx-presence.yaml
+++ b/src/test/resources/org/eolang/lints/packs/mandatory-spdx/passes-on-spdx-presence.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/mandatory-spdx.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  +spdx SPDX-License-Identifier MIT
+  +architect jeff@google.com
+
+  # No comments.
+  [] > f


### PR DESCRIPTION
In this PR I've introduced new lint: `mandatory-spdx`, that issues defect with `warning` severity, if `+spdx` meta is missing.

see #354