### PR TITLE
feat(#386): granular line unlinting in `+unlint`

### DIFF
--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -17,6 +17,11 @@ import org.cactoos.list.ListOf;
  * Lint that ignores linting if {@code +unlint} meta is present.
  *
  * @since 0.0.1
+ * @todo #386:30min Replace `XML.xpath()` with `Xnav.path()` usage in defects() method.
+ *  Currently, we cannot use `Xnav.path()` method due to
+ *  <a href="https://github.com/volodya-lombrozo/xnav/issues/74">this</a> bug.
+ *  Once it will be resolved, we should replace `XML.xpath()` with `Xnav.path()`
+ *  in order to improve the performance of the `LtUnlint.defects()` execution.
  */
 final class LtUnlint implements Lint<XML> {
 

--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -4,11 +4,14 @@
  */
 package org.eolang.lints;
 
-import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.cactoos.list.ListOf;
 
 /**
  * Lint that ignores linting if {@code +unlint} meta is present.
@@ -16,6 +19,11 @@ import java.util.Collection;
  * @since 0.0.1
  */
 final class LtUnlint implements Lint<XML> {
+
+    /**
+     * Line number to unlint.
+     */
+    private static final Pattern LINE_NUMBER = Pattern.compile(".*:\\d+$");
 
     /**
      * The original lint.
@@ -37,14 +45,41 @@ final class LtUnlint implements Lint<XML> {
 
     @Override
     public Collection<Defect> defects(final XML xmir) throws IOException {
-        final boolean suppress = new Xnav(xmir.inner()).path(
-            String.format(
-                "/program/metas/meta[head='unlint' and tail='%s']",
-                this.origin.name()
-            )
-        ).findAny().isPresent();
         final Collection<Defect> defects = new ArrayList<>(0);
-        if (!suppress) {
+        final String lname = this.origin.name();
+        final Collection<Defect> found = this.origin.defects(xmir);
+        final List<Integer> problematic = found.stream().
+            filter(defect -> defect.rule().equals(lname))
+            .map(Defect::line)
+            .collect(Collectors.toList());
+        final List<String> granular = xmir.xpath(
+            String.format(
+                "/program/metas/meta[head='unlint' and (tail='%s' or starts-with(tail, '%s:'))]/tail/text()",
+                lname, lname
+            )
+        );
+        final boolean global = !granular.isEmpty();
+        granular.forEach(
+            unlint -> {
+                if (LtUnlint.LINE_NUMBER.matcher(unlint).matches()) {
+                    final List<String> split = new ListOf<>(unlint.split(":"));
+                    final int lineno = Integer.parseInt(
+                        split.get(1)
+                    );
+                    problematic.removeIf(line -> line == lineno);
+                }
+            }
+        );
+        problematic.forEach(
+            line -> found.forEach(
+                defect -> {
+                    if (line != 0 && defect.line() == line) {
+                        defects.add(defect);
+                    }
+                }
+            )
+        );
+        if (!global) {
             defects.addAll(this.origin.defects(xmir));
         }
         return defects;

--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -67,6 +67,8 @@ final class LtUnlint implements Lint<XML> {
                         split.get(1)
                     );
                     problematic.removeIf(line -> line == lineno);
+                } else {
+                    problematic.clear();
                 }
             }
         );

--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -48,8 +48,8 @@ final class LtUnlint implements Lint<XML> {
         final Collection<Defect> defects = new ArrayList<>(0);
         final String lname = this.origin.name();
         final Collection<Defect> found = this.origin.defects(xmir);
-        final List<Integer> problematic = found.stream().
-            filter(defect -> defect.rule().equals(lname))
+        final List<Integer> problematic = found.stream()
+            .filter(defect -> defect.rule().equals(lname))
             .map(Defect::line)
             .collect(Collectors.toList());
         final List<String> granular = xmir.xpath(

--- a/src/test/java/org/eolang/lints/LtUnlintTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintTest.java
@@ -52,7 +52,7 @@ final class LtUnlintTest {
                 new EoSyntax(
                     String.join(
                         "\n",
-                        "+unlint comment-without-dot:2",
+                        "+unlint comment-without-dot:4",
                         "",
                         "# Foo",
                         "[] > foo",
@@ -68,11 +68,36 @@ final class LtUnlintTest {
                     Matchers.hasToString(
                         Matchers.allOf(
                             Matchers.containsString("comment-without-dot WARNING"),
-                            Matchers.containsString(":5")
+                            Matchers.containsString(":7")
                         )
                     )
                 )
             )
+        );
+    }
+
+    @Test
+    void unlintsMultipleDefectsWithGranularUnlint() throws IOException {
+        MatcherAssert.assertThat(
+            "All defects should be unlinted",
+            new LtUnlint(
+                new LtByXsl("comments/comment-without-dot")
+            ).defects(
+                new EoSyntax(
+                    String.join(
+                        "\n",
+                        "+unlint comment-without-dot:5",
+                        "+unlint comment-without-dot:8",
+                        "",
+                        "# Foo",
+                        "[] > foo",
+                        "",
+                        "# Bar",
+                        "[] > bar"
+                    )
+                ).parsed()
+            ),
+            Matchers.emptyIterable()
         );
     }
 }

--- a/src/test/java/org/eolang/lints/LtUnlintTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintTest.java
@@ -5,6 +5,7 @@
 package org.eolang.lints;
 
 import java.io.IOException;
+import java.util.Collection;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -38,6 +39,40 @@ final class LtUnlintTest {
                 ).parsed()
             ),
             Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void unlintsGrainy() throws IOException {
+        MatcherAssert.assertThat(
+            "Only one defect should be unlinted",
+            new LtUnlint(
+                new LtByXsl("comments/comment-without-dot")
+            ).defects(
+                new EoSyntax(
+                    String.join(
+                        "\n",
+                        "+unlint comment-without-dot:2",
+                        "",
+                        "# Foo",
+                        "[] > foo",
+                        "",
+                        "# Bar",
+                        "[] > bar"
+                    )
+                ).parsed()
+            ),
+            Matchers.allOf(
+                Matchers.iterableWithSize(1),
+                Matchers.hasItem(
+                    Matchers.hasToString(
+                        Matchers.allOf(
+                            Matchers.containsString("comment-without-dot WARNING"),
+                            Matchers.containsString(":5")
+                        )
+                    )
+                )
+            )
         );
     }
 }

--- a/src/test/java/org/eolang/lints/LtUnlintTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintTest.java
@@ -5,7 +5,6 @@
 package org.eolang.lints;
 
 import java.io.IOException;
-import java.util.Collection;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -88,6 +87,30 @@ final class LtUnlintTest {
                         "\n",
                         "+unlint comment-without-dot:5",
                         "+unlint comment-without-dot:8",
+                        "",
+                        "# Foo",
+                        "[] > foo",
+                        "",
+                        "# Bar",
+                        "[] > bar"
+                    )
+                ).parsed()
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void unlintsGlobally() throws IOException {
+        MatcherAssert.assertThat(
+            "All defects should be unlinted",
+            new LtUnlint(
+                new LtByXsl("comments/comment-without-dot")
+            ).defects(
+                new EoSyntax(
+                    String.join(
+                        "\n",
+                        "+unlint comment-without-dot",
                         "",
                         "# Foo",
                         "[] > foo",


### PR DESCRIPTION
In this PR I've implemented granular unlinting of defects by lines in `+unlint`.

closes #386
History:
- **feat(#386): test**
- **feat(#386): granularity**
- **feat(#386): problematic.clear()**
- **feat(#386): clean for qulice**
