### PR TITLE
bug(#394): check decoratee of specific lint to be `LtUnlint` in `PkMonoTest.checksThatLintsCanBeUnlinted()`

### DIFF
--- a/src/test/java/org/eolang/lints/PkMonoTest.java
+++ b/src/test/java/org/eolang/lints/PkMonoTest.java
@@ -4,11 +4,13 @@
  */
 package org.eolang.lints;
 
+import com.jcabi.xml.XML;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import com.yegor256.Together;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.stream.Collectors;
 import org.cactoos.list.ListOf;
 import org.cactoos.scalar.LengthOf;
@@ -69,7 +71,7 @@ final class PkMonoTest {
                             "Lint '%s' can not be unlinted, since its not wrapped by LtUnlint",
                             lint.name()
                         ),
-                        lint.getClass().equals(LtUnlint.class),
+                        PkMonoTest.decoratee(lint).getClass().equals(LtUnlint.class),
                         new IsEqual<>(true)
                     )
             );
@@ -84,6 +86,36 @@ final class PkMonoTest {
                 .withImportOption(new ImportOption.DoNotIncludeTests())
                 .importPackages("org.eolang.lints")
             );
+    }
+
+    /**
+     * Found decorated lint of specific lint.
+     * @param decorate Lint
+     * @return Decorated lint
+     * @todo #394:25min Replace `LtAlways` in comparison with lint caching decorator.
+     *  Currently, its not available, once <a href="https://github.com/objectionary/lints/issues/372">this</a>
+     *  ticket will be solved, we can replace the class.
+     */
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+    private static Lint<?> decoratee(final Lint<XML> decorate) {
+        Lint<?> result = decorate;
+        while (decorate.getClass().equals(LtAlways.class)) {
+            final Field[] fields = decorate.getClass().getDeclaredFields();
+            for (final Field field : fields) {
+                field.setAccessible(true);
+                final Object value;
+                try {
+                    value = field.get(decorate);
+                } catch (final IllegalAccessException exception) {
+                    throw new IllegalStateException("Failed to get decorated field", exception);
+                }
+                if (value instanceof Lint) {
+                    result = (Lint<?>) value;
+                    break;
+                }
+            }
+        }
+        return result;
     }
 
 }


### PR DESCRIPTION
In this PR I've updated `PkMonoTest.checksThatLintsCanBeUnlinted` to check decoratee of specific lint to be equal to `LtUnlint`, instead of specific lint to be `LtUnlint` itself.

closes #394