### PR TITLE
deps(eo): EO parser 0.52.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-parser</artifactId>
-      <version>0.51.6</version>
+      <version>0.52.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/main/resources/org/eolang/lints/metas/unknown-metas.xsl
+++ b/src/main/resources/org/eolang/lints/metas/unknown-metas.xsl
@@ -11,7 +11,7 @@
     <defects>
       <xsl:for-each select="/program/metas/meta">
         <xsl:variable name="meta-head" select="head"/>
-        <xsl:variable name="predefined" select="('package', 'alias', 'version', 'tests', 'rt', 'architect', 'home', 'unlint', 'probe')"/>
+        <xsl:variable name="predefined" select="('package', 'alias', 'version', 'tests', 'rt', 'architect', 'home', 'unlint', 'probe', 'spdx')"/>
         <xsl:if test="not($meta-head = $predefined)">
           <xsl:element name="defect">
             <xsl:attribute name="line">

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -149,8 +149,6 @@ final class ProgramTest {
                     new InputOf(
                         String.join(
                             "\n",
-                            "# This is the license",
-                            "",
                             "+version 8.8.8-beta",
                             "+alias org.eolang.txt.sprintf",
                             "+alias org . eolang . txt . broken",
@@ -180,7 +178,7 @@ final class ProgramTest {
                         Matchers.allOf(
                             Matchers.containsString("alias-too-long ERROR"),
                             Matchers.containsString("The alias has too many parts"),
-                            Matchers.containsString(":5")
+                            Matchers.containsString(":3")
                         )
                     )
                 )

--- a/src/test/resources/org/eolang/lints/canonical.eo
+++ b/src/test/resources/org/eolang/lints/canonical.eo
@@ -2,6 +2,8 @@
 +home https://www.eolang.org
 +package canonical
 +version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Times table, which is a canonical example of EO program.
 [args] > canonical

--- a/src/test/resources/org/eolang/lints/canonical.eo
+++ b/src/test/resources/org/eolang/lints/canonical.eo
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +architect yegor256@gmail.com
 +home https://www.eolang.org
 +package canonical

--- a/src/test/resources/org/eolang/lints/critical/incorrect-alias/no-aliases.eo
+++ b/src/test/resources/org/eolang/lints/critical/incorrect-alias/no-aliases.eo
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +package ttt
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Bar.
 [] > bar

--- a/src/test/resources/org/eolang/lints/critical/incorrect-alias/no-package.eo
+++ b/src/test/resources/org/eolang/lints/critical/incorrect-alias/no-package.eo
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias foo
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Bar.
 [] > bar

--- a/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/a.eo
+++ b/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/a.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # A.
 [attr] > a

--- a/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/abc-packaged.eo
+++ b/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/abc-packaged.eo
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +package a.b.z
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # ABC.
 [] > abc /string

--- a/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/abc.eo
+++ b/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/abc.eo
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +package a.b.c
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # ABC.
 [] > abc /string

--- a/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/app-1.eo
+++ b/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/app-1.eo
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +package xyz
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Foo.
 [] > app

--- a/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/app-2.eo
+++ b/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/app-2.eo
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +package xyz
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Foo app duplicate.
 [] > app

--- a/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/b.eo
+++ b/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/b.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # B.
 [attr] > b

--- a/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/bar-but-foo.eo
+++ b/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/bar-but-foo.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Bar, but its foo.
 [] > foo

--- a/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/bar.eo
+++ b/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/bar.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Bar.
 [] > bar

--- a/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/dups.eo
+++ b/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/dups.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Dups.
 [attr] > dups

--- a/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/foo.eo
+++ b/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/foo.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Foo.
 [] > foo

--- a/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/nested-dup.eo
+++ b/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/nested-dup.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Top object with nested atoms inside.
 [] > top

--- a/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/nested.eo
+++ b/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/nested.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Top object with nested atoms inside.
 [] > top

--- a/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/spb.eo
+++ b/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/spb.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Spb.
 [attr] > spb

--- a/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/x-packaged.eo
+++ b/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/x-packaged.eo
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +package xyz
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # X packaged.
 [] > app

--- a/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/x.eo
+++ b/src/test/resources/org/eolang/lints/errors/atom-is-not-unique/x.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # X.
 [] > app

--- a/src/test/resources/org/eolang/lints/errors/object-is-not-unique/bar-with-foo.eo
+++ b/src/test/resources/org/eolang/lints/errors/object-is-not-unique/bar-with-foo.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Bar.
 [] > foo

--- a/src/test/resources/org/eolang/lints/errors/object-is-not-unique/bar.eo
+++ b/src/test/resources/org/eolang/lints/errors/object-is-not-unique/bar.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Bar.
 [] > bar

--- a/src/test/resources/org/eolang/lints/errors/object-is-not-unique/baz-packaged.eo
+++ b/src/test/resources/org/eolang/lints/errors/object-is-not-unique/baz-packaged.eo
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +package utils
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Baz.
 [] > baz

--- a/src/test/resources/org/eolang/lints/errors/object-is-not-unique/baz.eo
+++ b/src/test/resources/org/eolang/lints/errors/object-is-not-unique/baz.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Baz.
 [] > baz

--- a/src/test/resources/org/eolang/lints/errors/object-is-not-unique/c.eo
+++ b/src/test/resources/org/eolang/lints/errors/object-is-not-unique/c.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # 42.
 [] > c

--- a/src/test/resources/org/eolang/lints/errors/object-is-not-unique/e.eo
+++ b/src/test/resources/org/eolang/lints/errors/object-is-not-unique/e.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # 52.
 [] > e

--- a/src/test/resources/org/eolang/lints/errors/object-is-not-unique/foo.eo
+++ b/src/test/resources/org/eolang/lints/errors/object-is-not-unique/foo.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # Foo.
 [] > foo

--- a/src/test/resources/org/eolang/lints/errors/object-is-not-unique/mul-packaged.eo
+++ b/src/test/resources/org/eolang/lints/errors/object-is-not-unique/mul-packaged.eo
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +package mul
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # test
 [] > foo

--- a/src/test/resources/org/eolang/lints/errors/object-is-not-unique/mul.eo
+++ b/src/test/resources/org/eolang/lints/errors/object-is-not-unique/mul.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # test
 [] > foo

--- a/src/test/resources/org/eolang/lints/errors/object-is-not-unique/test-1.eo
+++ b/src/test/resources/org/eolang/lints/errors/object-is-not-unique/test-1.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # test
 [] > foo

--- a/src/test/resources/org/eolang/lints/errors/object-is-not-unique/test-2.eo
+++ b/src/test/resources/org/eolang/lints/errors/object-is-not-unique/test-2.eo
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 
 # test
 [] > bar

--- a/src/test/resources/org/eolang/lints/misc/test-object-is-not-verb-in-singular/bad-tests.eo
+++ b/src/test/resources/org/eolang/lints/misc/test-object-is-not-verb-in-singular/bad-tests.eo
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +tests
 
 # Test.

--- a/src/test/resources/org/eolang/lints/misc/test-object-is-not-verb-in-singular/good-tests.eo
+++ b/src/test/resources/org/eolang/lints/misc/test-object-is-not-verb-in-singular/good-tests.eo
@@ -1,6 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
 +tests
 
 # Test.

--- a/src/test/resources/org/eolang/lints/misc/test-object-is-not-verb-in-singular/regex-tests.eo
+++ b/src/test/resources/org/eolang/lints/misc/test-object-is-not-verb-in-singular/regex-tests.eo
@@ -1,12 +1,11 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
 +alias org.eolang.txt.regex
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+tests
 +package org.eolang.txt
 +version 0.48.1
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++tests
 
 # This unit test is supposed to check the functionality of the corresponding object.
 [] > matches-regex-against-the-pattern


### PR DESCRIPTION
In this pull I removed license from all EO test sources, and upgraded EO parser to `0.52.0`.