### PR TITLE
feat(#354): `+spdx` meta is out of `unsorted-metas`

### DIFF
--- a/src/main/resources/org/eolang/lints/metas/unsorted-metas.xsl
+++ b/src/main/resources/org/eolang/lints/metas/unsorted-metas.xsl
@@ -9,9 +9,9 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="/program/metas/meta">
+      <xsl:for-each select="/program/metas/meta[not(head='spdx')]">
         <xsl:variable name="meta-text" select="concat(head, ' ', tail)"/>
-        <xsl:variable name="previous" select="(preceding-sibling::meta)[1]"/>
+        <xsl:variable name="previous" select="(preceding-sibling::meta[not(head = 'spdx')])[1]"/>
         <xsl:variable name="sibling-text" select="concat($previous/head/text(), ' ', $previous/tail/text())"/>
         <xsl:if test="$meta-text &lt; $sibling-text">
           <xsl:element name="defect">

--- a/src/test/resources/org/eolang/lints/packs/unsorted-metas/ignores-spdx-meta.yaml
+++ b/src/test/resources/org/eolang/lints/packs/unsorted-metas/ignores-spdx-meta.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/unsorted-metas.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  +spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+  +aaa
+  +bbb
+
+  # No comments.
+  [] > foo
+    42 > @


### PR DESCRIPTION
In this PR I removed `+spdx` meta from order checking in `unsorted-metas`, since `spdx` meta is designed to be located at the top of the file (usually 1st and 2nd lines).

see #354