### PR TITLE
bug(#473): pit exclude hadoop class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,6 +323,9 @@
                     <class>org.eolang.lints.WpaLintsTest</class>
                     <class>org.eolang.lints.LtReservedNameTest</class>
                   </excludedTestClasses>
+                  <excludedClasses>
+                    <class>org.apache.hadoop.hdfs.server.namenode.FSNamesystem</class>
+                  </excludedClasses>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -324,6 +324,7 @@
                     <class>org.eolang.lints.LtReservedNameTest</class>
                   </excludedTestClasses>
                   <excludedClasses>
+                    <!-- Used as benchmark resource. -->
                     <class>org.apache.hadoop.hdfs.server.namenode.FSNamesystem</class>
                   </excludedClasses>
                 </configuration>


### PR DESCRIPTION
In this PR I've updated `pit` configuration to exclude large Hadoop HDFS benchmark class `org.apache.hadoop.hdfs.server.namenode.FSNamesystem` from mutation checks.

closes #473