### PR TITLE
bug(#483): remove defect duplication in `anonymous-formation`

### DIFF
--- a/src/main/resources/org/eolang/lints/names/anonymous-formation.xsl
+++ b/src/main/resources/org/eolang/lints/names/anonymous-formation.xsl
@@ -12,7 +12,7 @@
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="//o[not(@name) and not(@base) and not(eo:has-data(.) and parent::o[@base='Q.org.eolang.bytes'])]">
-        <xsl:for-each select="//o[starts-with(@base, '$.^.')]">
+        <xsl:for-each select=".//o[starts-with(@base, '$.^.')]">
           <defect>
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/catches-anonymous-with-multiple-formations.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/catches-anonymous-with-multiple-formations.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/anonymous-formation.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=2]
+  - /defects/defect[@line='9']
+  - /defects/defect[@line='14']
+input: |
+  # App.
+  [] > app
+    "1st" > f
+    "2nd" > t
+    malloc.of
+      64
+      [m]
+        QQ.io.stdout > @
+          t
+    malloc.of
+      52
+      [o]
+        QQ.io.stdout > @
+          f


### PR DESCRIPTION
In this PR I've removed defect duplication in `anonymous-formation`, when multiple formations are in the scope.

closes #483