### PR TITLE
feat(#379): `no-attribute-formation` experimental lint

### DIFF
--- a/src/main/resources/org/eolang/lints/design/no-attribute-formation.xsl
+++ b/src/main/resources/org/eolang/lints/design/no-attribute-formation.xsl
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="no-attribute-formation">
+  <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+<!--   ignore tests   -->
+      <xsl:for-each select="//o[eo:abstract(.) and not(parent::o[@base='Q.org.eolang.bytes']) and not(o[@base='∅'])]">
+        <defect>
+          <xsl:variable name="line" select="eo:lineno(@line)"/>
+          <xsl:attribute name="line">
+            <xsl:value-of select="$line"/>
+          </xsl:attribute>
+          <xsl:if test="$line = '0'">
+            <xsl:attribute name="context">
+              <xsl:value-of select="eo:defect-context(.)"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:attribute name="severity">warning</xsl:attribute>
+          <xsl:text>The formation </xsl:text>
+          <xsl:value-of select="eo:escape(@name)"/>
+          <xsl:text> does not have any void attributes</xsl:text>
+        </defect>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/design/no-attribute-formation.xsl
+++ b/src/main/resources/org/eolang/lints/design/no-attribute-formation.xsl
@@ -24,6 +24,7 @@
               </xsl:attribute>
             </xsl:if>
             <xsl:attribute name="severity">warning</xsl:attribute>
+            <xsl:attribute name="experimental">true</xsl:attribute>
             <xsl:text>The formation </xsl:text>
             <xsl:value-of select="eo:escape(@name)"/>
             <xsl:text> does not have any void attributes</xsl:text>

--- a/src/main/resources/org/eolang/lints/design/no-attribute-formation.xsl
+++ b/src/main/resources/org/eolang/lints/design/no-attribute-formation.xsl
@@ -11,24 +11,25 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-<!--   ignore tests   -->
-      <xsl:for-each select="//o[eo:abstract(.) and not(parent::o[@base='Q.org.eolang.bytes']) and not(o[@base='∅'])]">
-        <defect>
-          <xsl:variable name="line" select="eo:lineno(@line)"/>
-          <xsl:attribute name="line">
-            <xsl:value-of select="$line"/>
-          </xsl:attribute>
-          <xsl:if test="$line = '0'">
-            <xsl:attribute name="context">
-              <xsl:value-of select="eo:defect-context(.)"/>
+      <xsl:if test="not(/program[metas/meta[head='tests']])">
+        <xsl:for-each select="//o[eo:abstract(.) and not(parent::o[@base='Q.org.eolang.bytes']) and not(o[@base='∅'])]">
+          <defect>
+            <xsl:variable name="line" select="eo:lineno(@line)"/>
+            <xsl:attribute name="line">
+              <xsl:value-of select="$line"/>
             </xsl:attribute>
-          </xsl:if>
-          <xsl:attribute name="severity">warning</xsl:attribute>
-          <xsl:text>The formation </xsl:text>
-          <xsl:value-of select="eo:escape(@name)"/>
-          <xsl:text> does not have any void attributes</xsl:text>
-        </defect>
-      </xsl:for-each>
+            <xsl:if test="$line = '0'">
+              <xsl:attribute name="context">
+                <xsl:value-of select="eo:defect-context(.)"/>
+              </xsl:attribute>
+            </xsl:if>
+            <xsl:attribute name="severity">warning</xsl:attribute>
+            <xsl:text>The formation </xsl:text>
+            <xsl:value-of select="eo:escape(@name)"/>
+            <xsl:text> does not have any void attributes</xsl:text>
+          </defect>
+        </xsl:for-each>
+      </xsl:if>
     </defects>
   </xsl:template>
 </xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/design/no-attribute-formation.md
+++ b/src/main/resources/org/eolang/motives/design/no-attribute-formation.md
@@ -1,0 +1,22 @@
+# No Attribute Formation
+
+It's not recommended to have formation without void attributes. Such formations
+are similar to [Utility classes] in Java.
+
+Incorrect:
+
+```eo
+# Foo.
+[] > foo
+  52 > spb
+```
+
+Correct:
+
+```eo
+# Foo.
+[x] > foo
+  x > sbp
+```
+
+[Utility classes]: https://www.yegor256.com/2015/02/26/composable-decorators.html

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -77,8 +77,8 @@ final class ProgramTest {
                         // REUSE-IgnoreEnd
                         "",
                         "# This is just a test object with no functionality.",
-                        "[] > foo",
-                        "  42 > x"
+                        "[i] > foo",
+                        "  i > x"
                     )
                 ).parsed()
             ).defects(),
@@ -105,6 +105,7 @@ final class ProgramTest {
                             "+unlint comment-too-short",
                             "+unlint unsorted-metas",
                             "+unlint mandatory-spdx",
+                            "+unlint no-attribute-formation",
                             "# Test.",
                             "[] > foo"
                         )
@@ -256,7 +257,8 @@ final class ProgramTest {
                 "mandatory-version",
                 "mandatory-package",
                 "comment-too-short",
-                "mandatory-spdx"
+                "mandatory-spdx",
+                "no-attribute-formation"
             ).defects(),
             Matchers.emptyIterable()
         );
@@ -276,9 +278,11 @@ final class ProgramTest {
                         "+version 0.0.0",
                         "",
                         "# No comments.",
-                        "[] > main",
+                        "[c] > main",
                         "  QQ.io.stdout",
-                        "    \"Hello world\""
+                        "    QQ.txt.sprintf",
+                        "      \"Hello %s\"",
+                        "      * c"
                     )
                 ).parsed()
             ).without("mandatory-spdx", "comment-too-short").defects(),

--- a/src/test/resources/org/eolang/lints/canonical.eo
+++ b/src/test/resources/org/eolang/lints/canonical.eo
@@ -7,9 +7,9 @@
 +unlint unused-void-attr
 
 # Times table, which is a canonical example of EO program.
-[] > canonical
+[start] > canonical
   malloc.for > @
-    0
+    start
     [x] >>
       seq > @
         *

--- a/src/test/resources/org/eolang/lints/packs/single/no-attribute-formation/allows-formation-with-voids.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/no-attribute-formation/allows-formation-with-voids.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/no-attribute-formation.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # No comments.
+  [x] > string-utils
+    42 > mw

--- a/src/test/resources/org/eolang/lints/packs/single/no-attribute-formation/allows-formation-without-voids-in-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/no-attribute-formation/allows-formation-without-voids-in-tests.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/no-attribute-formation.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  +tests
+
+  # No comments.
+  [] > runs-analysis
+    52 > spb

--- a/src/test/resources/org/eolang/lints/packs/single/no-attribute-formation/catches-formation-without-voids.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/no-attribute-formation/catches-formation-without-voids.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/no-attribute-formation.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='2']
+input: |
+  # No comments.
+  [] > foo
+    42 > mw

--- a/src/test/resources/org/eolang/lints/packs/single/no-attribute-formation/catches-formation-without-voids.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/no-attribute-formation/catches-formation-without-voids.yaml
@@ -4,7 +4,7 @@
 sheets:
   - /org/eolang/lints/design/no-attribute-formation.xsl
 asserts:
-  - /defects[count(defect[@severity='warning'])=1]
+  - /defects[count(defect[@severity='warning' and @experimental])=1]
   - /defects/defect[@line='2']
 input: |
   # No comments.


### PR DESCRIPTION
In this PR I've introduced new experimental lint: `no-attribute-formation`, that issues defect with `warning` severity, if formation does not have any void attributes.

closes #379
History:
- **feat(#379): start**
- **feat(#379): ignore in tests**
- **feat(#379): motive**
- **feat(#379): void in canonical**
- **feat(#379): clean up sources**
