### PR TITLE
bug(#488): jcabi-xml up to `0.34.0`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-xml</artifactId>
-      <version>0.33.5</version>
+      <version>0.34.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.secretx33</groupId>


### PR DESCRIPTION
In this PR I've updated `jcabi-xml` to `0.34.0` version with feature of re-throwing stylesheet compilation warnings. Thus, our 
XSL pipeline will be more strict.

closes #488