### PR TITLE
bug(#459): `sparse-decoration` allowed in tests

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/sparse-decoration.xsl
+++ b/src/main/resources/org/eolang/lints/misc/sparse-decoration.xsl
@@ -9,23 +9,26 @@
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
+    <xsl:variable name="test" select="/program[metas/meta[head='tests']]"/>
     <defects>
       <xsl:for-each select="//o[eo:abstract(.) and count(o)=1 and o[1][@name='@']]">
-        <xsl:element name="defect">
-          <xsl:variable name="line" select="eo:lineno(@line)"/>
-          <xsl:attribute name="line">
-            <xsl:value-of select="$line"/>
-          </xsl:attribute>
-          <xsl:if test="$line = '0'">
-            <xsl:attribute name="context">
-              <xsl:value-of select="eo:defect-context(.)"/>
+        <xsl:if test="not($test)">
+          <xsl:element name="defect">
+            <xsl:variable name="line" select="eo:lineno(@line)"/>
+            <xsl:attribute name="line">
+              <xsl:value-of select="$line"/>
             </xsl:attribute>
-          </xsl:if>
-          <xsl:attribute name="severity">
-            <xsl:text>warning</xsl:text>
-          </xsl:attribute>
-          <xsl:text>Sparse decoration is prohibited</xsl:text>
-        </xsl:element>
+            <xsl:if test="$line = '0'">
+              <xsl:attribute name="context">
+                <xsl:value-of select="eo:defect-context(.)"/>
+              </xsl:attribute>
+            </xsl:if>
+            <xsl:attribute name="severity">
+              <xsl:text>warning</xsl:text>
+            </xsl:attribute>
+            <xsl:text>Sparse decoration is prohibited</xsl:text>
+          </xsl:element>
+        </xsl:if>
       </xsl:for-each>
     </defects>
   </xsl:template>

--- a/src/main/resources/org/eolang/lints/misc/sparse-decoration.xsl
+++ b/src/main/resources/org/eolang/lints/misc/sparse-decoration.xsl
@@ -9,10 +9,9 @@
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
-    <xsl:variable name="test" select="/program[metas/meta[head='tests']]"/>
     <defects>
-      <xsl:for-each select="//o[eo:abstract(.) and count(o)=1 and o[1][@name='@']]">
-        <xsl:if test="not($test)">
+      <xsl:if test="not(/program[metas/meta[head='tests']])">
+        <xsl:for-each select="//o[eo:abstract(.) and count(o)=1 and o[1][@name='@']]">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">
@@ -28,8 +27,8 @@
             </xsl:attribute>
             <xsl:text>Sparse decoration is prohibited</xsl:text>
           </xsl:element>
-        </xsl:if>
-      </xsl:for-each>
+        </xsl:for-each>
+      </xsl:if>
     </defects>
   </xsl:template>
 </xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/misc/sparse-decoration.md
+++ b/src/main/resources/org/eolang/motives/misc/sparse-decoration.md
@@ -23,3 +23,12 @@ Correct:
 [free] > decorates-with-free-args
   five > @
 ```
+
+Also, it is possible to have sparse decoration in tests:
+
+```eo
+# This is my unit test.
+[] > runs-analysis
+  assert > @
+    foo.eq 42
+```

--- a/src/test/resources/org/eolang/lints/packs/single/sparse-decoration/allows-sparse-in-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sparse-decoration/allows-sparse-in-tests.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/sparse-decoration.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  +tests
+
+  # No comments.
+  [] > my-super-test
+    assert > @
+      foo.eq 42


### PR DESCRIPTION
In this PR I updated `sparse-decoration` to stay quiet when `+tests` meta is specified.

closes #459