### PR TITLE
feat(#476): `Defect.experimental()`

### DIFF
--- a/src/main/java/org/eolang/lints/Defect.java
+++ b/src/main/java/org/eolang/lints/Defect.java
@@ -97,6 +97,12 @@ public interface Defect {
     String context();
 
     /**
+     * Experimental?
+     * @return Experimental
+     */
+    boolean experimental();
+
+    /**
      * Default implementation of {@link Defect}.
      * <p>
      * Provides a standard implementation with basic functionality.
@@ -131,6 +137,27 @@ public interface Defect {
         private final String txt;
 
         /**
+         * Experiment?
+         */
+        private final boolean experiment;
+
+        /**
+         * Ctor.
+         * @param rule Rule name
+         * @param severity Severity level
+         * @param program Name of the program
+         * @param line Line number
+         * @param text Description of the defect
+         * @checkstyle ParameterNumberCheck (5 lines)
+         */
+        public Default(
+            final String rule, final Severity severity,
+            final String program, final int line, final String text
+        ) {
+            this(rule, severity, program, line, text, false);
+        }
+
+        /**
          * Ctor.
          * <p>
          * Constructs a defect with all required information.
@@ -145,13 +172,15 @@ public interface Defect {
          */
         public Default(
             final String rule, final Severity severity,
-            final String program, final int line, final String text
+            final String program, final int line, final String text,
+            final boolean exprmnt
         ) {
             this.rle = rule;
             this.sev = severity;
             this.prg = program;
             this.lineno = line;
             this.txt = text;
+            this.experiment = exprmnt;
         }
 
         @Override
@@ -199,6 +228,11 @@ public interface Defect {
         @Override
         public String context() {
             return "Context is empty";
+        }
+
+        @Override
+        public boolean experimental() {
+            return this.experiment;
         }
 
         @Override

--- a/src/main/java/org/eolang/lints/Defect.java
+++ b/src/main/java/org/eolang/lints/Defect.java
@@ -110,6 +110,7 @@ public interface Defect {
      *
      * @since 0.0.1
      */
+    @SuppressWarnings("PMD.TooManyMethods")
     final class Default implements Defect {
         /**
          * Rule.
@@ -168,6 +169,7 @@ public interface Defect {
          * @param program Name of the program
          * @param line Line number
          * @param text Description of the defect
+         * @param exprmnt Experimental?
          * @checkstyle ParameterNumberCheck (5 lines)
          */
         public Default(

--- a/src/main/java/org/eolang/lints/DfContext.java
+++ b/src/main/java/org/eolang/lints/DfContext.java
@@ -70,6 +70,11 @@ final class DfContext implements Defect {
     }
 
     @Override
+    public boolean experimental() {
+        return this.origin.experimental();
+    }
+
+    @Override
     public String toString() {
         return this.origin.toString();
     }

--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -104,7 +104,8 @@ final class LtByXsl implements Lint<XML> {
                         Severity.parsed(sever.get()),
                         LtByXsl.findName(xmir),
                         this.lineno(xml),
-                        xml.text().get()
+                        xml.text().get(),
+                        this.experimental(xml)
                     ),
                     xml.attribute("context").text().orElse("")
                 )
@@ -116,6 +117,17 @@ final class LtByXsl implements Lint<XML> {
     @Override
     public String motive() throws IOException {
         return new IoCheckedText(new TextOf(this.doc)).asString();
+    }
+
+    private boolean experimental(final Xnav defect) {
+        final boolean result;
+        final Optional<String> attr = defect.attribute("experimental").text();
+        if (attr.isEmpty()) {
+            result = false;
+        } else {
+            result = Boolean.parseBoolean(attr.get());
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -105,7 +105,7 @@ final class LtByXsl implements Lint<XML> {
                         LtByXsl.findName(xmir),
                         this.lineno(xml),
                         xml.text().get(),
-                        this.experimental(xml)
+                        LtByXsl.experimental(xml)
                     ),
                     xml.attribute("context").text().orElse("")
                 )
@@ -119,7 +119,7 @@ final class LtByXsl implements Lint<XML> {
         return new IoCheckedText(new TextOf(this.doc)).asString();
     }
 
-    private boolean experimental(final Xnav defect) {
+    private static boolean experimental(final Xnav defect) {
         final boolean result;
         final Optional<String> attr = defect.attribute("experimental").text();
         if (attr.isEmpty()) {

--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -119,6 +119,11 @@ final class LtByXsl implements Lint<XML> {
         return new IoCheckedText(new TextOf(this.doc)).asString();
     }
 
+    /**
+     * Defect is experimental?
+     * @param defect Defect
+     * @return Experimental or not
+     */
     private static boolean experimental(final Xnav defect) {
         final boolean result;
         final Optional<String> attr = defect.attribute("experimental").text();

--- a/src/test/java/org/eolang/lints/DefectTest.java
+++ b/src/test/java/org/eolang/lints/DefectTest.java
@@ -61,4 +61,20 @@ final class DefectTest {
             Matchers.hasToString(Matchers.not(Matchers.containsString(":0")))
         );
     }
+
+    @Test
+    void returnsExperimental() {
+        MatcherAssert.assertThat(
+            "Experimental flag should be true",
+            new Defect.Default(
+                "f12",
+                Severity.ERROR,
+                "f.12",
+                42,
+                "This is wrong",
+                true
+            ).experimental(),
+            Matchers.equalTo(true)
+        );
+    }
 }

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import matchers.DefectsMatcher;
 import org.cactoos.io.ResourceOf;
+import org.cactoos.list.ListOf;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 import org.eolang.jucs.ClasspathSource;
@@ -218,6 +219,25 @@ final class LtByXslTest {
                 new BytecodeClass("com/sun/jna/Pointer.class").value()
             ),
             "Huge XMIR must pass in reasonable time. See the timeout value."
+        );
+    }
+
+    @Test
+    void returnsNonExperimentalWhenXslStaysQuiet() throws IOException {
+        MatcherAssert.assertThat(
+            "Experimental flag should be set to false",
+            new ListOf<>(
+                new LtByXsl("comments/comment-without-dot").defects(
+                    new EoSyntax(
+                        String.join(
+                            "\n",
+                            "# Foo",
+                            "[] > foo"
+                        )
+                    ).parsed()
+                )
+            ).get(0).experimental(),
+            Matchers.equalTo(false)
         );
     }
 


### PR DESCRIPTION
In this PR I've added new method into `Defect`: `Defect.experimental()`, which serves as indicator of experimental lint.

closes #476
History:
- **feat(#476): Defect.experimental()**
- **feat(#476): clean for qulice**
