### PR TITLE
bug(#495): `unlint-non-existing-defect` does not execute excluded lints from `Program`/`Programs`

### DIFF
--- a/src/main/java/org/eolang/lints/DefectMissing.java
+++ b/src/main/java/org/eolang/lints/DefectMissing.java
@@ -39,7 +39,7 @@ final class DefectMissing implements Function<String, Boolean> {
 
     @Override
     public Boolean apply(final String unlint) {
-        final boolean matches;
+        final boolean missing;
         final String[] split = unlint.split(":");
         final String name = split[0];
         final Set<String> names;
@@ -49,12 +49,16 @@ final class DefectMissing implements Function<String, Boolean> {
             names = new SetOf<>();
         }
         if (split.length > 1) {
-            final List<Integer> lines = this.defects.get(name);
-            matches = (!names.contains(name) || !lines.contains(Integer.parseInt(split[1])))
-                && !this.excluded.contains(name);
+            if (this.defects != null) {
+                final List<Integer> lines = this.defects.get(name);
+                missing = (!names.contains(name) || !lines.contains(Integer.parseInt(split[1])))
+                    && !this.excluded.contains(name);
+            } else {
+                missing = true;
+            }
         } else {
-            matches = !names.contains(name) && !this.excluded.contains(name);
+            missing = !names.contains(name) && !this.excluded.contains(name);
         }
-        return matches;
+        return missing;
     }
 }

--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -86,7 +86,7 @@ final class LtUnlint implements Lint<XML> {
             )
         );
         if (!added.get() && !global) {
-            defects.addAll(this.origin.defects(xmir));
+            defects.addAll(found);
         }
         return defects;
     }

--- a/src/main/java/org/eolang/lints/PkMono.java
+++ b/src/main/java/org/eolang/lints/PkMono.java
@@ -66,7 +66,7 @@ final class PkMono extends IterableEnvelope<Lint<XML>> {
      * @param names Lint names to exclude
      * @return Filtered lints
      */
-    PkMono without(final String... names) {
+    static PkMono without(final String... names) {
         return new PkMono(new WithoutLints<>(PkMono.LINTS, new ListOf<>(names)));
     }
 }

--- a/src/main/java/org/eolang/lints/PkMono.java
+++ b/src/main/java/org/eolang/lints/PkMono.java
@@ -5,8 +5,9 @@
 package org.eolang.lints;
 
 import com.jcabi.xml.XML;
-import java.util.List;
+import java.util.Collection;
 import javax.annotation.concurrent.ThreadSafe;
+import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.IterableEnvelope;
 import org.cactoos.iterable.Joined;
 import org.cactoos.iterable.Mapped;
@@ -37,19 +38,37 @@ final class PkMono extends IterableEnvelope<Lint<XML>> {
      * Default ctor.
      */
     PkMono() {
+        this(PkMono.LINTS);
+    }
+
+    /**
+     * Ctor.
+     * @param lints Lints
+     */
+    PkMono(final Iterable<Lint<XML>> lints) {
         super(
             new Joined<>(
                 new Mapped<Lint<XML>>(
                     LtUnlint::new,
                     new Joined<Lint<XML>>(
-                        PkMono.LINTS,
-                        List.of(
+                        lints,
+                        new ListOf<>(
                             new LtUnlintNonExistingDefect(
-                                PkMono.LINTS, new ListOf<>(new WpaLintNames())
+                                lints, new ListOf<>(new WpaLintNames())
                             )
                         )
                     )
                 )
+            )
+        );
+    }
+
+    PkMono without(final String... names) {
+        final Collection<String> listed = new ListOf<>(names);
+        return new PkMono(
+            new Filtered<>(
+            PkMono.LINTS,
+            lint -> () -> !listed.contains(lint.name())
             )
         );
     }

--- a/src/main/java/org/eolang/lints/PkMono.java
+++ b/src/main/java/org/eolang/lints/PkMono.java
@@ -5,9 +5,7 @@
 package org.eolang.lints;
 
 import com.jcabi.xml.XML;
-import java.util.Collection;
 import javax.annotation.concurrent.ThreadSafe;
-import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.IterableEnvelope;
 import org.cactoos.iterable.Joined;
 import org.cactoos.iterable.Mapped;
@@ -63,13 +61,12 @@ final class PkMono extends IterableEnvelope<Lint<XML>> {
         );
     }
 
+    /**
+     * Without lints.
+     * @param names Lint names to exclude
+     * @return Filtered lints
+     */
     PkMono without(final String... names) {
-        final Collection<String> listed = new ListOf<>(names);
-        return new PkMono(
-            new Filtered<>(
-            PkMono.LINTS,
-            lint -> () -> !listed.contains(lint.name())
-            )
-        );
+        return new PkMono(new WithoutLints<>(PkMono.LINTS, new ListOf<>(names)));
     }
 }

--- a/src/main/java/org/eolang/lints/PkWpa.java
+++ b/src/main/java/org/eolang/lints/PkWpa.java
@@ -5,9 +5,7 @@
 package org.eolang.lints;
 
 import com.jcabi.xml.XML;
-import java.util.Collection;
 import java.util.Map;
-import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.IterableEnvelope;
 import org.cactoos.iterable.Joined;
 import org.cactoos.iterable.Mapped;
@@ -58,13 +56,12 @@ final class PkWpa extends IterableEnvelope<Lint<Map<String, XML>>> {
         );
     }
 
+    /**
+     * Without lints.
+     * @param names Lint names to exclude
+     * @return Filtered lints
+     */
     PkWpa without(final String... names) {
-        final Collection<String> listed = new ListOf<>(names);
-        return new PkWpa(
-            new Filtered<>(
-                PkWpa.WPA,
-                lint -> () -> !listed.contains(lint.name())
-            )
-        );
+        return new PkWpa(new WithoutLints<>(PkWpa.WPA, new ListOf<>(names)));
     }
 }

--- a/src/main/java/org/eolang/lints/PkWpa.java
+++ b/src/main/java/org/eolang/lints/PkWpa.java
@@ -5,7 +5,9 @@
 package org.eolang.lints;
 
 import com.jcabi.xml.XML;
+import java.util.Collection;
 import java.util.Map;
+import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.IterableEnvelope;
 import org.cactoos.iterable.Joined;
 import org.cactoos.iterable.Mapped;
@@ -28,22 +30,40 @@ final class PkWpa extends IterableEnvelope<Lint<Map<String, XML>>> {
     private static final Iterable<Lint<Map<String, XML>>> WPA = new WpaLints();
 
     /**
-     * Ctor.
+     * Default ctor.
      */
     PkWpa() {
+        this(PkWpa.WPA);
+    }
+
+    /**
+     * Ctor.
+     * @param lints Lints
+     */
+    PkWpa(final Iterable<Lint<Map<String, XML>>> lints) {
         super(
             new Shuffled<>(
                 new Mapped<Lint<Map<String, XML>>>(
                     LtWpaUnlint::new,
                     new Joined<Lint<Map<String, XML>>>(
-                        PkWpa.WPA,
+                        lints,
                         new ListOf<>(
                             new LtUnlintNonExistingDefectWpa(
-                                PkWpa.WPA, new ListOf<>(new MonoLintNames())
+                                lints, new ListOf<>(new MonoLintNames())
                             )
                         )
                     )
                 )
+            )
+        );
+    }
+
+    PkWpa without(final String... names) {
+        final Collection<String> listed = new ListOf<>(names);
+        return new PkWpa(
+            new Filtered<>(
+                PkWpa.WPA,
+                lint -> () -> !listed.contains(lint.name())
             )
         );
     }

--- a/src/main/java/org/eolang/lints/PkWpa.java
+++ b/src/main/java/org/eolang/lints/PkWpa.java
@@ -61,7 +61,7 @@ final class PkWpa extends IterableEnvelope<Lint<Map<String, XML>>> {
      * @param names Lint names to exclude
      * @return Filtered lints
      */
-    PkWpa without(final String... names) {
+    static PkWpa without(final String... names) {
         return new PkWpa(new WithoutLints<>(PkWpa.WPA, new ListOf<>(names)));
     }
 }

--- a/src/main/java/org/eolang/lints/Program.java
+++ b/src/main/java/org/eolang/lints/Program.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import org.cactoos.iterable.Sticky;
 import org.cactoos.iterable.Synced;
-import org.cactoos.list.ListOf;
 
 /**
  * A single XMIR program to analyze.
@@ -81,7 +80,7 @@ public final class Program {
     public Program without(final String... names) {
         return new Program(
             this.xmir,
-            new PkMono(new WithoutLints<>(this.lints, new ListOf<>(names))).without(names)
+            PkMono.without(names)
         );
     }
 

--- a/src/main/java/org/eolang/lints/Program.java
+++ b/src/main/java/org/eolang/lints/Program.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.Sticky;
 import org.cactoos.iterable.Synced;
 import org.cactoos.list.ListOf;
@@ -80,15 +79,9 @@ public final class Program {
      * @return Program analysis without specific name
      */
     public Program without(final String... names) {
-        final Collection<String> listed = new ListOf<>(names);
         return new Program(
             this.xmir,
-            new PkMono(
-                new Filtered<>(
-                    this.lints,
-                    lint -> () -> !listed.contains(lint.name())
-                )
-            ).without(names)
+            new PkMono(new WithoutLints<>(this.lints, new ListOf<>(names))).without(names)
         );
     }
 

--- a/src/main/java/org/eolang/lints/Program.java
+++ b/src/main/java/org/eolang/lints/Program.java
@@ -83,9 +83,12 @@ public final class Program {
         final Collection<String> listed = new ListOf<>(names);
         return new Program(
             this.xmir,
-            new Filtered<>(
-                this.lints, lint -> () -> !listed.contains(lint.name())
-            )
+            new PkMono(
+                new Filtered<>(
+                    this.lints,
+                    lint -> () -> !listed.contains(lint.name())
+                )
+            ).without(names)
         );
     }
 

--- a/src/main/java/org/eolang/lints/Programs.java
+++ b/src/main/java/org/eolang/lints/Programs.java
@@ -111,7 +111,7 @@ public final class Programs {
     public Programs without(final String... names) {
         return new Programs(
             this.pkg,
-            new PkWpa(new WithoutLints<>(this.lints, new ListOf<>(names))).without(names)
+            PkWpa.without(names)
         );
     }
 

--- a/src/main/java/org/eolang/lints/Programs.java
+++ b/src/main/java/org/eolang/lints/Programs.java
@@ -113,9 +113,11 @@ public final class Programs {
         final Collection<String> listed = new ListOf<>(names);
         return new Programs(
             this.pkg,
-            new Filtered<>(
-                this.lints, lint -> () -> !listed.contains(lint.name())
-            )
+            new PkWpa(
+                new Filtered<>(
+                    this.lints, lint -> () -> !listed.contains(lint.name())
+                )
+            ).without(names)
         );
     }
 

--- a/src/main/java/org/eolang/lints/Programs.java
+++ b/src/main/java/org/eolang/lints/Programs.java
@@ -18,7 +18,6 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.Sticky;
 import org.cactoos.list.ListOf;
 import org.cactoos.list.Synced;
@@ -110,14 +109,9 @@ public final class Programs {
      * @return Program analysis without specifics names
      */
     public Programs without(final String... names) {
-        final Collection<String> listed = new ListOf<>(names);
         return new Programs(
             this.pkg,
-            new PkWpa(
-                new Filtered<>(
-                    this.lints, lint -> () -> !listed.contains(lint.name())
-                )
-            ).without(names)
+            new PkWpa(new WithoutLints<>(this.lints, new ListOf<>(names))).without(names)
         );
     }
 

--- a/src/main/java/org/eolang/lints/WithoutLints.java
+++ b/src/main/java/org/eolang/lints/WithoutLints.java
@@ -10,6 +10,7 @@ import org.cactoos.iterable.IterableEnvelope;
 
 /**
  * Lints without some lints.
+ * @param <X> Lint generic type
  * @since 0.0.46
  */
 final class WithoutLints<X extends Lint<?>> extends IterableEnvelope<X> {

--- a/src/main/java/org/eolang/lints/WithoutLints.java
+++ b/src/main/java/org/eolang/lints/WithoutLints.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import java.util.Collection;
+import org.cactoos.iterable.Filtered;
+import org.cactoos.iterable.IterableEnvelope;
+
+/**
+ * Lints without some lints.
+ * @since 0.0.46
+ */
+final class WithoutLints<X extends Lint<?>> extends IterableEnvelope<X> {
+    /**
+     * Ctor.
+     *
+     * @param origin Origin lints
+     * @param names Lint names to exclude
+     */
+    WithoutLints(final Iterable<X> origin, final Collection<String> names) {
+        super(
+            new Filtered<>(
+                origin,
+                lint -> () -> !names.contains(lint.name())
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/lints/DefectMissingTest.java
+++ b/src/test/java/org/eolang/lints/DefectMissingTest.java
@@ -39,4 +39,15 @@ final class DefectMissingTest {
             Matchers.equalTo(true)
         );
     }
+
+    @Test
+    void returnsTrueWhenDefectAreNull() {
+        MatcherAssert.assertThat(
+            "Defect should be missed, since defects are NULL",
+            new DefectMissing(
+                null, new ListOf<>()
+            ).apply("unit-test-missing:0"),
+            Matchers.equalTo(true)
+        );
+    }
 }

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -5,16 +5,12 @@
 package org.eolang.lints;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.stream.Collectors;
-import org.cactoos.io.InputOf;
 import org.cactoos.list.ListOf;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for {@link LtUnlintNonExistingDefect}.
@@ -176,45 +172,6 @@ final class LtUnlintNonExistingDefectTest {
                 ).parsed()
             ),
             Matchers.hasSize(Matchers.greaterThan(0))
-        );
-    }
-
-    @ParameterizedTest
-    @ValueSource(
-        strings = {"mandatory-home", "mandatory-home:0"}
-    )
-    void catchesNonExistingDefectForRemovedLintFromProgram(final String lid) throws IOException {
-        MatcherAssert.assertThat(
-            "Found defect does not match with expected",
-            new ListOf<>(
-                new Program(
-                    new EoSyntax(
-                        new InputOf(
-                            String.join(
-                                "\n",
-                                String.format("+unlint %s", lid),
-                                "",
-                                "# Foo.",
-                                "[] > foo"
-                            )
-                        )
-                    ).parsed()
-                ).without(
-                    "mandatory-home",
-                    "mandatory-version",
-                    "empty-object",
-                    "mandatory-package",
-                    "mandatory-spdx",
-                    "comment-too-short",
-                    "no-attribute-formation"
-                ).defects()
-            ).get(0).text(),
-            Matchers.containsString(
-                String.format(
-                    "Unlinting rule '%s' doesn't make sense",
-                    lid
-                )
-            )
         );
     }
 }

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -13,6 +13,8 @@ import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for {@link LtUnlintNonExistingDefect}.
@@ -177,8 +179,11 @@ final class LtUnlintNonExistingDefectTest {
         );
     }
 
-    @Test
-    void catchesNonExistingDefectForRemovedLintFromProgram() throws IOException {
+    @ParameterizedTest
+    @ValueSource(
+        strings = {"mandatory-home", "mandatory-home:0"}
+    )
+    void catchesNonExistingDefectForRemovedLintFromProgram(final String lid) throws IOException {
         MatcherAssert.assertThat(
             "Found defect does not match with expected",
             new ListOf<>(
@@ -187,7 +192,7 @@ final class LtUnlintNonExistingDefectTest {
                         new InputOf(
                             String.join(
                                 "\n",
-                                "+unlint mandatory-home",
+                                String.format("+unlint %s", lid),
                                 "",
                                 "# Foo.",
                                 "[] > foo"
@@ -205,7 +210,10 @@ final class LtUnlintNonExistingDefectTest {
                 ).defects()
             ).get(0).text(),
             Matchers.containsString(
-                "Unlinting rule 'mandatory-home' doesn't make sense"
+                String.format(
+                    "Unlinting rule '%s' doesn't make sense",
+                    lid
+                )
             )
         );
     }

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -180,7 +180,7 @@ final class LtUnlintNonExistingDefectTest {
     @Test
     void catchesNonExistingDefectForRemovedLintFromProgram() throws IOException {
         MatcherAssert.assertThat(
-            "Found defects does not match with expected",
+            "Found defect does not match with expected",
             new ListOf<>(
                 new Program(
                     new EoSyntax(

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -5,7 +5,9 @@
 package org.eolang.lints;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.stream.Collectors;
+import org.cactoos.io.InputOf;
 import org.cactoos.list.ListOf;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
@@ -172,6 +174,39 @@ final class LtUnlintNonExistingDefectTest {
                 ).parsed()
             ),
             Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
+
+    @Test
+    void catchesNonExistingDefectForRemovedLintFromProgram() throws IOException {
+        MatcherAssert.assertThat(
+            "Found defects does not match with expected",
+            new ListOf<>(
+                new Program(
+                    new EoSyntax(
+                        new InputOf(
+                            String.join(
+                                "\n",
+                                "+unlint mandatory-home",
+                                "",
+                                "# Foo.",
+                                "[] > foo"
+                            )
+                        )
+                    ).parsed()
+                ).without(
+                    "mandatory-home",
+                    "mandatory-version",
+                    "empty-object",
+                    "mandatory-package",
+                    "mandatory-spdx",
+                    "comment-too-short",
+                    "no-attribute-formation"
+                ).defects()
+            ).get(0).text(),
+            Matchers.containsString(
+                "Unlinting rule 'mandatory-home' doesn't make sense"
+            )
         );
     }
 }

--- a/src/test/java/org/eolang/lints/ProgramsTest.java
+++ b/src/test/java/org/eolang/lints/ProgramsTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.stream.Collectors;
 import matchers.DefectMatcher;
 import org.cactoos.list.ListOf;
@@ -133,6 +134,37 @@ final class ProgramsTest {
                 )
             ).without("unit-test-missing", "unit-test-without-live-file").defects(),
             Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void catchesNonExistingDefectForRemovedLintFromPrograms(@Mktmp final Path dir) throws IOException {
+        final Collection<Defect> found = new Programs(
+            this.withProgram(
+                dir,
+                "f.xmir",
+                String.join(
+                    "\n",
+                    "+unlint unit-test-missing",
+                    "",
+                    "# F.",
+                    "[] > f"
+                )
+            )
+        ).without("unit-test-missing").defects();
+        MatcherAssert.assertThat(
+            "Defects were not found, though code is broken",
+            found,
+            Matchers.hasSize(Matchers.greaterThan(0))
+        );
+        MatcherAssert.assertThat(
+            "Found defect does not match with expected",
+            new ListOf<>(
+                found
+            ).get(0).text(),
+            Matchers.containsString(
+                "Unlinting rule 'unit-test-missing' doesn't make sense"
+            )
         );
     }
 

--- a/src/test/java/org/eolang/lints/ProgramsTest.java
+++ b/src/test/java/org/eolang/lints/ProgramsTest.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.lints;
 
-import com.jcabi.xml.XML;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
 import com.yegor256.Together;

--- a/src/test/java/org/eolang/lints/WithoutLintsTest.java
+++ b/src/test/java/org/eolang/lints/WithoutLintsTest.java
@@ -4,9 +4,13 @@
  */
 package org.eolang.lints;
 
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -35,5 +39,17 @@ final class WithoutLintsTest {
             ),
             Matchers.iterableWithSize(1)
         );
+    }
+
+    @Test
+    @SuppressWarnings("JTCOP.RuleAssertionMessage")
+    void staysPackagePrivate() {
+        ArchRuleDefinition.classes()
+            .that().haveSimpleName("WithoutLints")
+            .should().bePackagePrivate()
+            .check(new ClassFileImporter()
+                .withImportOption(new ImportOption.DoNotIncludeTests())
+                .importPackages("org.eolang.lints")
+            );
     }
 }

--- a/src/test/java/org/eolang/lints/WithoutLintsTest.java
+++ b/src/test/java/org/eolang/lints/WithoutLintsTest.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for {@link WithoutLints}.
+ * @since 0.0.46
+ */
+final class WithoutLintsTest {
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = {"unit-test-missing", "unit-test-without-live-file"}
+    )
+    void excludesLints(final String lid) {
+        MatcherAssert.assertThat(
+            String.format(
+                "Lint with name '%s' was not excluded, but it should",
+                lid
+            ),
+            new WithoutLints<>(
+                new ListOf<>(
+                    new LtUnitTestMissing(),
+                    new LtUnitTestWithoutLiveFile()
+                ),
+                new ListOf<>(lid)
+            ),
+            Matchers.iterableWithSize(1)
+        );
+    }
+}


### PR DESCRIPTION
In this PR I fixed the bug with redundant execution of lints inside `LtUnlintNonExistingDefect` and `LtUnlintNonExistingDefectWpa`, after lints were removed in `Program.without()` and `Programs.without()`.

closes #495
History:
- **bug(#495): tests**
- **bug(#495): typo**
- **bug(#495): lined too**
- **bug(#495): move test to ProgramTest**
- **bug(#495): ProgramsTest**
- **bug(#495): more tests, implementation**
- **bug(#495): WithoutLints**
- **bug(#495): arch test**
- **bug(#495): clean for qulice**
