### PR TITLE
bug(#460): relatively `program/@source` check in `object-does-not-match-filename`

### DIFF
--- a/src/main/resources/org/eolang/lints/names/object-does-not-match-filename.xsl
+++ b/src/main/resources/org/eolang/lints/names/object-does-not-match-filename.xsl
@@ -28,7 +28,7 @@
       </xsl:choose>
     </xsl:variable>
     <xsl:variable name="source" as="xs:string" select="replace($opath, '\.', '/')"/>
-    <xsl:if test="not(contains(/program/@source, concat($source, '.')))">
+    <xsl:if test="not(contains(/program/@source, concat($source, '.eo')) or contains(/program/@source, concat($source, '.phi')))">
       <defect>
         <xsl:variable name="line" select="eo:lineno(@line)"/>
         <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/lints/names/object-does-not-match-filename.xsl
+++ b/src/main/resources/org/eolang/lints/names/object-does-not-match-filename.xsl
@@ -28,7 +28,7 @@
       </xsl:choose>
     </xsl:variable>
     <xsl:variable name="source" as="xs:string" select="replace($opath, '\.', '/')"/>
-    <xsl:if test="not(contains(/program/@source, concat($source, '.')))">
+    <xsl:if test="not(contains(/program/@source, concat($source, concat('.', substring-after(substring-after(/program/@source, '.'), '.')))))">
       <defect>
         <xsl:variable name="line" select="eo:lineno(@line)"/>
         <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/lints/names/object-does-not-match-filename.xsl
+++ b/src/main/resources/org/eolang/lints/names/object-does-not-match-filename.xsl
@@ -28,7 +28,7 @@
       </xsl:choose>
     </xsl:variable>
     <xsl:variable name="source" as="xs:string" select="replace($opath, '\.', '/')"/>
-    <xsl:if test="not(starts-with(/program/@source, concat($source, '.')))">
+    <xsl:if test="not(contains(/program/@source, concat($source, '.')))">
       <defect>
         <xsl:variable name="line" select="eo:lineno(@line)"/>
         <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/lints/names/object-does-not-match-filename.xsl
+++ b/src/main/resources/org/eolang/lints/names/object-does-not-match-filename.xsl
@@ -28,7 +28,7 @@
       </xsl:choose>
     </xsl:variable>
     <xsl:variable name="source" as="xs:string" select="replace($opath, '\.', '/')"/>
-    <xsl:if test="not(contains(/program/@source, concat($source, '.eo')) or contains(/program/@source, concat($source, '.phi')))">
+    <xsl:if test="not(contains(/program/@source, concat($source, '.')))">
       <defect>
         <xsl:variable name="line" select="eo:lineno(@line)"/>
         <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/single/object-does-not-match-filename/allows-good-name-relatively-with-dots-in-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/object-does-not-match-filename/allows-good-name-relatively-with-dots-in-name.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/object-does-not-match-filename.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+document: |
+  <program source="foo/bar/seq.some.eo">
+    <metas>
+      <meta>
+        <head>package</head>
+        <tail>foo.bar</tail>
+        <part>foo.bar</part>
+      </meta>
+    </metas>
+    <objects>
+      <o line="2" name="seq" pos="0"/>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/single/object-does-not-match-filename/allows-good-name-relatively.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/object-does-not-match-filename/allows-good-name-relatively.yaml
@@ -4,18 +4,17 @@
 sheets:
   - /org/eolang/lints/names/object-does-not-match-filename.xsl
 asserts:
-  - /defects[count(defect[@severity='warning'])=1]
-  - /defects/defect[@line='2']
+  - /defects[count(defect[@severity='warning'])=0]
 document: |
-  <program source="app/app/app.eo">
+  <program source=".eoc/2-pull/org/eolang/sys/posix.eo">
     <metas>
       <meta>
         <head>package</head>
-        <tail>app</tail>
-        <part>app</part>
+        <tail>org.eolang.sys</tail>
+        <part>org.eolang.sys</part>
       </meta>
     </metas>
     <objects>
-      <o line="2" name="app" pos="0"/>
+      <o line="2" name="posix" pos="0"/>
     </objects>
   </program>

--- a/src/test/resources/org/eolang/lints/packs/single/object-does-not-match-filename/catches-bad-name-relatively.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/object-does-not-match-filename/catches-bad-name-relatively.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/object-does-not-match-filename.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='2']
+document: |
+  <program source=".eoc/2-pull/org/eolang/broken/posix.eo">
+    <metas>
+      <meta>
+        <head>package</head>
+        <tail>org.eolang.sys</tail>
+        <part>org.eolang.sys</part>
+      </meta>
+    </metas>
+    <objects>
+      <o line="2" name="posix" pos="0"/>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/single/object-does-not-match-filename/catches-bad-name-with-many-dots.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/object-does-not-match-filename/catches-bad-name-with-many-dots.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/object-does-not-match-filename.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='2']
+document: |
+  <program source="foo/bar/foo.seq.bar.baz.xyz.eo">
+    <metas>
+      <meta>
+        <head>package</head>
+        <tail>foo.bar</tail>
+        <part>foo.bar</part>
+      </meta>
+    </metas>
+    <objects>
+      <o line="2" name="foo" pos="0"/>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/single/object-does-not-match-filename/catches-name-with-dots.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/object-does-not-match-filename/catches-name-with-dots.yaml
@@ -4,7 +4,8 @@
 sheets:
   - /org/eolang/lints/names/object-does-not-match-filename.xsl
 asserts:
-  - /defects[count(defect[@severity='warning'])=0]
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='2']
 document: |
   <program source="foo/bar/seq.some.eo">
     <metas>


### PR DESCRIPTION
In this PR I've updated `object-does-not-match-filename` to check only `program/@source` contains object name, instead of checking full path `program/@source` starts with object name.

closes #460
