### PR TITLE
feat(#486): add info about min xcop version

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ mvn jmh:benchmark
 ```
 
 You will need [Maven 3.3+](https://maven.apache.org) and Java 11+ installed.
-Also, if you have [xcop](https://github.com/yegor256/xcop) installed, make sure
-it is version `0.8.0`+.
+Also, if you have [xcop](https://github.com/yegor256/xcop) installed, make 
+sure it is version `0.8.0`+.
 
 [XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html
 [EO]: https://www.eolang.org

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ mvn jmh:benchmark
 ```
 
 You will need [Maven 3.3+](https://maven.apache.org) and Java 11+ installed.
+Also, if you have [xcop](https://github.com/yegor256/xcop) installed, make sure
+it is version `0.8.0`+.
 
 [XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html
 [EO]: https://www.eolang.org

--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ mvn jmh:benchmark
 ```
 
 You will need [Maven 3.3+](https://maven.apache.org) and Java 11+ installed.
-Also, if you have [xcop](https://github.com/yegor256/xcop) installed, make 
-sure it is version `0.8.0`+.
+Also, if you have [xcop](https://github.com/yegor256/xcop) installed, make sure
+it is version `0.8.0`+.
 
 [XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html
 [EO]: https://www.eolang.org


### PR DESCRIPTION
This task solves the problem that when building a project locally, a strange error may occur due to an incorrect version of xcop

The information in the README about the minimum version has been added here