### PR TITLE
feat(#36): incorrect-number-of-attributes

### DIFF
--- a/src/main/java/org/eolang/lints/LtIncorrectNumberOfAttrs.java
+++ b/src/main/java/org/eolang/lints/LtIncorrectNumberOfAttrs.java
@@ -14,7 +14,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
+import org.cactoos.text.TextOf;
+import org.cactoos.text.UncheckedText;
 
 /**
  * Lint to check incorrect number of attributes passed to the object in scope.
@@ -61,7 +64,15 @@ final class LtIncorrectNumberOfAttrs implements Lint<Map<String, XML>> {
 
     @Override
     public String motive() throws IOException {
-        throw new UnsupportedOperationException("#motive()");
+        return new UncheckedText(
+            new TextOf(
+                new ResourceOf(
+                    String.format(
+                        "org/eolang/motives/errors/%s.md", this.name()
+                    )
+                )
+            )
+        ).asString();
     }
 
     /**

--- a/src/main/java/org/eolang/lints/LtIncorrectNumberOfAttrs.java
+++ b/src/main/java/org/eolang/lints/LtIncorrectNumberOfAttrs.java
@@ -4,10 +4,16 @@
  */
 package org.eolang.lints;
 
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
+import org.cactoos.list.ListOf;
 
 /**
  * Lint to check incorrect number of attributes passed to the object in scope.
@@ -17,7 +23,11 @@ final class LtIncorrectNumberOfAttrs implements Lint<Map<String, XML>> {
 
     @Override
     public Collection<Defect> defects(final Map<String, XML> pkg) throws IOException {
-        throw new UnsupportedOperationException("#defects()");
+        final Collection<Defect> defects = new LinkedList<>();
+        // step 1: build map of definitions
+        final Map<String, Integer> definitions = LtIncorrectNumberOfAttrs.objectDefinitions(pkg);
+        System.out.println(definitions);
+        return defects;
     }
 
     @Override
@@ -28,5 +38,27 @@ final class LtIncorrectNumberOfAttrs implements Lint<Map<String, XML>> {
     @Override
     public String motive() throws IOException {
         throw new UnsupportedOperationException("#motive()");
+    }
+
+    /**
+     * Build object definitions.
+     * @param pkg Package to scan
+     * @return Map of object name and attributes count
+     */
+    private static Map<String, Integer> objectDefinitions(final Map<String, XML> pkg) {
+        final Map<String, Integer> definitions = new HashMap<>(0);
+        pkg.forEach(
+            (program, xmir) -> new Xnav(xmir.inner()).element("program")
+                .element("objects")
+                .elements(Filter.withName("o")).forEach(
+                    xob -> {
+                        final List<Xnav> attrs = new ListOf<>();
+                        xob.path("o[@base='∅']").forEach(attrs::add);
+                        final String name = xob.attribute("name").text().orElse("unknown");
+                        definitions.put(name, attrs.size());
+                    }
+                )
+        );
+        return definitions;
     }
 }

--- a/src/main/java/org/eolang/lints/LtIncorrectNumberOfAttrs.java
+++ b/src/main/java/org/eolang/lints/LtIncorrectNumberOfAttrs.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import com.jcabi.xml.XML;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Lint to check incorrect number of attributes passed to the object in scope.
+ * @since 0.0.43
+ */
+final class LtIncorrectNumberOfAttrs implements Lint<Map<String, XML>> {
+
+    @Override
+    public Collection<Defect> defects(final Map<String, XML> pkg) throws IOException {
+        throw new UnsupportedOperationException("#defects()");
+    }
+
+    @Override
+    public String name() {
+        return "incorrect-number-of-attributes";
+    }
+
+    @Override
+    public String motive() throws IOException {
+        throw new UnsupportedOperationException("#motive()");
+    }
+}

--- a/src/main/java/org/eolang/lints/LtIncorrectNumberOfAttrs.java
+++ b/src/main/java/org/eolang/lints/LtIncorrectNumberOfAttrs.java
@@ -13,13 +13,12 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.cactoos.list.ListOf;
 
 /**
  * Lint to check incorrect number of attributes passed to the object in scope.
+ *
  * @since 0.0.43
  */
 final class LtIncorrectNumberOfAttrs implements Lint<Map<String, XML>> {
@@ -28,37 +27,29 @@ final class LtIncorrectNumberOfAttrs implements Lint<Map<String, XML>> {
     public Collection<Defect> defects(final Map<String, XML> pkg) throws IOException {
         final Collection<Defect> defects = new LinkedList<>();
         final Map<String, Integer> definitions = LtIncorrectNumberOfAttrs.objectDefinitions(pkg);
-        // step 2: scan usages
         pkg.forEach(
-            new BiConsumer<String, XML>() {
-                @Override
-                public void accept(final String program, final XML xmir) {
-                    new Xnav(xmir.inner()).path("//o[@base and not(@base='∅')]").forEach(
-                        new Consumer<Xnav>() {
-                            @Override
-                            public void accept(final Xnav xnav) {
-                                final int provided = (int) xnav.elements(Filter.withName("o")).count();
-                                final String object = xnav.attribute("base").text().orElse("unknown");
-                                final Integer expected = definitions.get(object);
-                                if (expected != null && provided != expected) {
-                                    defects.add(
-                                        new Defect.Default(
-                                            LtIncorrectNumberOfAttrs.this.name(),
-                                            Severity.ERROR,
-                                            program,
-                                            Integer.parseInt(xnav.attribute("line").text().orElse("0")),
-                                            String.format(
-                                                "The object %s expects %d arguments, while %d provided",
-                                                object, expected, provided
-                                            )
-                                        )
-                                    );
-                                }
-                            }
+            (program, xmir) -> new Xnav(xmir.inner()).path("//o[@base and not(@base='∅')]")
+                .forEach(
+                    xnav -> {
+                        final int provided = (int) xnav.elements(Filter.withName("o")).count();
+                        final String object = xnav.attribute("base").text().orElse("unknown");
+                        final Integer expected = definitions.get(object);
+                        if (expected != null && provided != expected) {
+                            defects.add(
+                                new Defect.Default(
+                                    this.name(),
+                                    Severity.ERROR,
+                                    program,
+                                    Integer.parseInt(xnav.attribute("line").text().orElse("0")),
+                                    String.format(
+                                        "The object %s expects %d arguments, while %d provided",
+                                        object, expected, provided
+                                    )
+                                )
+                            );
                         }
-                    );
-                }
-            }
+                    }
+                )
         );
         return defects;
     }
@@ -75,6 +66,7 @@ final class LtIncorrectNumberOfAttrs implements Lint<Map<String, XML>> {
 
     /**
      * Build object definitions.
+     *
      * @param pkg Package to scan
      * @return Map of object name and attributes count
      */

--- a/src/main/java/org/eolang/lints/LtIncorrectNumberOfAttrs.java
+++ b/src/main/java/org/eolang/lints/LtIncorrectNumberOfAttrs.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.cactoos.list.ListOf;
 
@@ -40,10 +39,7 @@ final class LtIncorrectNumberOfAttrs implements Lint<Map<String, XML>> {
                             public void accept(final Xnav xnav) {
                                 final int provided = (int) xnav.elements(Filter.withName("o")).count();
                                 final String object = xnav.attribute("base").text().orElse("unknown");
-                                System.out.println(object);
                                 final Integer expected = definitions.get(object);
-                                System.out.println(provided);
-                                System.out.println(expected);
                                 if (expected != null && provided != expected) {
                                     defects.add(
                                         new Defect.Default(

--- a/src/main/java/org/eolang/lints/LtIncorrectNumberOfAttrs.java
+++ b/src/main/java/org/eolang/lints/LtIncorrectNumberOfAttrs.java
@@ -77,7 +77,6 @@ final class LtIncorrectNumberOfAttrs implements Lint<Map<String, XML>> {
 
     /**
      * Build object definitions.
-     *
      * @param pkg Package to scan
      * @return Map of object name and attributes count
      */
@@ -94,7 +93,7 @@ final class LtIncorrectNumberOfAttrs implements Lint<Map<String, XML>> {
                             xob.path("o[@base='∅']").forEach(attrs::add);
                             final String name = xob.attribute("name").text().orElse("unknown");
                             definitions.put(
-                                LtIncorrectNumberOfAttrs.fqnPackaged(name, xml), attrs.size()
+                                LtIncorrectNumberOfAttrs.packagedFqn(name, xml), attrs.size()
                             );
                         }
                     );
@@ -103,7 +102,13 @@ final class LtIncorrectNumberOfAttrs implements Lint<Map<String, XML>> {
         return definitions;
     }
 
-    private static String fqnPackaged(final String oname, final Xnav xml) {
+    /**
+     * Packaged FQN.
+     * @param oname Object name
+     * @param xml XML
+     * @return Packaged FQN of object name
+     */
+    private static String packagedFqn(final String oname, final Xnav xml) {
         final String pack;
         final List<Xnav> packages = xml.element("program")
             .element("metas")

--- a/src/main/java/org/eolang/lints/WpaLints.java
+++ b/src/main/java/org/eolang/lints/WpaLints.java
@@ -26,7 +26,8 @@ final class WpaLints extends IterableEnvelope<Lint<Map<String, XML>>> {
                 new LtUnitTestWithoutLiveFile(),
                 new LtIncorrectAlias(),
                 new LtObjectIsNotUnique(),
-                new LtAtomIsNotUnique()
+                new LtAtomIsNotUnique(),
+                new LtIncorrectNumberOfAttrs()
             )
         );
     }

--- a/src/main/resources/org/eolang/motives/errors/incorrect-number-of-attributes.md
+++ b/src/main/resources/org/eolang/motives/errors/incorrect-number-of-attributes.md
@@ -1,7 +1,7 @@
 # Incorrect Number Of Attributes
 
-The number of provided attributes to object should match with the number of its
-declared attributes.
+The number of provided attributes to the object should match with the number of
+its declared attributes.
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/errors/incorrect-number-of-attributes.md
+++ b/src/main/resources/org/eolang/motives/errors/incorrect-number-of-attributes.md
@@ -1,6 +1,6 @@
 # Incorrect Number Of Attributes
 
-The number of provided attributes to object should match with the number of
+The number of provided attributes to object should match with the number of its
 declared attributes.
 
 Incorrect:

--- a/src/main/resources/org/eolang/motives/errors/incorrect-number-of-attributes.md
+++ b/src/main/resources/org/eolang/motives/errors/incorrect-number-of-attributes.md
@@ -1,0 +1,38 @@
+# Incorrect Number Of Attributes
+
+The number of provided attributes to object should match with the number of
+declared attributes.
+
+Incorrect:
+
+`foo.eo`:
+
+```eo
+# Its foo with one attribute.
+[at] > foo
+```
+
+`bar.eo`:
+
+```eo
+# Its bar.
+[args] > bar
+  foo 1 2
+```
+
+Correct:
+
+`foo.eo`:
+
+```eo
+# Its foo with one attribute.
+[at] > foo
+```
+
+`bar.eo`:
+
+```eo
+# Its bar.
+[args] > bar
+  foo 1
+```

--- a/src/test/java/org/eolang/lints/LtIncorrectNumberOfAttrsTest.java
+++ b/src/test/java/org/eolang/lints/LtIncorrectNumberOfAttrsTest.java
@@ -291,7 +291,8 @@ final class LtIncorrectNumberOfAttrsTest {
                                 "\n",
                                 "# Usage of A and B objects with vertical application.",
                                 "[] > app",
-                                "  b 1",
+                                "  b",
+                                "    0",
                                 "    a 0"
                             )
                         ).parsed()
@@ -299,6 +300,52 @@ final class LtIncorrectNumberOfAttrsTest {
                 )
             ),
             Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void catchesInCorrectAttributesInVerticalApplication() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects should not be empty, since attributes are passed incorrectly",
+            new LtIncorrectNumberOfAttrs().defects(
+                new MapOf<>(
+                    new MapEntry<>(
+                        "x",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# X with one attribute.",
+                                "[pos sigma] > x",
+                                ""
+                            )
+                        ).parsed()
+                    ),
+                    new MapEntry<>(
+                        "y",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# Y with two attributes.",
+                                "[left right] > y"
+                            )
+                        ).parsed()
+                    ),
+                    new MapEntry<>(
+                        "xy-app",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# Usage of X and Y objects with vertical application.",
+                                "[] > app",
+                                "  y",
+                                "    1",
+                                "    x 0"
+                            )
+                        ).parsed()
+                    )
+                )
+            ),
+            Matchers.hasSize(Matchers.greaterThan(0))
         );
     }
 }

--- a/src/test/java/org/eolang/lints/LtIncorrectNumberOfAttrsTest.java
+++ b/src/test/java/org/eolang/lints/LtIncorrectNumberOfAttrsTest.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import com.jcabi.xml.XML;
+import java.io.IOException;
+import org.cactoos.map.MapEntry;
+import org.cactoos.map.MapOf;
+import org.eolang.parser.EoSyntax;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link LtIncorrectNumberOfAttrs}.
+ * @since 0.0.43
+ */
+final class LtIncorrectNumberOfAttrsTest {
+
+    @Test
+    void catchesIncorrectNumberOfAttributes() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are empty, but they should not",
+            new LtIncorrectNumberOfAttrs().defects(
+                new MapOf<String, XML>(
+                    new MapEntry<>(
+                        "foo",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# Foo with one attribute.",
+                                "[a] > foo"
+                            )
+                        ).parsed()
+                    ),
+                    new MapEntry<>(
+                        "app",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# App uses foo with two attributes instead.",
+                                "[a b] > app",
+                                "  foo a b"
+                            )
+                        ).parsed()
+                    )
+                )
+            ),
+            Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
+}

--- a/src/test/java/org/eolang/lints/LtIncorrectNumberOfAttrsTest.java
+++ b/src/test/java/org/eolang/lints/LtIncorrectNumberOfAttrsTest.java
@@ -159,6 +159,8 @@ final class LtIncorrectNumberOfAttrsTest {
                         new EoSyntax(
                             String.join(
                                 "\n",
+                                "+package broken",
+                                "",
                                 "# F with one attribute.",
                                 "[pos] > f",
                                 "",
@@ -171,6 +173,132 @@ final class LtIncorrectNumberOfAttrsTest {
                 )
             ),
             Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
+
+    @Test
+    void ignoresUndefinedObjectInPackage() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects should empty, since object is not defined in provided package",
+            new LtIncorrectNumberOfAttrs().defects(
+                new MapOf<String, XML>(
+                    new MapEntry<>(
+                        "hello",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# Say hello.",
+                                "[content] > hello"
+                            )
+                        ).parsed()
+                    ),
+                    new MapEntry<>(
+                        "app",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# App uses undeclared object.",
+                                "[] > app",
+                                "  hello \"f\"",
+                                "  bye 0x1"
+                            )
+                        ).parsed()
+                    )
+                )
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void understandsPackages() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects should be empty, since object is expected to be packaged",
+            new LtIncorrectNumberOfAttrs().defects(
+                new MapOf<>(
+                    new MapEntry<>(
+                        "foo-unpackaged",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# An unpackaged foo.",
+                                "[] > foo"
+                            )
+                        ).parsed()
+                    ),
+                    new MapEntry<>(
+                        "foo-packaged",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "+package f",
+                                "",
+                                "# Packaged foo in f.",
+                                "[bar] > foo"
+                            )
+                        ).parsed()
+                    ),
+                    new MapEntry<>(
+                        "res",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "+alias f.foo",
+                                "",
+                                "# Resolver application that uses f.foo.",
+                                "[args] > app",
+                                "  foo args > @"
+                            )
+                        ).parsed()
+                    )
+                )
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void allowsCorrectAttributesInVerticalApplication() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects should be empty, since attributes are correct in vertical application",
+            new LtIncorrectNumberOfAttrs().defects(
+                new MapOf<>(
+                    new MapEntry<>(
+                        "a",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# A with one attribute.",
+                                "[pos] > a",
+                                ""
+                            )
+                        ).parsed()
+                    ),
+                    new MapEntry<>(
+                        "b",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# B with two attributes.",
+                                "[left right] > b"
+                            )
+                        ).parsed()
+                    ),
+                    new MapEntry<>(
+                        "usage",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# Usage of A and B objects with vertical application.",
+                                "[] > app",
+                                "  b 1",
+                                "    a 0"
+                            )
+                        ).parsed()
+                    )
+                )
+            ),
+            Matchers.emptyIterable()
         );
     }
 }

--- a/src/test/java/org/eolang/lints/LtIncorrectNumberOfAttrsTest.java
+++ b/src/test/java/org/eolang/lints/LtIncorrectNumberOfAttrsTest.java
@@ -51,4 +51,41 @@ final class LtIncorrectNumberOfAttrsTest {
             Matchers.hasSize(Matchers.greaterThan(0))
         );
     }
+
+    @Test
+    void catchesMultipleHighLevelObjectsInFile() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are empty, but they should not",
+            new LtIncorrectNumberOfAttrs().defects(
+                new MapOf<String, XML>(
+                    new MapEntry<>(
+                        "std",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# Std.",
+                                "[a] > std",
+                                "",
+                                "# Stf.",
+                                "[] > stf"
+                            )
+                        ).parsed()
+                    ),
+                    new MapEntry<>(
+                        "usage",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# App uses std and stf.",
+                                "[args] > app",
+                                "  std 0",
+                                "  stf 1"
+                            )
+                        ).parsed()
+                    )
+                )
+            ),
+            Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
 }

--- a/src/test/java/org/eolang/lints/LtIncorrectNumberOfAttrsTest.java
+++ b/src/test/java/org/eolang/lints/LtIncorrectNumberOfAttrsTest.java
@@ -88,4 +88,89 @@ final class LtIncorrectNumberOfAttrsTest {
             Matchers.hasSize(Matchers.greaterThan(0))
         );
     }
+
+    @Test
+    void allowsCorrectNumberOfAttributes() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are not empty, but they should",
+            new LtIncorrectNumberOfAttrs().defects(
+                new MapOf<String, XML>(
+                    new MapEntry<>(
+                        "a",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# A with one attribute.",
+                                "[pos] > a"
+                            )
+                        ).parsed()
+                    ),
+                    new MapEntry<>(
+                        "app",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# App uses a with correct number of arguments.",
+                                "[] > app",
+                                "  a 0"
+                            )
+                        ).parsed()
+                    )
+                )
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void allowsCorrectAttributesCountInSameFile() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are not empty, but they should",
+            new LtIncorrectNumberOfAttrs().defects(
+                new MapOf<>(
+                    new MapEntry<>(
+                        "single",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# A with one attribute.",
+                                "[pos] > a",
+                                "",
+                                "# B uses A with one attribute",
+                                "[] > b",
+                                "  a 52"
+                            )
+                        ).parsed()
+                    )
+                )
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void catchesIncorrectPassedNumberOfAttributesInSameFile() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are empty, but they should not",
+            new LtIncorrectNumberOfAttrs().defects(
+                new MapOf<>(
+                    new MapEntry<>(
+                        "single-broken",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "# F with one attribute.",
+                                "[pos] > f",
+                                "",
+                                "# Z uses F with two attributes",
+                                "[] > z",
+                                "  f 52 42"
+                            )
+                        ).parsed()
+                    )
+                )
+            ),
+            Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
 }


### PR DESCRIPTION
In this PR I've introduced new lint: `incorrect-number-of-attributes`, that issues `ERROR` defect if the number of provided attributes to object does not match with the number of its declared attributes.

closes #36
History:
- **feat(#36): test**
- **feat(#36): objectDefinitions**
- **feat(#36): scan usages**
- **feat(#36): more tests**
- **feat(#36): packaged fqn, more tests**
- **feat(#36): correct vertical application**
- **feat(#36): clean for qulice**
- **feat(#36): integrate into WpaLints**
- **feat(#36): motive**
- **feat(#36): packagedFqn**
- **feat(#36): more clear**
- **feat(#36): more clear 2x**
- **feat(#36): polish**
