### PR TITLE
feat(#412): removed the empty object warning for lambda objects

### DIFF
--- a/src/main/resources/org/eolang/lints/errors/empty-object.xsl
+++ b/src/main/resources/org/eolang/lints/errors/empty-object.xsl
@@ -11,7 +11,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="/object//o[not(@base) and not(o) and not(eo:atom(.)) and not(eo:has-data(.) and parent::o[@base='Q.org.eolang.bytes'])]">
+      <xsl:for-each select="/object//o[not(@base) and not(o) and not(eo:atom(.)) and not(eo:has-data(.) and parent::o[@base='Q.org.eolang.bytes']) and not(parent::o[eo:atom(.)])]">
         <xsl:element name="defect">
           <xsl:variable name="line" select="eo:lineno(@line)"/>
           <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/single/empty-object/allows-lambda-object-in-atom.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/empty-object/allows-lambda-object-in-atom.yaml
@@ -6,10 +6,8 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='warning'])=0]
 document: |
-  <program>
-    <objects>
-      <o name="@">
-        <o name="λ"/>
-      </o>
-    </objects>
-  </program>
+  <object>
+    <o name="@">
+      <o name="λ"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/empty-object/allows-lambda-object-in-atom.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/empty-object/allows-lambda-object-in-atom.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/errors/empty-object.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+document: |
+  <program>
+    <objects>
+      <o name="@">
+        <o name="λ"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/single/empty-object/cathes-lambda-object-outside-atom.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/empty-object/cathes-lambda-object-outside-atom.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/errors/empty-object.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+document: |
+  <program>
+    <objects>
+      <o name="λ"/>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/single/empty-object/cathes-lambda-object-outside-atom.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/empty-object/cathes-lambda-object-outside-atom.yaml
@@ -6,8 +6,6 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
 document: |
-  <program>
-    <objects>
-      <o name="λ"/>
-    </objects>
-  </program>
+  <object>
+    <o name="λ"/>
+  </object>


### PR DESCRIPTION
It seems to be in the eo repository in the file https://github.com/objectionary/eo/blob/master/eo-parser/src/main/resources/org/eolang/parser/_funcs.xsl there is a problem with the atom function, as it checks that the nested one, not the current one, has the name `lambda`