### PR TITLE
bug(#447): `LtUnlintNonExistingDefect` and `LtUnlintNonExistingDefectWpa` understand unlints with line number

### DIFF
--- a/.github/workflows/pit.yml
+++ b/.github/workflows/pit.yml
@@ -12,7 +12,7 @@ name: pit
       - master
 jobs:
   pit:
-    timeout-minutes: 25
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/src/main/java/org/eolang/lints/DefectMissing.java
+++ b/src/main/java/org/eolang/lints/DefectMissing.java
@@ -12,10 +12,10 @@ import org.cactoos.Func;
 import org.cactoos.set.SetOf;
 
 /**
- * Matches lined unlint.
+ * Does defect missing.
  * @since 0.0.44
  */
-final class MatchesLinedUnlint implements Func<String, Boolean> {
+final class DefectMissing implements Func<String, Boolean> {
 
     /**
      * Mapped defects.
@@ -32,7 +32,7 @@ final class MatchesLinedUnlint implements Func<String, Boolean> {
      * @param present Present defects
      * @param exld Excluded lints
      */
-    MatchesLinedUnlint(final Map<String, List<Integer>> present, final Collection<String> exld) {
+    DefectMissing(final Map<String, List<Integer>> present, final Collection<String> exld) {
         this.defects = present;
         this.excluded = exld;
     }

--- a/src/main/java/org/eolang/lints/DefectMissing.java
+++ b/src/main/java/org/eolang/lints/DefectMissing.java
@@ -8,14 +8,14 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.cactoos.Func;
+import java.util.function.Function;
 import org.cactoos.set.SetOf;
 
 /**
  * Does defect missing.
  * @since 0.0.44
  */
-final class DefectMissing implements Func<String, Boolean> {
+final class DefectMissing implements Function<String, Boolean> {
 
     /**
      * Mapped defects.

--- a/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
+++ b/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
@@ -13,6 +13,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
@@ -69,8 +70,9 @@ final class LtUnlintNonExistingDefect implements Lint<XML> {
         final Set<String> unlints = xml.path("/program/metas/meta[head='unlint']/tail")
             .map(xnav -> xnav.text().get())
             .collect(Collectors.toSet());
+        final Function<String, Boolean> missing = new DefectMissing(present, this.excluded);
         unlints.stream()
-            .filter(unlint -> new DefectMissing(present, this.excluded).apply(unlint))
+            .filter(missing::apply)
             .forEach(
                 unlint ->
                     xml.path(

--- a/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
+++ b/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
@@ -64,7 +64,6 @@ final class LtUnlintNonExistingDefect implements Lint<XML> {
     public Collection<Defect> defects(final XML xmir) throws IOException {
         final Collection<Defect> defects = new LinkedList<>();
         final Map<String, List<Integer>> present = this.existingDefects(xmir);
-        System.out.println(present);
         final Xnav xml = new Xnav(xmir.inner());
         final Set<String> unlints = xml.path("/program/metas/meta[head='unlint']/tail")
             .map(xnav -> xnav.text().get())

--- a/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
+++ b/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
@@ -70,7 +70,7 @@ final class LtUnlintNonExistingDefect implements Lint<XML> {
             .map(xnav -> xnav.text().get())
             .collect(Collectors.toSet());
         unlints.stream()
-            .filter(unlint -> new MatchesLinedUnlint(present, this.excluded).apply(unlint))
+            .filter(unlint -> new DefectMissing(present, this.excluded).apply(unlint))
             .forEach(
                 unlint ->
                     xml.path(

--- a/src/main/java/org/eolang/lints/LtUnlintNonExistingDefectWpa.java
+++ b/src/main/java/org/eolang/lints/LtUnlintNonExistingDefectWpa.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import jdk.jshell.spi.SPIResolutionException;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
+import org.cactoos.set.SetOf;
 import org.cactoos.text.IoCheckedText;
 import org.cactoos.text.TextOf;
 
@@ -75,7 +76,12 @@ final class LtUnlintNonExistingDefectWpa implements Lint<Map<String, XML>> {
             xmir -> {
                 final Xnav xml = new Xnav(xmir.inner());
                 final Map<String, List<Integer>> present = existing.get(xmir);
-                final Set<String> names = present.keySet();
+                final Set<String> names;
+                if (present != null) {
+                     names = present.keySet();
+                } else {
+                    names = new SetOf<>();
+                }
                 xml.path("/program/metas/meta[head='unlint']/tail")
                     .map(xnav -> xnav.text().get())
                     .collect(Collectors.toSet())

--- a/src/main/java/org/eolang/lints/LtUnlintNonExistingDefectWpa.java
+++ b/src/main/java/org/eolang/lints/LtUnlintNonExistingDefectWpa.java
@@ -78,7 +78,7 @@ final class LtUnlintNonExistingDefectWpa implements Lint<Map<String, XML>> {
                     .map(xnav -> xnav.text().get())
                     .collect(Collectors.toSet())
                     .stream()
-                    .filter(unlint -> new MatchesLinedUnlint(present, this.excluded).apply(unlint))
+                    .filter(unlint -> new DefectMissing(present, this.excluded).apply(unlint))
                     .forEach(
                         unlint -> xml
                             .path(

--- a/src/main/java/org/eolang/lints/LtUnlintNonExistingDefectWpa.java
+++ b/src/main/java/org/eolang/lints/LtUnlintNonExistingDefectWpa.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
@@ -73,12 +74,14 @@ final class LtUnlintNonExistingDefectWpa implements Lint<Map<String, XML>> {
         pkg.values().forEach(
             xmir -> {
                 final Xnav xml = new Xnav(xmir.inner());
-                final Map<String, List<Integer>> present = existing.get(xmir);
+                final Function<String, Boolean> missing = new DefectMissing(
+                    existing.get(xmir), this.excluded
+                );
                 xml.path("/program/metas/meta[head='unlint']/tail")
                     .map(xnav -> xnav.text().get())
                     .collect(Collectors.toSet())
                     .stream()
-                    .filter(unlint -> new DefectMissing(present, this.excluded).apply(unlint))
+                    .filter(missing::apply)
                     .forEach(
                         unlint -> xml
                             .path(

--- a/src/main/java/org/eolang/lints/MatchesLinedUnlint.java
+++ b/src/main/java/org/eolang/lints/MatchesLinedUnlint.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.cactoos.Func;
+import org.cactoos.set.SetOf;
+
+/**
+ * Matches lined unlint.
+ * @since 0.0.44
+ */
+final class MatchesLinedUnlint implements Func<String, Boolean> {
+
+    /**
+     * Mapped defects.
+     */
+    private final Map<String, List<Integer>> defects;
+
+    /**
+     * Excluded lints.
+     */
+    private final Collection<String> excluded;
+
+    /**
+     * Ctor.
+     * @param present Present defects
+     * @param exld Excluded lints
+     */
+    MatchesLinedUnlint(final Map<String, List<Integer>> present, final Collection<String> exld) {
+        this.defects = present;
+        this.excluded = exld;
+    }
+
+    @Override
+    public Boolean apply(final String unlint) {
+        final boolean matches;
+        final String[] split = unlint.split(":");
+        final String name = split[0];
+        final Set<String> names;
+        if (this.defects != null) {
+            names = this.defects.keySet();
+        } else {
+            names = new SetOf<>();
+        }
+        if (split.length > 1) {
+            final List<Integer> lines = this.defects.get(name);
+            matches = (!names.contains(name) || !lines.contains(Integer.parseInt(split[1])))
+                && !this.excluded.contains(name);
+        } else {
+            matches = !names.contains(name) && !this.excluded.contains(name);
+        }
+        return matches;
+    }
+}

--- a/src/test/java/org/eolang/lints/DefectMissingTest.java
+++ b/src/test/java/org/eolang/lints/DefectMissingTest.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import org.cactoos.list.ListOf;
+import org.cactoos.map.MapEntry;
+import org.cactoos.map.MapOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link DefectMissing}.
+ *
+ * @since 0.0.44
+ */
+final class DefectMissingTest {
+
+    @Test
+    void returnsTrueOnMatch() {
+        MatcherAssert.assertThat(
+            "Input should not match, since defect is present",
+            new DefectMissing(
+                new MapOf<>(new MapEntry<>("foo", new ListOf<>(42, 43))), new ListOf<>()
+            ).apply("foo:42"),
+            Matchers.equalTo(false)
+        );
+    }
+
+    @Test
+    void returnsFalseWhenDoesNotMatch() {
+        MatcherAssert.assertThat(
+            "Input should match",
+            new DefectMissing(
+                new MapOf<>(new MapEntry<>("bar", new ListOf<>(42, 43))), new ListOf<>()
+            ).apply("foo:52"),
+            Matchers.equalTo(true)
+        );
+    }
+}

--- a/src/test/java/org/eolang/lints/DefectMissingTest.java
+++ b/src/test/java/org/eolang/lints/DefectMissingTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 final class DefectMissingTest {
 
     @Test
-    void returnsTrueOnMatch() {
+    void returnsFalseOnMatch() {
         MatcherAssert.assertThat(
             "Input should not match, since defect is present",
             new DefectMissing(
@@ -30,7 +30,7 @@ final class DefectMissingTest {
     }
 
     @Test
-    void returnsFalseWhenDoesNotMatch() {
+    void returnsTrueWhenDoesNotMatch() {
         MatcherAssert.assertThat(
             "Input should match",
             new DefectMissing(

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -130,4 +130,48 @@ final class LtUnlintNonExistingDefectTest {
             Matchers.emptyIterable()
         );
     }
+
+    @Test
+    void allowsExistingUnlintWithLineNumber() throws IOException {
+        MatcherAssert.assertThat(
+            "An existing defect should be able to be unlinted with line number",
+            new LtUnlintNonExistingDefect(
+                new ListOf<>(new LtAsciiOnly()),
+                new ListOf<>()
+            ).defects(
+                new EoSyntax(
+                    String.join(
+                        "\n",
+                        "+unlint ascii-only:3",
+                        "",
+                        "# привет мы тут.",
+                        "[] > hello"
+                    )
+                ).parsed()
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void catchesNonExistingUnlintWithLineNumber() throws IOException {
+        MatcherAssert.assertThat(
+            "Non existing unlint with line number should be reported",
+            new LtUnlintNonExistingDefect(
+                new ListOf<>(new LtAsciiOnly()),
+                new ListOf<>()
+            ).defects(
+                new EoSyntax(
+                    String.join(
+                        "\n",
+                        "+unlint ascii-only:2",
+                        "",
+                        "# Мы тут.",
+                        "[] > boom"
+                    )
+                ).parsed()
+            ),
+            Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
 }

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -142,7 +142,7 @@ final class LtUnlintNonExistingDefectTest {
                 new EoSyntax(
                     String.join(
                         "\n",
-                        "+unlint ascii-only:3",
+                        "+unlint ascii-only:4",
                         "",
                         "# привет мы тут.",
                         "[] > hello"

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectWpaTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectWpaTest.java
@@ -147,4 +147,33 @@ final class LtUnlintNonExistingDefectWpaTest {
             Matchers.emptyIterable()
         );
     }
+
+    @Test
+    void allowsExistingUnlintWithLineNumber() throws IOException {
+        MatcherAssert.assertThat(
+            "An existing defect should be able to be unlinted with line number",
+            new LtUnlintNonExistingDefectWpa(
+                new ListOf<>(new LtInconsistentArgs()),
+                new ListOf<>()
+            ).defects(
+                new MapOf<>(
+                    new MapEntry<>(
+                        "foo",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "+unlint inconsistent-args:6",
+                                "",
+                                "# Foo.",
+                                "[] > foo",
+                                "  bar 42 > x",
+                                "  bar 42 52 > y"
+                            )
+                        ).parsed()
+                    )
+                )
+            ),
+            Matchers.emptyIterable()
+        );
+    }
 }

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectWpaTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectWpaTest.java
@@ -176,4 +176,33 @@ final class LtUnlintNonExistingDefectWpaTest {
             Matchers.emptyIterable()
         );
     }
+
+    @Test
+    void catchesNonExistingUnlintWithLineNumber() throws IOException {
+        MatcherAssert.assertThat(
+            "Non existing defect with line number should be reported",
+            new LtUnlintNonExistingDefectWpa(
+                new ListOf<>(new LtInconsistentArgs()),
+                new ListOf<>()
+            ).defects(
+                new MapOf<>(
+                    new MapEntry<>(
+                        "app",
+                        new EoSyntax(
+                            String.join(
+                                "\n",
+                                "+unlint inconsistent-args:25",
+                                "",
+                                "# App.",
+                                "[] > app",
+                                "  tee 42 > x",
+                                "  tee 42 52 > y"
+                            )
+                        ).parsed()
+                    )
+                )
+            ),
+            Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
 }


### PR DESCRIPTION
In this PR I've added support of unlints with line number via `DefectMissing.java` in both: `LtUnlintNonExistingDefect` and `LtUnlintNonExistingDefectWpa`.

closes #447
History:
- **bug(#447): tests**
- **bug(#447): filters correctly in single scope**
- **bug(#447): matches in WPA**
- **bug(#447): more test**
- **bug(#447): check if present**
- **bug(#447): MatchesLinedUnlint**
- **bug(#447): clean for qulice**
