### PR TITLE
bug(#445): `LtIncorrectUnlint` understands unlints with line number

### DIFF
--- a/src/main/java/org/eolang/lints/LtIncorrectUnlint.java
+++ b/src/main/java/org/eolang/lints/LtIncorrectUnlint.java
@@ -44,7 +44,10 @@ final class LtIncorrectUnlint implements Lint<XML> {
         final Collection<Defect> defects = new LinkedList<>();
         final Xnav xml = new Xnav(xmir.inner());
         xml.path("/program/metas/meta[head='unlint']")
-            .filter(u -> !this.names.contains(u.element("tail").text().orElse("unknown")))
+            .filter(
+                u ->
+                    !this.names.contains(u.element("tail").text().orElse("unknown").split(":")[0])
+            )
             .forEach(
                 u -> defects.add(
                     new Defect.Default(

--- a/src/test/java/org/eolang/lints/LtIncorrectUnlintTest.java
+++ b/src/test/java/org/eolang/lints/LtIncorrectUnlintTest.java
@@ -62,4 +62,45 @@ final class LtIncorrectUnlintTest {
             Matchers.containsString("Suppressing \"boom\" does not make sense")
         );
     }
+
+    @Test
+    void understandsUnlintsWithLineNumber() throws IOException {
+        MatcherAssert.assertThat(
+            "Unlints with line number should be supported",
+            new LtIncorrectUnlint(new ListOf<>("comment-not-capitalized"))
+                .defects(
+                    new EoSyntax(
+                        "foo",
+                        String.join(
+                            "\n",
+                            "+unlint comment-not-capitalized:3",
+                            "",
+                            "# foo.",
+                            "[] > foo"
+                        )
+                    ).parsed()
+                ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void catchesNonExistingUnlintWithLineNumber() throws IOException {
+        MatcherAssert.assertThat(
+            "Non existing unlint with line number should be caught",
+            new LtIncorrectUnlint(new ListOf<>("a")).defects(
+                new EoSyntax(
+                    "app",
+                    String.join(
+                        "\n",
+                        "+unlint b:1",
+                        "",
+                        "# App.",
+                        "[] > app"
+                    )
+                ).parsed()
+            ),
+            Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
 }


### PR DESCRIPTION
In this PR I've updated `LtIncorrectUnlint`, so it understands the unlints with line number e.g: `+unlint comment-too-short:42`.

closes #445
History:
- **feat(#445): tests**
- **bug(#445): split**
