### PR TITLE
bug(#519): list all supported formatters in the `sprintf-without-formatters`

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/sprintf-without-formatters.xsl
+++ b/src/main/resources/org/eolang/lints/misc/sprintf-without-formatters.xsl
@@ -57,7 +57,7 @@
             </xsl:attribute>
             <xsl:text>According to the formatting template of the "Q.org.eolang.txt.sprintf" object, </xsl:text>
             <xsl:value-of select="eo:escape($placeholder)"/>
-            <xsl:text> does not have any formatters, which makes no sense to use "Q.org.eolang.txt.sprintf"</xsl:text>
+            <xsl:text> does not have any supported formatters ("%s", "%d", "%f", "%x", "%b"), which makes no sense to use "Q.org.eolang.txt.sprintf"</xsl:text>
           </defect>
         </xsl:if>
       </xsl:for-each>

--- a/src/test/resources/org/eolang/lints/packs/single/sprintf-without-formatters/catches-sprintf-with-incorrect-formatter.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sprintf-without-formatters/catches-sprintf-with-incorrect-formatter.yaml
@@ -6,11 +6,11 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
   - /defects/defect[@line='4']
-  - /defects/defect[1][normalize-space()='According to the formatting template of the "Q.org.eolang.txt.sprintf" object, "Hello⌴Jeff!" does not have any supported formatters ("%s", "%d", "%f", "%x", "%b"), which makes no sense to use "Q.org.eolang.txt.sprintf"']
+  - /defects/defect[1][normalize-space()='According to the formatting template of the "Q.org.eolang.txt.sprintf" object, "Hello⌴%o" does not have any supported formatters ("%s", "%d", "%f", "%x", "%b"), which makes no sense to use "Q.org.eolang.txt.sprintf"']
 input: |
   # App.
-  [] > app
+  [args] > app
     QQ.io.stdout > @
       QQ.txt.sprintf
-        "Hello Jeff!"
-        *
+        "Hello %o"
+        * args


### PR DESCRIPTION
In this PR I've updated defect text in the `sprintf-without-formatters` to list all the supported formatters.

see #519