### PR TITLE
bug(#451): Defect duplication fixed in `LtUnlint`

### DIFF
--- a/src/main/java/org/eolang/lints/Defect.java
+++ b/src/main/java/org/eolang/lints/Defect.java
@@ -5,6 +5,7 @@
 package org.eolang.lints;
 
 import com.jcabi.manifests.Manifests;
+import java.util.Objects;
 
 /**
  * A single defect found.
@@ -198,6 +199,27 @@ public interface Defect {
         @Override
         public String context() {
             return "Context is empty";
+        }
+
+        @Override
+        public boolean equals(final Object obj) {
+            final boolean result;
+            if (obj == null || this.getClass() != obj.getClass()) {
+                result = false;
+            } else {
+                final Defect.Default defect = (Defect.Default) obj;
+                result = this.lineno == defect.lineno
+                    && Objects.equals(this.rle, defect.rle)
+                    && this.sev == defect.sev
+                    && Objects.equals(this.prg, defect.prg)
+                    && Objects.equals(this.txt, defect.txt);
+            }
+            return result;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.rle, this.sev, this.prg, this.lineno, this.txt);
         }
     }
 

--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.cactoos.list.ListOf;
@@ -60,6 +61,7 @@ final class LtUnlint implements Lint<XML> {
             )
         ).map(xnav -> xnav.text().get()).collect(Collectors.toList());
         final boolean global = !granular.isEmpty();
+        final AtomicBoolean completed = new AtomicBoolean(false);
         granular.forEach(
             unlint -> {
                 if (LtUnlint.LINE_NUMBER.matcher(unlint).matches()) {
@@ -78,11 +80,12 @@ final class LtUnlint implements Lint<XML> {
                 defect -> {
                     if (line != 0 && defect.line() == line) {
                         defects.add(defect);
+                        completed.set(true);
                     }
                 }
             )
         );
-        if (!global) {
+        if (!completed.get() && !global) {
             defects.addAll(this.origin.defects(xmir));
         }
         return defects;

--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -61,7 +61,7 @@ final class LtUnlint implements Lint<XML> {
             )
         ).map(xnav -> xnav.text().get()).collect(Collectors.toList());
         final boolean global = !granular.isEmpty();
-        final AtomicBoolean completed = new AtomicBoolean(false);
+        final AtomicBoolean added = new AtomicBoolean(false);
         granular.forEach(
             unlint -> {
                 if (LtUnlint.LINE_NUMBER.matcher(unlint).matches()) {
@@ -80,12 +80,12 @@ final class LtUnlint implements Lint<XML> {
                 defect -> {
                     if (line != 0 && defect.line() == line) {
                         defects.add(defect);
-                        completed.set(true);
+                        added.set(true);
                     }
                 }
             )
         );
-        if (!completed.get() && !global) {
+        if (!added.get() && !global) {
             defects.addAll(this.origin.defects(xmir));
         }
         return defects;

--- a/src/test/java/org/eolang/lints/LtUnlintTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintTest.java
@@ -123,4 +123,57 @@ final class LtUnlintTest {
             Matchers.emptyIterable()
         );
     }
+
+    @Test
+    void doesNotDuplicateDefects() throws IOException {
+        MatcherAssert.assertThat(
+            "Unlint should not duplicate defects",
+            new LtUnlint(
+                new LtByXsl("errors/noname-attribute")
+            ).defects(
+                new EoSyntax(
+                    "app",
+                    String.join(
+                        "\n",
+                        "+home https://github.com/objectionary/eo",
+                        "+package f",
+                        "+version 0.0.0",
+                        "",
+                        "# No comments.",
+                        "[] > main",
+                        "  QQ.io.stdout",
+                        "    \"Hello world\""
+                    )
+                ).parsed()
+            ),
+            Matchers.iterableWithSize(1)
+        );
+    }
+
+    @Test
+    void doesNotReportWhenUnlinted() throws IOException {
+        MatcherAssert.assertThat(
+            "Defect should not be reported when its unlinted",
+            new LtUnlint(
+                new LtByXsl("errors/noname-attribute")
+            ).defects(
+                new EoSyntax(
+                    "boom",
+                    String.join(
+                        "\n",
+                        "+home https://github.com/objectionary/eo",
+                        "+package f",
+                        "+version 0.0.0",
+                        "+unlint noname-attribute:8",
+                        "",
+                        "# No comments.",
+                        "[] > boom",
+                        "  QQ.io.stdout",
+                        "    \"we are booming!\""
+                    )
+                ).parsed()
+            ),
+            Matchers.emptyIterable()
+        );
+    }
 }

--- a/src/test/java/org/eolang/lints/MonoLintsTest.java
+++ b/src/test/java/org/eolang/lints/MonoLintsTest.java
@@ -73,6 +73,7 @@ final class MonoLintsTest {
                 }
             }
         );
+        // check no duplicates by name
         MatcherAssert.assertThat(
             "Found defects size does not match with expected",
             found,

--- a/src/test/java/org/eolang/lints/MonoLintsTest.java
+++ b/src/test/java/org/eolang/lints/MonoLintsTest.java
@@ -10,6 +10,7 @@ import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.stream.Collectors;
 import org.cactoos.list.ListOf;
 import org.eolang.parser.EoSyntax;
@@ -63,7 +64,7 @@ final class MonoLintsTest {
                 "    \"Hello world\""
             )
         ).parsed();
-        Collection<Defect> found = new ListOf<>();
+        final Collection<Defect> found = new ListOf<>();
         new ListOf<>(new MonoLints()).forEach(
             lint -> {
                 try {
@@ -73,11 +74,10 @@ final class MonoLintsTest {
                 }
             }
         );
-        // check no duplicates by name
         MatcherAssert.assertThat(
-            "Found defects size does not match with expected",
-            found,
-            Matchers.hasSize(1)
+            "Found defects should be all unique",
+            new HashSet<>(found).size() == found.size(),
+            Matchers.equalTo(true)
         );
     }
 }

--- a/src/test/java/org/eolang/lints/MonoLintsTest.java
+++ b/src/test/java/org/eolang/lints/MonoLintsTest.java
@@ -4,11 +4,15 @@
  */
 package org.eolang.lints;
 
+import com.jcabi.xml.XML;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import java.io.IOException;
+import java.util.Collection;
 import java.util.stream.Collectors;
 import org.cactoos.list.ListOf;
+import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -40,6 +44,39 @@ final class MonoLintsTest {
             Matchers.hasItem(
                 "incorrect-unlint"
             )
+        );
+    }
+
+    @Test
+    void lintsProgramCorrectly() throws IOException {
+        final XML xmir = new EoSyntax(
+            "app",
+            String.join(
+                "\n",
+                "+home https://github.com/objectionary/eo",
+                "+package f",
+                "+version 0.0.0",
+                "",
+                "# No comments.",
+                "[] > main",
+                "  QQ.io.stdout",
+                "    \"Hello world\""
+            )
+        ).parsed();
+        Collection<Defect> found = new ListOf<>();
+        new ListOf<>(new MonoLints()).forEach(
+            lint -> {
+                try {
+                    found.addAll(lint.defects(xmir));
+                } catch (final IOException exception) {
+                    throw new IllegalStateException("Failed to lint XMIR", exception);
+                }
+            }
+        );
+        MatcherAssert.assertThat(
+            "Found defects size does not match with expected",
+            found,
+            Matchers.hasSize(1)
         );
     }
 }

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -266,7 +266,9 @@ final class ProgramTest {
                     "app",
                     String.join(
                         "\n",
+                        "+home https://github.com/objectionary/eo",
                         "+package f",
+                        "+version 0.0.0",
                         "",
                         "# No comments.",
                         "[] > main",
@@ -274,7 +276,7 @@ final class ProgramTest {
                         "    \"Hello world\""
                     )
                 ).parsed()
-            ).defects(),
+            ).without("mandatory-spdx", "comment-too-short").defects(),
             Matchers.hasSize(1)
         );
     }

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -51,6 +51,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *  adjust lint-summary.txt file to capture all the measurements.
  * @checkstyle MethodBodyCommentsCheck (50 lines)
  */
+@SuppressWarnings("PMD.TooManyMethods")
 @ExtendWith(MktmpResolver.class)
 final class ProgramTest {
 

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -258,6 +258,28 @@ final class ProgramTest {
     }
 
     @Test
+    void returnsOnlyOneDefect() throws IOException {
+        MatcherAssert.assertThat(
+            "Only one defect should be found",
+            new Program(
+                new EoSyntax(
+                    "app",
+                    String.join(
+                        "\n",
+                        "+package f",
+                        "",
+                        "# No comments.",
+                        "[] > main",
+                        "  QQ.io.stdout",
+                        "    \"Hello world\""
+                    )
+                ).parsed()
+            ).defects(),
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
     @Tag("benchmark")
     @ExtendWith(MktmpResolver.class)
     @ExtendWith(MayBeSlow.class)

--- a/src/test/java/org/eolang/lints/ProgramsTest.java
+++ b/src/test/java/org/eolang/lints/ProgramsTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @since 0.1.0
  */
+@SuppressWarnings("PMD.TooManyMethods")
 @ExtendWith(MktmpResolver.class)
 final class ProgramsTest {
 

--- a/src/test/java/org/eolang/lints/ProgramsTest.java
+++ b/src/test/java/org/eolang/lints/ProgramsTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @since 0.1.0
  */
-@SuppressWarnings("PMD.TooManyMethods")
 @ExtendWith(MktmpResolver.class)
 final class ProgramsTest {
 

--- a/src/test/resources/org/eolang/lints/packs/single/noname-attribute/catches-only-one-noname.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/noname-attribute/catches-only-one-noname.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/errors/noname-attribute.xsl
+asserts:
+  - /defects[count(defect[@severity='error'])=1]
+  - /defects/defect[@line='5']
+input: |
+  +package f
+
+  # No comments.
+  [] > main
+    QQ.io.stdout
+      "Hello world"


### PR DESCRIPTION
In this PR I've fixed the bug with defect duplication, caused by `LtUnlint` mapping, and added bunch of tests.

see #451
History:
- **bug(#451): test case**
- **bug(#451): broken**
- **bug(#451): show**
- **bug(#451): test MonoLints**
- **bug(#451): more tests**
- **bug(#451): clean for qulice**
