### PR TITLE
feat(#165): `reserved-name` lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ mochawesome-report/
 node_modules/
 target/
 temp/
+cloned/

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ mochawesome-report/
 node_modules/
 target/
 temp/
-cloned/

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,26 @@
       <version>3.0.2</version>
     </dependency>
     <dependency>
+      <groupId>com.jcabi</groupId>
+      <artifactId>jcabi-http</artifactId>
+      <!-- version from the parent pom -->
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-common</artifactId>
+      <version>3.1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+      <!-- version from the parent pom -->
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.parsson</groupId>
+      <artifactId>parsson</artifactId>
+      <version>1.1.6</version>
+    </dependency>
+    <dependency>
       <groupId>com.yegor256</groupId>
       <artifactId>tojos</artifactId>
       <version>0.18.5</version>

--- a/pom.xml
+++ b/pom.xml
@@ -138,24 +138,9 @@
       <version>3.0.2</version>
     </dependency>
     <dependency>
-      <groupId>com.jcabi</groupId>
-      <artifactId>jcabi-http</artifactId>
-      <!-- version from the parent pom -->
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.core</groupId>
-      <artifactId>jersey-common</artifactId>
-      <version>3.1.2</version>
-    </dependency>
-    <dependency>
-      <groupId>jakarta.json</groupId>
-      <artifactId>jakarta.json-api</artifactId>
-      <!-- version from the parent pom -->
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.parsson</groupId>
-      <artifactId>parsson</artifactId>
-      <version>1.1.6</version>
+      <groupId>org.eclipse.jgit</groupId>
+      <artifactId>org.eclipse.jgit</artifactId>
+      <version>5.13.3.202401111512-r</version>
     </dependency>
     <dependency>
       <groupId>com.yegor256</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,7 @@
                     <class>org.eolang.lints.LtUnlintNonExistingDefectWpaTest</class>
                     <class>org.eolang.lints.LtTestNotVerbTest</class>
                     <class>org.eolang.lints.WpaLintsTest</class>
+                    <class>org.eolang.lints.LtReservedNameTest</class>
                   </excludedTestClasses>
                 </configuration>
               </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -438,6 +438,7 @@
         <version>1.13.0</version>
         <executions>
           <execution>
+            <id>download-model</id>
             <phase>process-resources</phase>
             <goals>
               <goal>wget</goal>
@@ -448,26 +449,36 @@
               <outputDirectory>${project.build.directory}/classes</outputDirectory>
             </configuration>
           </execution>
+          <execution>
+            <id>download-home</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://github.com/objectionary/home/archive/refs/heads/master.zip</url>
+              <outputDirectory>${project.build.directory}/downloaded</outputDirectory>
+              <outputFileName>home.zip</outputFileName>
+              <skipCache>true</skipCache>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>3.1.0</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <!-- version from the parent pom -->
         <executions>
           <execution>
             <phase>generate-sources</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
             <configuration>
-              <executable>git</executable>
-              <arguments>
-                <argument>clone</argument>
-                <argument>https://github.com/objectionary/home.git</argument>
-                <argument>${project.build.directory}/cloned/home</argument>
-              </arguments>
+              <target>
+                <unzip src="${project.build.directory}/downloaded/home.zip" dest="${project.build.directory}/downloaded"/>
+              </target>
             </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>
@@ -482,10 +493,10 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/classes/cloned/home</outputDirectory>
+              <outputDirectory>${project.build.directory}/classes/downloaded/home</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${project.build.directory}/cloned/home</directory>
+                  <directory>${project.build.directory}/downloaded/home-master</directory>
                   <filtering>false</filtering>
                 </resource>
               </resources>

--- a/pom.xml
+++ b/pom.xml
@@ -138,11 +138,6 @@
       <version>3.0.2</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jgit</groupId>
-      <artifactId>org.eclipse.jgit</artifactId>
-      <version>5.13.3.202401111512-r</version>
-    </dependency>
-    <dependency>
       <groupId>com.yegor256</groupId>
       <artifactId>tojos</artifactId>
       <version>0.18.5</version>
@@ -450,6 +445,49 @@
               <url>https://opennlp.sourceforge.net/models-1.5/en-pos-perceptron.bin</url>
               <outputFileName>en-pos-perceptron.bin</outputFileName>
               <outputDirectory>${project.build.directory}/classes</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>git</executable>
+              <arguments>
+                <argument>clone</argument>
+                <argument>https://github.com/objectionary/home.git</argument>
+                <argument>${project.build.directory}/cloned/home</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <!-- version from the parent pom -->
+        <executions>
+          <execution>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/classes/cloned/home</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.build.directory}/cloned/home</directory>
+                  <filtering>false</filtering>
+                </resource>
+              </resources>
             </configuration>
           </execution>
         </executions>

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -109,8 +109,14 @@ final class LtReservedName implements Lint<XML> {
         final URL resource = Thread.currentThread().getContextClassLoader().getResource(location);
         final Predicate<Path> sources = p -> {
             final String file = p.toString().replace("\\", "/");
-            return file.endsWith(".eo") &&
-                file.contains(Path.of(location).resolve("objects").toString().replace("\\", "/"));
+            return file.endsWith(".eo")
+                && file.contains(
+                    Path.of(location)
+                        .resolve("objects")
+                        .resolve("org")
+                        .resolve("eolang")
+                        .toString().replace("\\", "/")
+            );
         };
         if ("jar".equals(resource.getProtocol())) {
             final URI uri = URI.create(

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -50,6 +50,7 @@ final class LtReservedName implements Lint<XML> {
 
     /**
      * Reserved names.
+     * The key is object name, the value is the path to EO file.
      */
     private final Map<String, String> reserved;
 

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -108,9 +108,9 @@ final class LtReservedName implements Lint<XML> {
         final Map<String, String> names = new HashMap<>(64);
         final URL resource = Thread.currentThread().getContextClassLoader().getResource(location);
         final Predicate<Path> sources = p -> {
-            final String file = p.toString();
-            return file.endsWith(".eo")
-                && file.contains(String.format("%s/objects", location));
+            final String file = p.toString().replace("\\", "/");
+            return file.endsWith(".eo") &&
+                file.contains(Path.of(location).resolve("objects").toString().replace("\\", "/"));
         };
         if ("jar".equals(resource.getProtocol())) {
             final URI uri = URI.create(

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -43,7 +43,7 @@ final class LtReservedName implements Lint<XML> {
     /**
      * Home objects regex.
      */
-    private static final Pattern HOME_OBJECTS = Pattern.compile(".*/cloned/home/objects");
+    private static final Pattern HOME_OBJECTS = Pattern.compile(".*/downloaded/home/objects");
 
     /**
      * Non-unix file separators.
@@ -60,7 +60,7 @@ final class LtReservedName implements Lint<XML> {
      * Ctor.
      */
     LtReservedName() {
-        this(LtReservedName.home(Paths.get("cloned", "home").toString()));
+        this(LtReservedName.home(Paths.get("downloaded", "home").toString()));
     }
 
     /**
@@ -120,12 +120,12 @@ final class LtReservedName implements Lint<XML> {
 
     /**
      * Locate reserved names from home EO objects.
-     * During the `generate-sources` maven phase we are cloning <a href="https://github.com/objectionary/home">home repo</a>
-     * as the source of object names. After repo cloning, during `process-resources` phase,
-     * we copy cloned repo to classes in lints JAR: `${project.build.directory}/classes/`.
+     * During the `generate-sources` maven phase we are downloading <a href="https://github.com/objectionary/home">home repo</a>
+     * as the source of object names. After repo downloaded, during `process-resources` phase,
+     * we copy downloaded repo to classes in lints JAR: `${project.build.directory}/classes/`.
      * This is mandatory step in order to provide access to the home repo files, when the programs
      * are linted from the outside the lints project, using lints as dependency. While, in local
-     * tests, cloned home repo is accessed as normal file.
+     * tests, home repo is accessed as normal file.
      * Both methods depend on the same directory, which we pass in the ctor, the only difference
      * in the term of access - for JAR we need to "mount" the file system using {@link FileSystem}.
      * @param location Location of home repo.

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XML;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Lint for reserved names.
+ * @since 0.0.43
+ */
+final class LtReservedName implements Lint<XML> {
+
+    /**
+     * Reserved names.
+     */
+    private final List<String> reserved;
+
+    /**
+     * Ctor.
+     *
+     * @param names Reserved names
+     */
+    LtReservedName(final List<String> names) {
+        this.reserved = names;
+    }
+
+    @Override
+    public String name() {
+        return "reserved-name";
+    }
+
+    @Override
+    public Collection<Defect> defects(final XML xmir) throws IOException {
+        // fetch objects from home: https://github.com/objectionary/home/tree/master/objects/org/eolang
+        // put into resources
+        // parse them into .xmir
+        final Collection<Defect> defects = new LinkedList<>();
+        final Xnav program = new Xnav(xmir.inner());
+        program.path("//o[@name]")
+            .forEach(
+                object -> {
+                    final String oname = object.attribute("name").text().get();
+                    if (this.reserved.contains(String.format("org.eolang.%s", oname))) {
+                        defects.add(
+                            new Defect.Default(
+                                this.name(),
+                                Severity.WARNING,
+                                program.element("program").attribute("name")
+                                    .text().orElse("unknown"),
+                                Integer.parseInt(object.attribute("line").text().orElse("0")),
+                                String.format(
+                                    "Object name %s is already reserved by object in the org.eolang package",
+                                    oname
+                                )
+                            )
+                        );
+                    }
+                }
+            );
+        return defects;
+    }
+
+    @Override
+    public String motive() throws IOException {
+        throw new UnsupportedOperationException("#motive()");
+    }
+}

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -54,7 +54,7 @@ final class LtReservedName implements Lint<XML> {
             .forEach(
                 object -> {
                     final String oname = object.attribute("name").text().get();
-                    System.out.println(oname);
+                    System.out.println(this.reserved);
                     if (this.reserved.contains(oname)) {
                         defects.add(
                             new Defect.Default(
@@ -82,6 +82,7 @@ final class LtReservedName implements Lint<XML> {
                 "\n",
                 "# Foo.",
                 "[] > foo",
+                "  42 > boom",
                 "# Bar.",
                 "[] > bar"
             )

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -120,6 +120,14 @@ final class LtReservedName implements Lint<XML> {
 
     /**
      * Locate reserved names from home EO objects.
+     * During the `generate-sources` maven phase we are cloning <a href="https://github.com/objectionary/home">home repo</a>
+     * as the source of object names. After repo cloning, during `process-resources` phase,
+     * we copy cloned repo to classes in lints JAR: `${project.build.directory}/classes/`.
+     * This is mandatory step in order to provide access to the home repo files, when the programs
+     * are linted from the outside the lints project, using lints as dependency. While, in local
+     * tests, cloned home repo is accessed as normal file.
+     * Both methods depend on the same directory, which we pass in the ctor, the only difference
+     * in the term of access - for JAR we need to "mount" the file system using {@link FileSystem}.
      * @param location Location of home repo.
      * @return Map of reserved names
      */

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -6,6 +6,7 @@ package org.eolang.lints;
 
 import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -129,7 +130,7 @@ final class LtReservedName implements Lint<XML> {
             }
         } else {
             try {
-                Files.walk(Paths.get(resource.getPath()))
+                Files.walk(new File(resource.getFile()).toPath())
                     .filter(sources)
                     .forEach(LtReservedName.file(location, names));
             } catch (final IOException exception) {

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -46,7 +46,7 @@ final class LtReservedName implements Lint<XML> {
      * Ctor.
      */
     LtReservedName() {
-        this(LtReservedName.home("cloned/home"));
+        this(LtReservedName.home(String.format("cloned%shome", File.separator)));
     }
 
     /**

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -33,7 +33,7 @@ import org.eolang.parser.EoSyntax;
 /**
  * Lint for reserved names.
  *
- * @since 0.0.43
+ * @since 0.0.44
  */
 final class LtReservedName implements Lint<XML> {
 

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -6,10 +6,10 @@ package org.eolang.lints;
 
 import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -130,11 +130,13 @@ final class LtReservedName implements Lint<XML> {
             }
         } else {
             try {
-                Files.walk(new File(resource.getFile()).toPath())
+                Files.walk(Paths.get(resource.toURI()))
                     .filter(sources)
                     .forEach(LtReservedName.file(location, names));
             } catch (final IOException exception) {
                 throw new IllegalStateException("Failed to walk through files", exception);
+            } catch (final URISyntaxException exception) {
+                throw new IllegalStateException("URI syntax is broken", exception);
             }
         }
         return names;

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -196,6 +196,6 @@ final class LtReservedName implements Lint<XML> {
 
     private static String prettyEoPath(final Path path, final String location) {
         return path.toString().replace(String.format("%s/objects", location), "")
-            .substring(1).replace(File.separator, ".");
+            .substring(1).replace("/", ".").replace("\"", ".");
     }
 }

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -220,7 +220,9 @@ final class LtReservedName implements Lint<XML> {
                 oname ->
                     names.put(
                         oname,
-                        LtReservedName.HOME_OBJECTS.matcher(path.toString())
+                        LtReservedName.HOME_OBJECTS.matcher(
+                            path.toString().replaceAll("\\\\", "/")
+                            )
                             .replaceFirst("")
                             .substring(1)
                             .replace("/", ".")

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import org.cactoos.list.ListOf;
 
 /**
  * Lint for reserved names.
@@ -21,6 +22,13 @@ final class LtReservedName implements Lint<XML> {
      * Reserved names.
      */
     private final List<String> reserved;
+
+    /**
+     * Ctor.
+     */
+    LtReservedName() {
+        this(LtReservedName.reservedInHome());
+    }
 
     /**
      * Ctor.
@@ -38,16 +46,13 @@ final class LtReservedName implements Lint<XML> {
 
     @Override
     public Collection<Defect> defects(final XML xmir) throws IOException {
-        // fetch objects from home: https://github.com/objectionary/home/tree/master/objects/org/eolang
-        // put into resources
-        // parse them into .xmir
         final Collection<Defect> defects = new LinkedList<>();
         final Xnav program = new Xnav(xmir.inner());
         program.path("//o[@name]")
             .forEach(
                 object -> {
                     final String oname = object.attribute("name").text().get();
-                    if (this.reserved.contains(String.format("org.eolang.%s", oname))) {
+                    if (this.reserved.contains(oname)) {
                         defects.add(
                             new Defect.Default(
                                 this.name(),
@@ -56,7 +61,7 @@ final class LtReservedName implements Lint<XML> {
                                     .text().orElse("unknown"),
                                 Integer.parseInt(object.attribute("line").text().orElse("0")),
                                 String.format(
-                                    "Object name %s is already reserved by object in the org.eolang package",
+                                    "Object name \"%s\" is already reserved by object in the org.eolang package",
                                     oname
                                 )
                             )
@@ -65,6 +70,14 @@ final class LtReservedName implements Lint<XML> {
                 }
             );
         return defects;
+    }
+
+    private static List<String> reservedInHome() {
+        // fetch objects from home with tag: https://github.com/objectionary/home/tree/master/objects/org/eolang
+        // put into resources
+        // parse them into .xmir
+        // find each name -> remove `org.eolang.<package>.` part
+        return new ListOf<>();
     }
 
     @Override

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -46,7 +46,7 @@ final class LtReservedName implements Lint<XML> {
      * Ctor.
      */
     LtReservedName() {
-        this(LtReservedName.home(String.format("cloned%shome", File.separator)));
+        this(LtReservedName.home(Paths.get("cloned", "home").toString()));
     }
 
     /**

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -48,6 +48,7 @@ final class LtReservedName implements Lint<XML> {
     public Collection<Defect> defects(final XML xmir) throws IOException {
         final Collection<Defect> defects = new LinkedList<>();
         final Xnav program = new Xnav(xmir.inner());
+        // move to the xpath @name = ...values
         program.path("//o[@name]")
             .forEach(
                 object -> {

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -44,6 +44,11 @@ final class LtReservedName implements Lint<XML> {
     private static final Pattern HOME_OBJECTS = Pattern.compile(".*/cloned/home/objects");
 
     /**
+     * Non-unix file separators.
+     */
+    private static final Pattern NON_UNIX = Pattern.compile("\\\\");
+
+    /**
      * Reserved names.
      */
     private final Map<String, String> reserved;
@@ -221,7 +226,7 @@ final class LtReservedName implements Lint<XML> {
                     names.put(
                         oname,
                         LtReservedName.HOME_OBJECTS.matcher(
-                            path.toString().replaceAll("\\\\", "/")
+                            LtReservedName.NON_UNIX.matcher(path.toString()).replaceAll("/")
                             )
                             .replaceFirst("")
                             .substring(1)

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -6,6 +6,7 @@ package org.eolang.lints;
 
 import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -154,12 +155,7 @@ final class LtReservedName implements Lint<XML> {
             }
             LtReservedName.processXmir(
                 parsed,
-                oname ->
-                    names.put(
-                        oname,
-                        eo.toString().replace(String.format("%s/objects", location), "")
-                            .substring(1).replace("/", ".")
-                    )
+                oname -> names.put(oname, LtReservedName.prettyEoPath(eo, location))
             );
         };
     }
@@ -187,12 +183,7 @@ final class LtReservedName implements Lint<XML> {
             }
             LtReservedName.processXmir(
                 parsed,
-                oname ->
-                    names.put(
-                        oname,
-                        eo.toString().replace(String.format("%s/objects", location), "")
-                            .substring(1).replace("/", ".")
-                    )
+                oname -> names.put(oname, LtReservedName.prettyEoPath(eo, location))
             );
         };
     }
@@ -201,5 +192,10 @@ final class LtReservedName implements Lint<XML> {
         new Xnav(xmir.inner()).path("/program/objects/o/@name")
             .map(oname -> oname.text().get())
             .forEach(each);
+    }
+
+    private static String prettyEoPath(final Path path, final String location) {
+        return path.toString().replace(String.format("%s/objects", location), "")
+            .substring(1).replace(File.separator, ".");
     }
 }

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -170,9 +170,9 @@ final class LtReservedName implements Lint<XML> {
     }
 
     /**
-     * Process home EO objects from regular file.
-     * @param names Names
-     * @return File consumer from path
+     * Names in EO file.
+     * @param path Path to EO file
+     * @return Map of names, the key is object name, the value us path
      */
     private static Map<String, String> namesInFile(final Path path) {
         final XML parsed;
@@ -189,9 +189,9 @@ final class LtReservedName implements Lint<XML> {
     }
 
     /**
-     * Process home EO objects from JAR.
-     * @param names Names
-     * @return JAR consumer from path
+     * Names in EO file from JAR.
+     * @param path Path to EO file in JAR
+     * @return Map of names, the key is object name, the value us path
      * @checkstyle IllegalCatchCheck (15 lines)
      */
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
@@ -209,10 +209,10 @@ final class LtReservedName implements Lint<XML> {
     }
 
     /**
-     * Process names of high-level objects from XMIR.
+     * High-level object names in XMIR.
      * @param xmir XMIR
-     * @param names Aggregated names
      * @param path EO source file path
+     * @return Map of object names in XMIR
      */
     private static Map<String, String> namesInXmir(final XML xmir, final Path path) {
         final Map<String, String> names = new HashMap<>(64);

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -174,9 +174,8 @@ final class LtReservedName implements Lint<XML> {
         return eo -> {
             final XML parsed;
             try {
-                parsed = new EoSyntax(
-                    "reserved", new UncheckedInput(new InputOf(eo.toFile()))
-                ).parsed();
+                parsed = new EoSyntax("reserved", new UncheckedInput(new InputOf(eo.toFile())))
+                    .parsed();
             } catch (final IOException exception) {
                 throw new IllegalStateException(
                     String.format("Failed to parse EO source in \"%s\"", eo),
@@ -198,9 +197,7 @@ final class LtReservedName implements Lint<XML> {
         return eo -> {
             final XML parsed;
             try (InputStream input = Files.newInputStream(eo)) {
-                parsed = new EoSyntax(
-                    "reserved", new TextOf(input).asString()
-                ).parsed();
+                parsed = new EoSyntax("reserved", new TextOf(input).asString()).parsed();
             } catch (final Exception exception) {
                 throw new IllegalStateException(
                     String.format("Failed to parse EO source in \"%s\"", eo),

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -6,7 +6,6 @@ package org.eolang.lints;
 
 import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;

--- a/src/main/java/org/eolang/lints/MonoLints.java
+++ b/src/main/java/org/eolang/lints/MonoLints.java
@@ -19,6 +19,12 @@ import org.cactoos.list.ListOf;
  * {@link PkMono} and {@link PkWpa} via {@link MonoLintNames}, to mutually ignore other
  * scope lints in both: {@link LtUnlintNonExistingDefect} and {@link LtUnlintNonExistingDefectWpa}
  * without causing recursion errors.
+ * @todo #165:60min Add {@link LtReservedName} to the LINTS Mono pipeline.
+ *  Currently, it will cause timeout exceptions in several places in tests, due to
+ *  the design of {@link LtReservedName}. Now, scans all the home EO objects, pulled
+ *  from Git by maven in the `generate-sources` phase, and process them. Will be great
+ *  to process home objects only once - initially during the build, and then reuse it
+ *  everywhere.
  * @since 0.0.43
  */
 final class MonoLints extends IterableEnvelope<Lint<XML>> {

--- a/src/main/java/org/eolang/lints/MonoLints.java
+++ b/src/main/java/org/eolang/lints/MonoLints.java
@@ -30,8 +30,7 @@ final class MonoLints extends IterableEnvelope<Lint<XML>> {
         new Joined<Lint<XML>>(
             new PkByXsl(),
             List.of(
-                new LtAsciiOnly(),
-                new LtReservedName()
+                new LtAsciiOnly()
             )
         )
     );

--- a/src/main/java/org/eolang/lints/MonoLints.java
+++ b/src/main/java/org/eolang/lints/MonoLints.java
@@ -22,7 +22,7 @@ import org.cactoos.list.ListOf;
  * @since 0.0.43
  * @todo #165:60min Add {@link LtReservedName} to the LINTS Mono pipeline.
  *  Currently, it will cause timeout exceptions in several places in tests, due to
- *  the design of {@link LtReservedName}. Now, scans all the home EO objects, pulled
+ *  the design of {@link LtReservedName}. There, it scans all the home EO objects, pulled
  *  from Git by maven in the `generate-sources` phase, and process them. Will be great
  *  to process home objects only once - initially during the build, and then reuse it
  *  everywhere.

--- a/src/main/java/org/eolang/lints/MonoLints.java
+++ b/src/main/java/org/eolang/lints/MonoLints.java
@@ -30,7 +30,8 @@ final class MonoLints extends IterableEnvelope<Lint<XML>> {
         new Joined<Lint<XML>>(
             new PkByXsl(),
             List.of(
-                new LtAsciiOnly()
+                new LtAsciiOnly(),
+                new LtReservedName()
             )
         )
     );

--- a/src/main/java/org/eolang/lints/MonoLints.java
+++ b/src/main/java/org/eolang/lints/MonoLints.java
@@ -19,13 +19,13 @@ import org.cactoos.list.ListOf;
  * {@link PkMono} and {@link PkWpa} via {@link MonoLintNames}, to mutually ignore other
  * scope lints in both: {@link LtUnlintNonExistingDefect} and {@link LtUnlintNonExistingDefectWpa}
  * without causing recursion errors.
+ * @since 0.0.43
  * @todo #165:60min Add {@link LtReservedName} to the LINTS Mono pipeline.
  *  Currently, it will cause timeout exceptions in several places in tests, due to
  *  the design of {@link LtReservedName}. Now, scans all the home EO objects, pulled
  *  from Git by maven in the `generate-sources` phase, and process them. Will be great
  *  to process home objects only once - initially during the build, and then reuse it
  *  everywhere.
- * @since 0.0.43
  */
 final class MonoLints extends IterableEnvelope<Lint<XML>> {
 

--- a/src/main/resources/org/eolang/motives/names/reserved-name.md
+++ b/src/main/resources/org/eolang/motives/names/reserved-name.md
@@ -1,0 +1,16 @@
+# Reserved Name
+
+Each named object should not duplicate already reserved names in `org.eolang.*`
+objects from [home].
+
+Incorrect:
+
+```eo
+# Foo.
+[] > foo
+  52 > true
+```
+
+Since `true` already exists in `org.eolang.true.eo`.
+
+[home]: https://github.com/objectionary/home

--- a/src/main/resources/org/eolang/motives/names/reserved-name.md
+++ b/src/main/resources/org/eolang/motives/names/reserved-name.md
@@ -1,7 +1,7 @@
 # Reserved Name
 
-Each named object should not duplicate already reserved names in `org.eolang.*`
-objects from [home].
+Each object name should not duplicate already reserved names in `org.eolang.*`
+objects [located in home][home].
 
 Incorrect:
 
@@ -13,4 +13,4 @@ Incorrect:
 
 Since `true` already exists in `org.eolang.true.eo`.
 
-[home]: https://github.com/objectionary/home
+[home]: https://github.com/objectionary/home/tree/master/objects/org/eolang

--- a/src/test/java/org/eolang/lints/LtReservedNameTest.java
+++ b/src/test/java/org/eolang/lints/LtReservedNameTest.java
@@ -37,4 +37,63 @@ final class LtReservedNameTest {
             Matchers.hasSize(Matchers.greaterThan(0))
         );
     }
+
+    @Test
+    void allowsNonReservedName() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are not empty, but they should",
+            new LtReservedName(new ListOf<>("org.eolang.true"))
+                .defects(
+                    new EoSyntax(
+                        "x",
+                        String.join(
+                            "# X object.",
+                            "[] > x",
+                            "  42 > y"
+                        )
+                    ).parsed()
+                ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void allowsUniqueNameInTopProgramObject() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are not empty, but they should",
+            new LtReservedName(new ListOf<>("org.eolang.f"))
+                .defects(
+                    new EoSyntax(
+                        "top",
+                        String.join(
+                            "# top.",
+                            "[] > top",
+                            "  52 > x"
+                        )
+                    ).parsed()
+                ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void catchesReservedNameWithPackage() throws IOException {
+        MatcherAssert.assertThat(
+            "There was no defects, though object name is already reserved",
+            new LtReservedName(new ListOf<>("org.eolang.stdout"))
+                .defects(
+                    new EoSyntax(
+                        "t-packaged",
+                        String.join(
+                            "+package org.foo",
+                            "",
+                            "# Tee packaged.",
+                            "[] > tee",
+                            "  52 > stdout"
+                        )
+                    ).parsed()
+                ),
+            Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
 }

--- a/src/test/java/org/eolang/lints/LtReservedNameTest.java
+++ b/src/test/java/org/eolang/lints/LtReservedNameTest.java
@@ -120,6 +120,47 @@ final class LtReservedNameTest {
         );
     }
 
+    @Test
+    void reportsAll() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are empty, but they should not",
+            new LtReservedName(new ListOf<>("ja", "jp", "spb")).defects(
+                new EoSyntax(
+                    "tops",
+                    String.join(
+                        "\n",
+                        "# JA.",
+                        "[] > ja",
+                        "  52 > spb",
+                        "",
+                        "# JP.",
+                        "[] > jp"
+                    )
+                ).parsed()
+            ),
+            Matchers.hasSize(2)
+        );
+    }
+
+    @Test
+    void reportsReservedNameInTopObject() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects should be caught",
+            new LtReservedName(new ListOf<>("foo")).defects(
+                new EoSyntax(
+                    "foo",
+                    String.join(
+                        "\n",
+                        "# Foo.",
+                        "[] > foo",
+                        "  52 > spb"
+                    )
+                ).parsed()
+            ),
+            Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
+
     @Tag("deep")
     @Test
     void scansReservedFromHome() throws IOException {
@@ -129,6 +170,7 @@ final class LtReservedNameTest {
                 new EoSyntax(
                     "foo",
                     String.join(
+                        "\n",
                         "# Foo",
                         "[] > foo",
                         "  52 > stdout"

--- a/src/test/java/org/eolang/lints/LtReservedNameTest.java
+++ b/src/test/java/org/eolang/lints/LtReservedNameTest.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import java.io.IOException;
+import org.cactoos.list.ListOf;
+import org.eolang.parser.EoSyntax;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link LtReservedName}.
+ *
+ * @since 0.0.43
+ */
+final class LtReservedNameTest {
+
+    @Test
+    void catchesReservedName() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are empty, but they should not",
+            new LtReservedName(new ListOf<>("org.eolang.true"))
+                .defects(
+                    new EoSyntax(
+                        "foo",
+                        String.join(
+                            "\n",
+                            "# Foo.",
+                            "[] > foo",
+                            "  42 > true"
+                        )
+                    ).parsed()
+                ),
+            Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
+}

--- a/src/test/java/org/eolang/lints/LtReservedNameTest.java
+++ b/src/test/java/org/eolang/lints/LtReservedNameTest.java
@@ -5,7 +5,8 @@
 package org.eolang.lints;
 
 import java.io.IOException;
-import org.cactoos.list.ListOf;
+import org.cactoos.map.MapEntry;
+import org.cactoos.map.MapOf;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -23,7 +24,7 @@ final class LtReservedNameTest {
     void catchesReservedName() throws IOException {
         MatcherAssert.assertThat(
             "Defects are empty, but they should not",
-            new LtReservedName(new ListOf<>("true"))
+            new LtReservedName(new MapOf<>("true", "org.eolang.true.eo"))
                 .defects(
                     new EoSyntax(
                         "foo",
@@ -43,7 +44,7 @@ final class LtReservedNameTest {
     void allowsNonReservedName() throws IOException {
         MatcherAssert.assertThat(
             "Defects are not empty, but they should",
-            new LtReservedName(new ListOf<>("true"))
+            new LtReservedName(new MapOf<>("true", "org.eolang.true.eo"))
                 .defects(
                     new EoSyntax(
                         "x",
@@ -62,7 +63,7 @@ final class LtReservedNameTest {
     void allowsUniqueNameInTopProgramObject() throws IOException {
         MatcherAssert.assertThat(
             "Defects are not empty, but they should",
-            new LtReservedName(new ListOf<>("f"))
+            new LtReservedName(new MapOf<>("f", "org.eolang.f.eo"))
                 .defects(
                     new EoSyntax(
                         "top",
@@ -81,7 +82,7 @@ final class LtReservedNameTest {
     void catchesReservedNameWithPackage() throws IOException {
         MatcherAssert.assertThat(
             "There was no defects, though object name is already reserved",
-            new LtReservedName(new ListOf<>("stdout"))
+            new LtReservedName(new MapOf<>("stdout", "org.eolang.stdout.eo"))
                 .defects(
                     new EoSyntax(
                         "t-packaged",
@@ -102,20 +103,24 @@ final class LtReservedNameTest {
     void catchesMultipleNames() throws IOException {
         MatcherAssert.assertThat(
             "Defects should be caught",
-            new LtReservedName(new ListOf<>("left", "right"))
-                .defects(
-                    new EoSyntax(
-                        "two-defects",
-                        String.join(
-                            "\n",
-                            "# Left.",
-                            "[] > left",
-                            "",
-                            "# Right.",
-                            "[] > right"
-                        )
-                    ).parsed()
-                ),
+            new LtReservedName(
+                new MapOf<String, String>(
+                    new MapEntry<>("left", "org.eolang.left.eo"),
+                    new MapEntry<>("right", "org.eolang.right.eo")
+                )
+            ).defects(
+                new EoSyntax(
+                    "two-defects",
+                    String.join(
+                        "\n",
+                        "# Left.",
+                        "[] > left",
+                        "",
+                        "# Right.",
+                        "[] > right"
+                    )
+                ).parsed()
+            ),
             Matchers.hasSize(2)
         );
     }
@@ -124,7 +129,13 @@ final class LtReservedNameTest {
     void reportsAll() throws IOException {
         MatcherAssert.assertThat(
             "Defects are empty, but they should not",
-            new LtReservedName(new ListOf<>("ja", "jp", "spb")).defects(
+            new LtReservedName(
+                new MapOf<>(
+                    new MapEntry<>("ja", "org.eolang.ja.eo"),
+                    new MapEntry<>("jp", "org.eolang.jp.eo"),
+                    new MapEntry<>("spb", "org.eolang.spb.eo")
+                )
+            ).defects(
                 new EoSyntax(
                     "tops",
                     String.join(
@@ -146,7 +157,7 @@ final class LtReservedNameTest {
     void reportsReservedNameInTopObject() throws IOException {
         MatcherAssert.assertThat(
             "Defects should be caught",
-            new LtReservedName(new ListOf<>("foo")).defects(
+            new LtReservedName(new MapOf<>("foo", "org.eolang.foo.eo")).defects(
                 new EoSyntax(
                     "foo",
                     String.join(

--- a/src/test/java/org/eolang/lints/LtReservedNameTest.java
+++ b/src/test/java/org/eolang/lints/LtReservedNameTest.java
@@ -138,7 +138,7 @@ final class LtReservedNameTest {
                     )
                 ).parsed()
             ),
-            Matchers.hasSize(2)
+            Matchers.hasSize(3)
         );
     }
 

--- a/src/test/java/org/eolang/lints/LtReservedNameTest.java
+++ b/src/test/java/org/eolang/lints/LtReservedNameTest.java
@@ -5,6 +5,7 @@
 package org.eolang.lints;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import org.cactoos.map.MapEntry;
 import org.cactoos.map.MapOf;
 import org.eolang.parser.EoSyntax;
@@ -12,6 +13,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Tests for {@link LtReservedName}.
@@ -173,6 +175,7 @@ final class LtReservedNameTest {
     }
 
     @Tag("deep")
+    @Timeout(value = 90L, unit = TimeUnit.SECONDS)
     @Test
     void scansReservedFromHome() throws IOException {
         MatcherAssert.assertThat(

--- a/src/test/java/org/eolang/lints/LtReservedNameTest.java
+++ b/src/test/java/org/eolang/lints/LtReservedNameTest.java
@@ -9,6 +9,7 @@ import org.cactoos.list.ListOf;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -22,7 +23,7 @@ final class LtReservedNameTest {
     void catchesReservedName() throws IOException {
         MatcherAssert.assertThat(
             "Defects are empty, but they should not",
-            new LtReservedName(new ListOf<>("org.eolang.true"))
+            new LtReservedName(new ListOf<>("true"))
                 .defects(
                     new EoSyntax(
                         "foo",
@@ -42,7 +43,7 @@ final class LtReservedNameTest {
     void allowsNonReservedName() throws IOException {
         MatcherAssert.assertThat(
             "Defects are not empty, but they should",
-            new LtReservedName(new ListOf<>("org.eolang.true"))
+            new LtReservedName(new ListOf<>("true"))
                 .defects(
                     new EoSyntax(
                         "x",
@@ -61,7 +62,7 @@ final class LtReservedNameTest {
     void allowsUniqueNameInTopProgramObject() throws IOException {
         MatcherAssert.assertThat(
             "Defects are not empty, but they should",
-            new LtReservedName(new ListOf<>("org.eolang.f"))
+            new LtReservedName(new ListOf<>("f"))
                 .defects(
                     new EoSyntax(
                         "top",
@@ -80,7 +81,7 @@ final class LtReservedNameTest {
     void catchesReservedNameWithPackage() throws IOException {
         MatcherAssert.assertThat(
             "There was no defects, though object name is already reserved",
-            new LtReservedName(new ListOf<>("org.eolang.stdout"))
+            new LtReservedName(new ListOf<>("stdout"))
                 .defects(
                     new EoSyntax(
                         "t-packaged",
@@ -93,6 +94,47 @@ final class LtReservedNameTest {
                         )
                     ).parsed()
                 ),
+            Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
+
+    @Test
+    void catchesMultipleNames() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects should be caught",
+            new LtReservedName(new ListOf<>("left", "right"))
+                .defects(
+                    new EoSyntax(
+                        "two-defects",
+                        String.join(
+                            "\n",
+                            "# Left.",
+                            "[] > left",
+                            "",
+                            "# Right.",
+                            "[] > right"
+                        )
+                    ).parsed()
+                ),
+            Matchers.hasSize(2)
+        );
+    }
+
+    @Tag("deep")
+    @Test
+    void scansReservedFromHome() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are empty, but they should not",
+            new LtReservedName().defects(
+                new EoSyntax(
+                    "foo",
+                    String.join(
+                        "# Foo",
+                        "[] > foo",
+                        "  52 > stdout"
+                    )
+                ).parsed()
+            ),
             Matchers.hasSize(Matchers.greaterThan(0))
         );
     }


### PR DESCRIPTION
In this PR I've implemented new lint: `reserved-name`, that issues defect with `warning` severity if object uses name, already reserved by object in `org.eolang.*` package.

closes #165
History:
- **feat(#165): start**
- **feat(#165): more tests**
- **feat(#165): deep test case, naming check**
- **feat(#165): no args**
- **feat(#165): parsing stream, more tests**
- **feat(#165): nested**
- **feat(#165): pull**
- **feat(#165): motive**
- **feat(#165): report object**
