### PR TITLE
bug(#368): disabled tests for bug: ignoring unlints from other scope in `unlint-non-existing-defect`

### DIFF
--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -10,6 +10,7 @@ import org.cactoos.list.ListOf;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -98,6 +99,37 @@ final class LtUnlintNonExistingDefectTest {
                         "\n",
                         "# тук-тук",
                         "[] > bar"
+                    )
+                ).parsed()
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    /**
+     * Ignores WPA unlint.
+     * @throws IOException if something went wrong.
+     * @todo #368:45min Configure `unlint-non-existing-defect` lint to ignore unlints from other
+     *  scope (WPA/Single program). On WPA side of this lint
+     *  ({@link LtUnlintNonExistingDefectWpaTest}) we should ignore single program lints. Also,
+     *  don't forget to enable
+     *  {@link LtUnlintNonExistingDefectWpaTest#ignoresSingleProgramUnlint()}.
+     */
+    @Disabled
+    @Test
+    void ignoresWpaUnlint() throws IOException {
+        MatcherAssert.assertThat(
+            "WPA unlints should be ignored",
+            new LtUnlintNonExistingDefect(
+                new ListOf<>(new LtAsciiOnly())
+            ).defects(
+                new EoSyntax(
+                    String.join(
+                        "\n",
+                        "+unlint unit-test-missing",
+                        "",
+                        "# Buzz",
+                        "[] > buzz"
                     )
                 ).parsed()
             ),

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectWpaTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectWpaTest.java
@@ -13,6 +13,7 @@ import org.cactoos.map.MapOf;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -114,6 +115,33 @@ final class LtUnlintNonExistingDefectWpaTest {
                 )
             ),
             Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
+
+    @Disabled
+    @Test
+    void ignoresSingleProgramUnlint() throws IOException {
+        MatcherAssert.assertThat(
+            "Single program unlint is not ignored, but it should be",
+            new LtUnlintNonExistingDefectWpa(
+                new ListOf<>(new LtUnitTestMissing())
+            ).defects(
+                new MapOf<>(
+                    new MapEntry<>(
+                        "",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "+unlint mandatory-home",
+                                "",
+                                "# Boom",
+                                "[] > boom"
+                            )
+                        ).parsed()
+                    )
+                )
+            ),
+            Matchers.emptyIterable()
         );
     }
 }


### PR DESCRIPTION
In this PR I've added disabled tests for found bug in `unlint-non-existing-defect` about ignoring `+unlint` meta for defect from the other scope: single program scope should ignore WPA unlints, while WPA - unlints from single program scope.

related to #368