### PR TITLE
bug(#482): allow atom formations in `unused-void-attr`

### DIFF
--- a/src/main/resources/org/eolang/lints/errors/unused-void-attr.xsl
+++ b/src/main/resources/org/eolang/lints/errors/unused-void-attr.xsl
@@ -14,7 +14,7 @@
       <xsl:for-each select="//o[@base='∅']">
         <xsl:variable name="attr" select="@name"/>
         <xsl:variable name="formation" select=".."/>
-        <xsl:if test="not($formation//o[contains(@base, concat('$.', $attr))]/ancestor::o[eo:abstract(.)][1][generate-id()=$formation/generate-id()]) and not($formation//o[eo:atom(.)])">
+        <xsl:if test="not(eo:atom($formation)) and not($formation//o[contains(@base, concat('$.', $attr))]/ancestor::o[eo:abstract(.)][1][generate-id()=$formation/generate-id()]) and not($formation//o[eo:atom(.)])">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/motives/errors/unused-void-attr.md
+++ b/src/main/resources/org/eolang/motives/errors/unused-void-attr.md
@@ -25,3 +25,10 @@ Unused void attributes are allowed only if there are atoms in the program:
 [x] > foo
   [] > bar ?
 ```
+
+Or formation itself is the atom:
+
+```eo
+# Foo.
+[x] > foo ?
+```

--- a/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/allows-unused-voids-in-atom.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/allows-unused-voids-in-atom.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/errors/unused-void-attr.xsl
+asserts:
+  - /defects[count(defect[@severity='error'])=0]
+input: |
+  # Error.
+  [message] > error ?


### PR DESCRIPTION
In this PR I've updated `unused-void-attr` lint to not complain about unused void attributes, if the formation itself is the atom.

see #482