### PR TITLE
feat(#493): Xnav.one(path) for fail fast

### DIFF
--- a/src/main/java/org/eolang/lints/LtAtomIsNotUnique.java
+++ b/src/main/java/org/eolang/lints/LtAtomIsNotUnique.java
@@ -169,9 +169,7 @@ final class LtAtomIsNotUnique implements Lint<Map<String, XML>> {
         if (
             xml.path("/object/metas/meta[head='package']").count() == 1L
         ) {
-            final String pack = xml.path("/object/metas/meta[head='package']/tail")
-                .map(o -> o.text().get())
-                .findFirst().get();
+            final String pack = xml.one("/object/metas/meta[head='package']/tail").text().get();
             result = fqns.stream().map(fqn -> String.format("%s.%s", pack, fqn))
                 .collect(Collectors.toList());
         } else {

--- a/src/main/java/org/eolang/lints/LtObjectIsNotUnique.java
+++ b/src/main/java/org/eolang/lints/LtObjectIsNotUnique.java
@@ -110,8 +110,7 @@ final class LtObjectIsNotUnique implements Lint<Map<String, XML>> {
         if (
             xml.path("/object/metas/meta[head='package']").count() == 1L
         ) {
-            name = xml.path("/object/metas/meta[head='package']/tail")
-                .findFirst().get().text().get();
+            name = xml.one("/object/metas/meta[head='package']/tail").text().get();
         } else {
             name = "";
         }


### PR DESCRIPTION
In this PR I've placed usage of `.one(path)` to make XML navigation more strict, where it can be done.

closes #493