### PR TITLE
bug(#392): `Xnav.path()` in LtUnlint

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -4,7 +4,7 @@
 excludes:
   paths:
     - comment: It's a test
-      pattern: "@project.version@"
+      pattern: "src/it/**"
       reason: BUILD_TOOL_OF
   scopes:
     - pattern: "provided"

--- a/.ort.yml
+++ b/.ort.yml
@@ -4,7 +4,7 @@
 excludes:
   paths:
     - comment: It's a test
-      pattern: "src/it/**"
+      pattern: "src/it/lints-it/**"
       reason: BUILD_TOOL_OF
   scopes:
     - pattern: "provided"

--- a/.ort.yml
+++ b/.ort.yml
@@ -4,7 +4,7 @@
 excludes:
   paths:
     - comment: It's a test
-      pattern: "src/it/lints-it/**"
+      pattern: "src/it/lints-it/pom.xml"
       reason: BUILD_TOOL_OF
   scopes:
     - pattern: "provided"

--- a/.ort.yml
+++ b/.ort.yml
@@ -4,7 +4,7 @@
 excludes:
   paths:
     - comment: It's a test
-      pattern: "src/it/lints-it/pom.xml"
+      pattern: "@project.version@"
       reason: BUILD_TOOL_OF
   scopes:
     - pattern: "provided"

--- a/.ort.yml
+++ b/.ort.yml
@@ -5,7 +5,7 @@ excludes:
   paths:
     - comment: It's a test
       pattern: "src/it/**"
-      reason: BUILD_TOOL_OF
+      reason: "BUILD_TOOL_OF"
   scopes:
     - pattern: "provided"
       reason: "TEST_DEPENDENCY_OF"

--- a/.ort.yml
+++ b/.ort.yml
@@ -5,7 +5,7 @@ excludes:
   paths:
     - comment: It's a test
       pattern: "src/it/**"
-      reason: "BUILD_TOOL_OF"
+      reason: BUILD_TOOL_OF
   scopes:
     - pattern: "provided"
       reason: "TEST_DEPENDENCY_OF"

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>com.github.volodya-lombrozo</groupId>
       <artifactId>xnav</artifactId>
-      <version>0.1.13</version>
+      <version>0.1.14</version>
     </dependency>
     <dependency>
       <groupId>org.apache.opennlp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>com.github.volodya-lombrozo</groupId>
       <artifactId>xnav</artifactId>
-      <version>0.1.10</version>
+      <version>0.1.13</version>
     </dependency>
     <dependency>
       <groupId>org.apache.opennlp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>com.github.volodya-lombrozo</groupId>
       <artifactId>xnav</artifactId>
-      <version>0.1.14</version>
+      <version>0.1.15</version>
     </dependency>
     <dependency>
       <groupId>org.apache.opennlp</groupId>

--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.lints;
 
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -17,11 +18,6 @@ import org.cactoos.list.ListOf;
  * Lint that ignores linting if {@code +unlint} meta is present.
  *
  * @since 0.0.1
- * @todo #386:30min Replace `XML.xpath()` with `Xnav.path()` usage in defects() method.
- *  Currently, we cannot use `Xnav.path()` method due to
- *  <a href="https://github.com/volodya-lombrozo/xnav/issues/74">this</a> bug.
- *  Once it will be resolved, we should replace `XML.xpath()` with `Xnav.path()`
- *  in order to improve the performance of the `LtUnlint.defects()` execution.
  */
 final class LtUnlint implements Lint<XML> {
 
@@ -57,12 +53,12 @@ final class LtUnlint implements Lint<XML> {
             .filter(defect -> defect.rule().equals(lname))
             .map(Defect::line)
             .collect(Collectors.toList());
-        final List<String> granular = xmir.xpath(
+        final List<String> granular = new Xnav(xmir.inner()).path(
             String.format(
-                "/program/metas/meta[head='unlint' and (tail='%s' or starts-with(tail, '%s:'))]/tail/text()",
+                "/program/metas/meta[head='unlint' and (tail='%s' or starts-with(tail, '%s:'))]/tail",
                 lname, lname
             )
-        );
+        ).map(xnav -> xnav.text().get()).collect(Collectors.toList());
         final boolean global = !granular.isEmpty();
         granular.forEach(
             unlint -> {


### PR DESCRIPTION
In this PR I've replaced `XML.xpath()` with `Xnav.path()`, and upgraded `xnav` version to `0.1.14`.

closes #392