### PR TITLE
feat(#93): `duplicate-as-attribute` lint

### DIFF
--- a/src/main/resources/org/eolang/lints/names/duplicate-as-attribute.xsl
+++ b/src/main/resources/org/eolang/lints/names/duplicate-as-attribute.xsl
@@ -11,7 +11,7 @@
   <xsl:key name="as-key" match="o/@as" use="."/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o">
+      <xsl:for-each select="//o[o[@as]]">
         <xsl:variable name="oname" select="@name"/>
         <xsl:variable name="line" select="eo:lineno(@line)"/>
         <xsl:variable name="context" select="eo:defect-context(.)"/>

--- a/src/main/resources/org/eolang/lints/names/duplicate-as-attribute.xsl
+++ b/src/main/resources/org/eolang/lints/names/duplicate-as-attribute.xsl
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="duplicate-as-attribute">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:key name="as-key" match="o/@as" use="."/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o">
+        <xsl:variable name="oname" select="@name"/>
+        <xsl:variable name="line" select="eo:lineno(@line)"/>
+        <xsl:variable name="context" select="eo:defect-context(.)"/>
+        <xsl:variable name="attributes" select="o/@as"/>
+        <xsl:for-each select="distinct-values($attributes)">
+          <xsl:variable name="current" select="."/>
+          <xsl:variable name="duplicates" select="count($attributes[.= $current])"/>
+          <xsl:if test="$duplicates &gt; 1">
+            <defect>
+              <xsl:attribute name="line">
+                <xsl:value-of select="$line"/>
+              </xsl:attribute>
+              <xsl:if test="$line = '0'">
+                <xsl:attribute name="context">
+                  <xsl:value-of select="$context"/>
+                </xsl:attribute>
+              </xsl:if>
+              <xsl:attribute name="severity">warning</xsl:attribute>
+              <xsl:text>The </xsl:text>
+              <xsl:choose>
+                <xsl:when test="$oname">
+                  <xsl:text>object </xsl:text>
+                  <xsl:value-of select="eo:escape($oname)"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:text>anonymous object</xsl:text>
+                </xsl:otherwise>
+              </xsl:choose>
+              <xsl:text> has duplicated @as attribute </xsl:text>
+              <xsl:value-of select="eo:escape($current)"/>
+            </defect>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/names/duplicate-as-attribute.md
+++ b/src/main/resources/org/eolang/motives/names/duplicate-as-attribute.md
@@ -1,0 +1,23 @@
+# Duplicate `@as` Attribute
+
+In [XMIR], object should not have `@as` attributes duplicated inside.
+
+Incorrect:
+
+```xml
+<o base="foo">
+  <o base="f1" as="bar"/>
+  <o base="f1" as="bar"/>
+</o>
+```
+
+Correct:
+
+```xml
+<o base="foo">
+  <o base="f1" as="bar"/>
+  <o base="f1" as="buzz"/>
+</o>
+```
+
+[XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html

--- a/src/test/resources/org/eolang/lints/packs/duplicate-as-attribute/allows-as-distinct-attributes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/duplicate-as-attribute/allows-as-distinct-attributes.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/duplicate-as-attribute.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+document: |
+  <program>
+    <objects>
+      <o base="t">
+        <o base="f1" as="x"/>
+        <o base="f2" as="foo"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/duplicate-as-attribute/allows-only-one-attribute.yaml
+++ b/src/test/resources/org/eolang/lints/packs/duplicate-as-attribute/allows-only-one-attribute.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/duplicate-as-attribute.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+document: |
+  <program>
+    <objects>
+      <o base="foo">
+        <o base="f1" as="bar"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/duplicate-as-attribute/allows-when-attributes-empty.yaml
+++ b/src/test/resources/org/eolang/lints/packs/duplicate-as-attribute/allows-when-attributes-empty.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/duplicate-as-attribute.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+document: |
+  <program>
+    <objects>
+      <o base="man">
+        <o base="home"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/duplicate-as-attribute/catches-as-duplicates.yaml
+++ b/src/test/resources/org/eolang/lints/packs/duplicate-as-attribute/catches-as-duplicates.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/duplicate-as-attribute.xsl
+asserts:
+  - /defects[count(defect[@context and @severity='warning'])=1]
+document: |
+  <program>
+    <objects>
+      <o base="t">
+        <o base="f1" as="foo"/>
+        <o base="f2" as="foo"/>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/duplicate-as-attribute/checks-only-parent-level-attributes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/duplicate-as-attribute/checks-only-parent-level-attributes.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/duplicate-as-attribute.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+document: |
+  <program>
+    <objects>
+      <o base="foo">
+        <o base="f1" as="bar"/>
+        <o base="f2">
+          <o base="f3-nested" as="bar"/>
+        </o>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/duplicate-as-attribute/reports-line-correctly.yaml
+++ b/src/test/resources/org/eolang/lints/packs/duplicate-as-attribute/reports-line-correctly.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/duplicate-as-attribute.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='2']
+document: |
+  <program>
+    <objects>
+      <o base="foo" line="2">
+        <o base="f1" as="bar"/>
+        <o base="f2" as="bar"/>
+      </o>
+    </objects>
+  </program>


### PR DESCRIPTION
In this PR I've introduced new lint: `duplicate-as-attribute`, which issues `warning` defect if an object in XMIR has duplicate `@as` attributes on its first level of depth.

closes #93