### PR TITLE
feat(#383): `incorrect-sdpx` and `empty-spdx-tail` lints for `+spdx` meta

### DIFF
--- a/src/main/resources/org/eolang/lints/metas/empty-spdx-tail.xsl
+++ b/src/main/resources/org/eolang/lints/metas/empty-spdx-tail.xsl
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="empty-spdx-tail" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="/program/metas/meta[head/text()='spdx']">
+        <xsl:variable name="meta-tail" select="tail"/>
+        <xsl:if test="normalize-space(tail/text())=''">
+          <xsl:element name="defect">
+            <xsl:attribute name="line">
+              <xsl:value-of select="eo:lineno(@line)"/>
+            </xsl:attribute>
+            <xsl:attribute name="severity">
+              <xsl:text>warning</xsl:text>
+            </xsl:attribute>
+            <xsl:text>The tail of the "spdx" meta is empty, which is prohibited</xsl:text>
+          </xsl:element>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/metas/incorrect-spdx.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-spdx.xsl
@@ -20,8 +20,9 @@
             <xsl:attribute name="severity">
               <xsl:text>warning</xsl:text>
             </xsl:attribute>
-            <xsl:text>The format of the "spdx" meta is wrong: </xsl:text>
+            <xsl:text>The tail </xsl:text>
             <xsl:value-of select="eo:escape($header)"/>
+            <xsl:text> in the "spdx" meta is not SPDX-compliant header</xsl:text>
           </xsl:element>
         </xsl:if>
       </xsl:for-each>

--- a/src/main/resources/org/eolang/lints/metas/incorrect-spdx.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-spdx.xsl
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="incorrect-spdx" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="/program/metas/meta[head/text()='spdx' and count(part) &gt; 1]">
+        <xsl:variable name="meta-tail" select="tail"/>
+        <xsl:variable name="header" select="normalize-space(substring-before(concat($meta-tail, ' '), ' '))"/>
+        <xsl:if test="$header!='SPDX-FileCopyrightText' and $header!='SPDX-License-Identifier'">
+          <xsl:element name="defect">
+            <xsl:attribute name="line">
+              <xsl:value-of select="eo:lineno(@line)"/>
+            </xsl:attribute>
+            <xsl:attribute name="severity">
+              <xsl:text>warning</xsl:text>
+            </xsl:attribute>
+            <xsl:text>The format of the "spdx" meta is wrong: </xsl:text>
+            <xsl:value-of select="eo:escape($header)"/>
+          </xsl:element>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/metas/incorrect-spdx.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-spdx.xsl
@@ -22,7 +22,7 @@
             </xsl:attribute>
             <xsl:text>The tail </xsl:text>
             <xsl:value-of select="eo:escape($header)"/>
-            <xsl:text> in the "spdx" meta is not SPDX-compliant header</xsl:text>
+            <xsl:text> of the "spdx" meta is not SPDX-compliant header</xsl:text>
           </xsl:element>
         </xsl:if>
       </xsl:for-each>

--- a/src/main/resources/org/eolang/lints/metas/incorrect-spdx.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-spdx.xsl
@@ -12,7 +12,7 @@
       <xsl:for-each select="/program/metas/meta[head/text()='spdx' and count(part) &gt; 1]">
         <xsl:variable name="meta-tail" select="tail"/>
         <xsl:variable name="header" select="normalize-space(substring-before(concat($meta-tail, ' '), ' '))"/>
-        <xsl:if test="$header!='SPDX-FileCopyrightText' and $header!='SPDX-License-Identifier'">
+        <xsl:if test="$header!='SPDX-FileCopyrightText' and $header!='SPDX-License-Identifier:'">
           <xsl:element name="defect">
             <xsl:attribute name="line">
               <xsl:value-of select="eo:lineno(@line)"/>

--- a/src/main/resources/org/eolang/motives/metas/empty-spdx-tail.md
+++ b/src/main/resources/org/eolang/motives/metas/empty-spdx-tail.md
@@ -1,0 +1,21 @@
+# Empty `+spdx` Tail
+
+The special meta attribute `+spdx` cannot have an empty tail.
+
+Incorrect:
+
+```eo
++spdx
+
+# Foo.
+[] > foo
+```
+
+Correct:
+
+```eo
++spdx foo
+
+# Foo.
+[] > foo
+```

--- a/src/main/resources/org/eolang/motives/metas/incorrect-spdx.md
+++ b/src/main/resources/org/eolang/motives/metas/incorrect-spdx.md
@@ -1,0 +1,23 @@
+# Incorrect `+spdx`
+
+Tail of special meta `+spdx` should be [SPDX]-compliant headers.
+
+Incorrect:
+
+```eo
++spdx foo bar
+
+# Foo.
+[] > foo
+```
+
+Correct:
+
+```eo
++spdx SPDX-License-Identifier: MIT
+
+# Foo.
+[] > foo
+```
+
+[SPDX]: https://en.wikipedia.org/wiki/Software_Package_Data_Exchange

--- a/src/test/java/matchers/GrammarMatcher.java
+++ b/src/test/java/matchers/GrammarMatcher.java
@@ -45,7 +45,7 @@ public final class GrammarMatcher extends BaseMatcher<String> {
         for (final Rule rule : tool.getAllActiveRules()) {
             if (rule instanceof SpellingCheckRule) {
                 ((SpellingCheckRule) rule).addIgnoreTokens(
-                    Arrays.asList("decoratee", "eolang", "spdx")
+                    Arrays.asList("decoratee", "eolang", "spdx", "SPDX-compliant")
                 );
             }
         }

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -67,7 +67,7 @@ final class ProgramTest {
                         "+package com.example",
                         "+version 0.0.0",
                         // REUSE-IgnoreStart
-                        "+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com",
+                        "+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com",
                         "+spdx SPDX-License-Identifier: MIT",
                         // REUSE-IgnoreEnd
                         "",

--- a/src/test/resources/org/eolang/lints/packs/empty-spdx-tail/catches-empty-tail.yaml
+++ b/src/test/resources/org/eolang/lints/packs/empty-spdx-tail/catches-empty-tail.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/empty-spdx-tail.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='1']
+input: |
+  +spdx
+
+  # Foo.
+  [] > foo

--- a/src/test/resources/org/eolang/lints/packs/empty-spdx-tail/passes-on-good-tail.yaml
+++ b/src/test/resources/org/eolang/lints/packs/empty-spdx-tail/passes-on-good-tail.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/empty-spdx-tail.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  +spdx foo
+
+  # Foo.
+  [] > foo

--- a/src/test/resources/org/eolang/lints/packs/incorrect-spdx/catches-incorrect-spdx-metas.yaml
+++ b/src/test/resources/org/eolang/lints/packs/incorrect-spdx/catches-incorrect-spdx-metas.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/incorrect-spdx.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='1']
+input: |
+  +spdx foo bar
+
+  # Foo.
+  [] > foo

--- a/src/test/resources/org/eolang/lints/packs/incorrect-spdx/passes-on-good-spdx-metas.yaml
+++ b/src/test/resources/org/eolang/lints/packs/incorrect-spdx/passes-on-good-spdx-metas.yaml
@@ -7,7 +7,7 @@ asserts:
   - /defects[count(defect[@severity='warning'])=0]
 input: |
   +spdx SPDX-FileCopyrightText foo
-  +spdx SPDX-License-Identifier: f
+  +spdx SPDX-License-Identifier: MIT
 
   # Foo.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/incorrect-spdx/passes-on-good-spdx-metas.yaml
+++ b/src/test/resources/org/eolang/lints/packs/incorrect-spdx/passes-on-good-spdx-metas.yaml
@@ -7,7 +7,7 @@ asserts:
   - /defects[count(defect[@severity='warning'])=0]
 input: |
   +spdx SPDX-FileCopyrightText foo
-  +spdx SPDX-License-Identifier f
+  +spdx SPDX-License-Identifier: f
 
   # Foo.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/incorrect-spdx/passes-on-good-spdx.yaml
+++ b/src/test/resources/org/eolang/lints/packs/incorrect-spdx/passes-on-good-spdx.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/incorrect-spdx.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  +spdx SPDX-FileCopyrightText foo
+  +spdx SPDX-License-Identifier f
+
+  # Foo.
+  [] > foo


### PR DESCRIPTION
In this PR I've introduced new lints to check the format of `+sdpx` meta: `incorrect-spdx` and `empty-spdx-tail`.

closes #383
History:
- **feat(#383): incorrect-spdx lint**
- **feat(#383): better message**
- **feat(#383): typo**
- **feat(#383): better message**
- **feat(#383): motive**
- **feat(#383): empty-spdx-tail**
- **feat(#383): motive**
