### PR TITLE
bug(#409): revised message about `application-duality`

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/application-duality.xsl
+++ b/src/main/resources/org/eolang/lints/critical/application-duality.xsl
@@ -21,7 +21,10 @@
             </xsl:otherwise>
           </xsl:choose>
         </xsl:variable>
-        <xsl:if test="count($args/*) != count($args/*[@as]) and count($args/*) != count($args/*[not(@as)])">
+        <xsl:variable name="total" select="count($args/*)"/>
+        <xsl:variable name="bindings" select="count($args/*[@as])"/>
+        <xsl:variable name="without" select="count($args/*[not(@as)])"/>
+        <xsl:if test="$total != $bindings and $total != $without">
           <defect>
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">
@@ -45,7 +48,13 @@
                 <xsl:text>anonymous object</xsl:text>
               </xsl:otherwise>
             </xsl:choose>
-            <xsl:text> cannot mix child elements with and without the @as attribute, please ensure that all child elements either have the @as attribute or none of them do</xsl:text>
+            <xsl:text> cannot mix child elements with and without the @as attribute: </xsl:text>
+            <xsl:value-of select="$total"/>
+            <xsl:text> children, </xsl:text>
+            <xsl:value-of select="$bindings"/>
+            <xsl:text> with, </xsl:text>
+            <xsl:value-of select="$without"/>
+            <xsl:text> without; please ensure that all child elements either have the @as attribute or none of them do</xsl:text>
           </defect>
         </xsl:if>
       </xsl:for-each>

--- a/src/main/resources/org/eolang/lints/critical/application-duality.xsl
+++ b/src/main/resources/org/eolang/lints/critical/application-duality.xsl
@@ -45,7 +45,7 @@
                 <xsl:text>anonymous object</xsl:text>
               </xsl:otherwise>
             </xsl:choose>
-            <xsl:text> cannot have both @name and @as attributes as this is prohibited due to duality in the application, please use only one</xsl:text>
+            <xsl:text> cannot mix child elements with and without the @as attribute, please ensure that all child elements either have the @as attribute or none of them do</xsl:text>
           </defect>
         </xsl:if>
       </xsl:for-each>

--- a/src/test/resources/org/eolang/lints/packs/application-duality/catches-mix-of-as-and-bases-with-inners.yaml
+++ b/src/test/resources/org/eolang/lints/packs/application-duality/catches-mix-of-as-and-bases-with-inners.yaml
@@ -6,6 +6,7 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='critical'])=1]
   - /defects/defect[@line='7']
+  - /defects/defect[1][contains(normalize-space(), '3 children, 1 with, 2 without')]
 document: |
   <program>
     <objects>

--- a/src/test/resources/org/eolang/lints/packs/application-duality/catches-mix-of-as-and-bases-with-inners.yaml
+++ b/src/test/resources/org/eolang/lints/packs/application-duality/catches-mix-of-as-and-bases-with-inners.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/critical/application-duality.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=1]
+  - /defects/defect[@line='7']
+document: |
+  <program>
+    <objects>
+      <o base="Q.org.eolang.tuple" line="7">
+        <o base="Q.org.eolang.tuple.empty"/>
+        <o as="α1" base="Q.org.eolang.number" line="10" pos="8">
+          <o base="Q.org.eolang.bytes">3F-F0-00-00-00-00-00-00</o>
+        </o>
+        <o base="Q.org.eolang.number">
+          <o base="Q.org.eolang.bytes">3F-F0-00-00-00-00-00-00</o>
+        </o>
+      </o>
+    </objects>
+  </program>


### PR DESCRIPTION
In this PR I've updated the message about `application-duality` to make it more clear, and added one more test case with mix of `@as` and `@base` attributes with inner objects.

closes #409