### PR TITLE
bug(#510): correct Lint time formatting in benchmark

### DIFF
--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -23,7 +23,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.bytes.UncheckedBytes;
@@ -320,9 +325,26 @@ final class SourceTest {
                 );
             }
         );
+        final String summary = sum.toString();
+        final Pattern tpattern = Pattern.compile(
+            "^Lint time: (\\d+(?:\\.\\d+)?)(ms|s) \\(\\d+ ms\\)$"
+        );
+        Arrays.stream(summary.split("\\R"))
+            .filter(line -> line.startsWith("Lint time:"))
+            .forEach(
+                text ->
+                    MatcherAssert.assertThat(
+                        String.format(
+                            "Lint time '%s' does not match '%s' regex, but it should",
+                            text, tpattern
+                        ),
+                        tpattern.matcher(text).matches(),
+                        Matchers.equalTo(true)
+                    )
+            );
         Files.write(
             Paths.get("target").resolve("lint-summary.txt"),
-            sum.toString().getBytes(StandardCharsets.UTF_8)
+            summary.getBytes(StandardCharsets.UTF_8)
         );
     }
 

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -25,9 +25,8 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.regex.Matcher;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.cactoos.bytes.BytesOf;
@@ -37,6 +36,7 @@ import org.cactoos.io.ResourceOf;
 import org.cactoos.iterable.Sticky;
 import org.cactoos.iterable.Synced;
 import org.cactoos.list.ListOf;
+import org.cactoos.map.MapOf;
 import org.cactoos.scalar.Unchecked;
 import org.cactoos.set.SetOf;
 import org.eolang.parser.EoSyntax;
@@ -297,39 +297,39 @@ final class SourceTest {
     @ExtendWith(MayBeSlow.class)
     @Timeout(600L)
     void lintsBenchmarkSourcesFromJava() throws Exception {
-        final StringBuilder sum = new StringBuilder();
-        new ListOf<>(SourceSize.values()).forEach(
-            source -> {
-                final XML xmir = new Unchecked<>(new BytecodeClass(source)).value();
-                final long start = System.currentTimeMillis();
-                final Collection<Defect> defects = new BcSource(
-                    xmir, source.type()
-                ).defects();
-                final long msec = System.currentTimeMillis() - start;
-                sum.append(
-                    String.join(
-                        "\n",
-                        String.format(
-                            "Input: %s (%s source)", source.java(), source.type()
-                        ),
-                        Logger.format(
-                            "Lint time: %s[ms]s (%d ms)",
-                            msec, msec
-                        )
-                    )
-                ).append("\n\n");
+        final Map<Map<SourceSize, Collection<Defect>>, String> result =
+            SourceTest.benchmarkResults();
+        result.keySet().forEach(
+            defects -> {
+                final SourceSize source = defects.keySet().iterator().next();
                 MatcherAssert.assertThat(
-                    "Defects are empty, but they should not be",
-                    defects,
+                    String.format(
+                        "Defects for source '%s' are empty, but they should not be",
+                        source.java()
+                    ),
+                    defects.get(source),
                     Matchers.hasSize(Matchers.greaterThan(0))
                 );
             }
         );
-        final String summary = sum.toString();
-        final Pattern tpattern = Pattern.compile(
-            "^Lint time: (\\d+(?:\\.\\d+)?)(ms|s) \\(\\d+ ms\\)$"
+        Files.write(
+            Paths.get("target").resolve("lint-summary.txt"),
+            result.values().iterator().next().getBytes(StandardCharsets.UTF_8)
         );
-        Arrays.stream(summary.split("\\R"))
+    }
+
+    @Test
+    @Tag("benchmark")
+    @ExtendWith(MayBeSlow.class)
+    @Timeout(600L)
+    void checksLintTimeFormattingInBenchmarkResults() {
+        final Pattern tpattern = Pattern.compile(
+            "^Lint time: (\\d+(?:\\.\\d+)?)(ms|s|min|h) \\(\\d+ ms\\)$"
+        );
+        final Pattern nlines = Pattern.compile("\\R");
+        Arrays.stream(
+            nlines.split(SourceTest.benchmarkResults().values().iterator().next())
+            )
             .filter(line -> line.startsWith("Lint time:"))
             .forEach(
                 text ->
@@ -342,10 +342,6 @@ final class SourceTest {
                         Matchers.equalTo(true)
                     )
             );
-        Files.write(
-            Paths.get("target").resolve("lint-summary.txt"),
-            summary.getBytes(StandardCharsets.UTF_8)
-        );
     }
 
     @Test
@@ -388,6 +384,41 @@ final class SourceTest {
                     )
                 );
             }
+        );
+    }
+
+    /**
+     * Run benchmark, and output the results.
+     * @return Benchmark results
+     */
+    private static Map<Map<SourceSize, Collection<Defect>>, String> benchmarkResults() {
+        final List<Map<SourceSize, Collection<Defect>>> runs = new ListOf<>();
+        final StringBuilder sum = new StringBuilder();
+        new ListOf<>(SourceSize.values()).forEach(
+            source -> {
+                final XML xmir = new Unchecked<>(new BytecodeClass(source)).value();
+                final long start = System.currentTimeMillis();
+                final Collection<Defect> defects = new BcSource(
+                    xmir, source.type()
+                ).defects();
+                final long msec = System.currentTimeMillis() - start;
+                runs.add(new MapOf<>(source, defects));
+                sum.append(
+                    String.join(
+                        "\n",
+                        String.format(
+                            "Input: %s (%s source)", source.java(), source.type()
+                        ),
+                        Logger.format(
+                            "Lint time: %[ms]s (%d ms)",
+                            msec, msec
+                        )
+                    )
+                ).append("\n\n");
+            }
+        );
+        return runs.stream().collect(
+            Collectors.toMap(run -> run, run -> sum.toString())
         );
     }
 


### PR DESCRIPTION
In this PR I've fixed the bug with lint time formatting, and added new test to validate it.

closes #510
History:
- **bug(#510): start**
- **bug(#510): two tests**
