### PR TITLE
bug(#419): spdx in XMIR

### DIFF
--- a/src/main/resources/org/eolang/motives/metas/incorrect-spdx.md
+++ b/src/main/resources/org/eolang/motives/metas/incorrect-spdx.md
@@ -42,5 +42,8 @@ In [XMIR], spdx meta should look like this:
 </metas>
 ```
 
+Please note, that these two contain valid SPDX headers. Thus, you can use any
+number of SPDX-compliant headers.
+
 [SPDX]: https://en.wikipedia.org/wiki/Software_Package_Data_Exchange
 [XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html

--- a/src/main/resources/org/eolang/motives/metas/incorrect-spdx.md
+++ b/src/main/resources/org/eolang/motives/metas/incorrect-spdx.md
@@ -20,4 +20,27 @@ Correct:
 [] > foo
 ```
 
+In [XMIR], spdx meta should look like this:
+
+```xml
+<metas>
+  <meta>
+    <head>spdx</head>
+    <tail>SPDX-License-Identifier: MIT</tail>
+    <part>SPDX-License-Identifier:</part>
+    <part>MIT</part>
+  </meta>
+  <meta>
+    <head>spdx</head>
+    <tail>SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com</tail>
+    <part>SPDX-FileCopyrightText</part>
+    <part>Copyright</part>
+    <part>(c)</part>
+    <part>2016-2025</part>
+    <part>Objectionary.com</part>
+  </meta>
+</metas>
+```
+
 [SPDX]: https://en.wikipedia.org/wiki/Software_Package_Data_Exchange
+[XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html

--- a/src/main/resources/org/eolang/motives/metas/mandatory-spdx.md
+++ b/src/main/resources/org/eolang/motives/metas/mandatory-spdx.md
@@ -17,3 +17,16 @@ Correct:
 # Foo.
 [] > foo
 ```
+
+In [XMIR], spdx meta should look like this:
+
+```xml
+<meta>
+  <head>spdx</head>
+  <tail>SPDX-License-Identifier: MIT</tail>
+  <part>SPDX-License-Identifier:</part>
+  <part>MIT</part>
+</meta>
+```
+
+[XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html


### PR DESCRIPTION
In this PR I've extended motives of `incorrect-spdx` and `mandatory-spdx` by adding information about `+spdx` meta structure in XMIR.

closes #419