### PR TITLE
feat(#291): `named-object-abstract-nested` lint

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/named-object-abstract-nested.xsl
+++ b/src/main/resources/org/eolang/lints/critical/named-object-abstract-nested.xsl
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="named-object-abstract-nested" version="2.0">
+  <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[@name]//o[@name and not(parent::o[eo:abstract(.)])]">
+        <defect>
+          <xsl:variable name="line" select="eo:lineno(@line)"/>
+          <xsl:attribute name="line">
+            <xsl:value-of select="$line"/>
+          </xsl:attribute>
+          <xsl:if test="$line = '0'">
+            <xsl:attribute name="context">
+              <xsl:value-of select="eo:defect-context(.)"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:attribute name="severity">critical</xsl:attribute>
+          <xsl:text>The </xsl:text>
+          <xsl:value-of select="eo:escape(@name)"/>
+          <xsl:text> object is deeply nested in the abstract object, while named objects are allowed only on the first level of depth in abstract objects</xsl:text>
+        </defect>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/critical/named-object-abstract-nested.md
+++ b/src/main/resources/org/eolang/motives/critical/named-object-abstract-nested.md
@@ -1,0 +1,32 @@
+# Named Object Abstract Nested
+
+In [XMIR], named objects cannot be nested deeper than one level inside an
+abstract object.
+
+Incorrect:
+
+```xml
+<objects>
+  <o base="x" name="@">
+    <o base="y" name="a">
+      <o base="z" name="b"/>
+    </o>
+  </o>
+</objects>
+```
+
+Correct:
+
+```xml
+<objects>
+  <o base="x" name="@">
+    <o base="$.a"/>
+  </o>
+  <o base="y" name="a">
+    <o base="$.b"/>
+  </o>
+  <o base="z" name="b"/>
+</objects>
+```
+
+[XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html

--- a/src/test/resources/org/eolang/lints/packs/single/named-object-abstract-nested/allows-chain-of-bases.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/named-object-abstract-nested/allows-chain-of-bases.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/critical/named-object-abstract-nested.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o name="foo">
+        <o base="xyz">
+          <o base="num"/>
+        </o>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/single/named-object-abstract-nested/allows-eo-in-canonical-form.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/named-object-abstract-nested/allows-eo-in-canonical-form.yaml
@@ -5,13 +5,9 @@ sheets:
   - /org/eolang/lints/critical/named-object-abstract-nested.xsl
 asserts:
   - /defects[count(defect[@severity='critical'])=0]
-document: |
-  <program>
-    <objects>
-      <o name="foo">
-        <o name="bar">
-          <o base="num"/>
-        </o>
-      </o>
-    </objects>
-  </program>
+input: |
+  # Foo.
+  [] > foo
+    z > b
+    y $.b > a
+    x $.a > @

--- a/src/test/resources/org/eolang/lints/packs/single/named-object-abstract-nested/allows-eo-with-syntax-sugar.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/named-object-abstract-nested/allows-eo-with-syntax-sugar.yaml
@@ -5,13 +5,9 @@ sheets:
   - /org/eolang/lints/critical/named-object-abstract-nested.xsl
 asserts:
   - /defects[count(defect[@severity='critical'])=0]
-document: |
-  <program>
-    <objects>
-      <o name="foo">
-        <o name="bar">
-          <o base="num"/>
-        </o>
-      </o>
-    </objects>
-  </program>
+input: |
+  # Foo.
+  [] > foo
+    x > @
+      y > a
+        z > b

--- a/src/test/resources/org/eolang/lints/packs/single/named-object-abstract-nested/allows-named-object-on-the-first-level.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/named-object-abstract-nested/allows-named-object-on-the-first-level.yaml
@@ -1,0 +1,18 @@
+
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/critical/named-object-abstract-nested.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o name="foo">
+        <o name="bar">
+          <o base="num"/>
+        </o>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/single/named-object-abstract-nested/allows-nested-bases.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/named-object-abstract-nested/allows-nested-bases.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/critical/named-object-abstract-nested.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <program>
+    <objects>
+      <o base="x" name="@">
+        <o base="$.a"/>
+      </o>
+      <o base="y" name="a">
+        <o base="$.b"/>
+      </o>
+      <o base="z" name="b"/>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/single/named-object-abstract-nested/catches-multiple-named-nested-abstract.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/named-object-abstract-nested/catches-multiple-named-nested-abstract.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/critical/named-object-abstract-nested.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=2]
+  - /defects/defect[@line='2']
+  - /defects/defect[@line='3']
+document: |
+  <program>
+    <objects>
+      <o base="x" name="@" line="1">
+        <o base="y" name="a" line="2">
+          <o base="z" name="b" line="3"/>
+        </o>
+      </o>
+    </objects>
+  </program>

--- a/src/test/resources/org/eolang/lints/packs/single/named-object-abstract-nested/catches-named-object-nested-in-abstract.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/named-object-abstract-nested/catches-named-object-nested-in-abstract.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/critical/named-object-abstract-nested.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=1]
+  - /defects/defect[@line='3']
+document: |
+  <program>
+    <objects>
+      <o name="foo" line="1">
+        <o base="xyz" line="2">
+          <o base="num" name="abc" line="3"/>
+        </o>
+      </o>
+    </objects>
+  </program>


### PR DESCRIPTION
In this PR I've introduced new lint: `named-object-abstract-nested`, that issues defect with `critical` severity, if named object is nested deeper more than one level inside abstract object.

closes #291
History:
- **feat(#291): start**
- **feat(#291): EO forms**
- **feat(#291): more tests**
- **feat(#291): motive**
