### PR TITLE
bug(#396): clear message in incorrect-unlint

### DIFF
--- a/src/main/java/org/eolang/lints/LtIncorrectUnlint.java
+++ b/src/main/java/org/eolang/lints/LtIncorrectUnlint.java
@@ -53,7 +53,7 @@ final class LtIncorrectUnlint implements Lint<XML> {
                         xml.element("program").attribute("name").text().orElse("unknown"),
                         Integer.parseInt(u.attribute("line").text().orElse("0")),
                         String.format(
-                            "Unlinting \"%s\" does not make sense, because there is no lint with that name",
+                            "Suppressing \"%s\" does not make sense, because there is no lint with that name",
                             u.element("tail").text().orElse("unknown")
                         )
                     )

--- a/src/main/java/org/eolang/lints/LtIncorrectUnlint.java
+++ b/src/main/java/org/eolang/lints/LtIncorrectUnlint.java
@@ -46,21 +46,18 @@ final class LtIncorrectUnlint implements Lint<XML> {
         xml.path("/program/metas/meta[head='unlint']")
             .filter(u -> !this.names.contains(u.element("tail").text().orElse("unknown")))
             .forEach(
-                u -> {
-                    final String name = u.element("tail").text().orElse("unknown");
-                    defects.add(
-                        new Defect.Default(
-                            this.name(),
-                            Severity.ERROR,
-                            xml.element("program").attribute("name").text().orElse("unknown"),
-                            Integer.parseInt(u.attribute("line").text().orElse("0")),
-                            String.format(
-                                "Unlinting \"%s\" does not make sense, because there is no lint with that name",
-                                name
-                            )
+                u -> defects.add(
+                    new Defect.Default(
+                        this.name(),
+                        Severity.ERROR,
+                        xml.element("program").attribute("name").text().orElse("unknown"),
+                        Integer.parseInt(u.attribute("line").text().orElse("0")),
+                        String.format(
+                            "Unlinting \"%s\" does not make sense, because there is no lint with that name",
+                            u.element("tail").text().orElse("unknown")
                         )
-                    );
-                }
+                    )
+                )
             );
         return defects;
     }

--- a/src/test/java/matchers/GrammarMatcher.java
+++ b/src/test/java/matchers/GrammarMatcher.java
@@ -45,7 +45,7 @@ public final class GrammarMatcher extends BaseMatcher<String> {
         for (final Rule rule : tool.getAllActiveRules()) {
             if (rule instanceof SpellingCheckRule) {
                 ((SpellingCheckRule) rule).addIgnoreTokens(
-                    Arrays.asList("decoratee", "eolang", "spdx", "SPDX-compliant", "Unlinting")
+                    Arrays.asList("decoratee", "eolang", "spdx", "SPDX-compliant")
                 );
             }
         }

--- a/src/test/java/matchers/GrammarMatcher.java
+++ b/src/test/java/matchers/GrammarMatcher.java
@@ -45,7 +45,7 @@ public final class GrammarMatcher extends BaseMatcher<String> {
         for (final Rule rule : tool.getAllActiveRules()) {
             if (rule instanceof SpellingCheckRule) {
                 ((SpellingCheckRule) rule).addIgnoreTokens(
-                    Arrays.asList("decoratee", "eolang", "spdx", "SPDX-compliant")
+                    Arrays.asList("decoratee", "eolang", "spdx", "SPDX-compliant", "Unlinting")
                 );
             }
         }

--- a/src/test/java/org/eolang/lints/LtIncorrectUnlintTest.java
+++ b/src/test/java/org/eolang/lints/LtIncorrectUnlintTest.java
@@ -59,7 +59,7 @@ final class LtIncorrectUnlintTest {
                     ).parsed()
                 )
             ).get(0).text(),
-            Matchers.containsString("Unlinting \"boom\" does not make sense")
+            Matchers.containsString("Suppressing \"boom\" does not make sense")
         );
     }
 }

--- a/src/test/java/org/eolang/lints/LtIncorrectUnlintTest.java
+++ b/src/test/java/org/eolang/lints/LtIncorrectUnlintTest.java
@@ -4,8 +4,10 @@
  */
 package org.eolang.lints;
 
+import java.io.IOException;
 import java.util.List;
 import matchers.DefectMatcher;
+import org.cactoos.list.ListOf;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -23,7 +25,7 @@ final class LtIncorrectUnlintTest {
             "unlint must point to existing lint",
             new LtIncorrectUnlint(List.of("hello")).defects(
                 new EoSyntax(
-                    "+unlint abracadabra\n+unlint vingardium-leviosa"
+                    "+unlint foo\n+unlint bar"
                 ).parsed()
             ),
             Matchers.allOf(
@@ -43,6 +45,21 @@ final class LtIncorrectUnlintTest {
                 ).parsed()
             ),
             Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void providesClearMessage() throws IOException {
+        MatcherAssert.assertThat(
+            "Lint text doesn't contain clear message to the reader",
+            new ListOf<>(
+                new LtIncorrectUnlint(List.of("hello")).defects(
+                    new EoSyntax(
+                        "+unlint boom"
+                    ).parsed()
+                )
+            ).get(0).text(),
+            Matchers.containsString("Unlinting \"boom\" does not make sense")
         );
     }
 }


### PR DESCRIPTION
In this PR I've improved defect message in `incorrect-unlint`.

closes #396