### PR TITLE
bug(#518): list clashes with other objects in `LtInconsistentArgs`

### DIFF
--- a/src/main/java/org/eolang/lints/LtInconsistentArgs.java
+++ b/src/main/java/org/eolang/lints/LtInconsistentArgs.java
@@ -45,25 +45,18 @@ final class LtInconsistentArgs implements Lint<Map<String, XML>> {
             (base, counts) -> {
                 if (counts.stream().distinct().count() != 1L) {
                     final List<Xnav> sources = bases.get(base);
-                    final Map<String, List<Integer>> clashes = LtInconsistentArgs.clashes(sources, base);
+                    final Map<String, List<Integer>> clashes = LtInconsistentArgs.clashes(
+                        sources, base
+                    );
                     sources.forEach(
                         src -> src.path(String.format("//o[@base='%s']", base))
                             .forEach(
                                 o -> {
-                                    final String current = new ObjectName(new XMLDocument(src.node())).get();
+                                    final String current = new ObjectName(
+                                        new XMLDocument(src.node())
+                                    ).get();
                                     final int cline = Integer.parseInt(
                                         o.attribute("line").text().orElse("0")
-                                    );
-                                    final Collection<String> others = new ArrayList<>();
-                                    clashes.forEach(
-                                        (program, lines) ->
-                                            lines.forEach(
-                                            line -> {
-                                                if (!(program.equals(current) && line == cline)) {
-                                                    others.add(String.format("%s:%d", program, line));
-                                                }
-                                            }
-                                        )
                                     );
                                     defects.add(
                                         new Defect.Default(
@@ -74,7 +67,9 @@ final class LtInconsistentArgs implements Lint<Map<String, XML>> {
                                             String.format(
                                                 "Object '%s' has arguments inconsistency (the usage clashes with [%s])",
                                                 base,
-                                                String.join(", ", others)
+                                                LtInconsistentArgs.objectClashes(
+                                                    clashes, current, cline
+                                                )
                                             )
                                         )
                                     );
@@ -147,8 +142,8 @@ final class LtInconsistentArgs implements Lint<Map<String, XML>> {
 
     /**
      * Object occurrences across all sources, grouped by object base attribute.
-     * @param whole All object usages across all sources.
-     * @return Grouped base occurrences in the sources.
+     * @param whole All object usages across all sources
+     * @return Grouped base occurrences in the sources
      */
     private static Map<String, List<Xnav>> baseOccurrences(
         final Map<Xnav, Map<String, List<Integer>>> whole
@@ -170,7 +165,9 @@ final class LtInconsistentArgs implements Lint<Map<String, XML>> {
      * @param base Base
      * @return Usage clashes
      */
-    private static Map<String, List<Integer>> clashes(final List<Xnav> sources, final String base) {
+    private static Map<String, List<Integer>> clashes(
+        final Iterable<Xnav> sources, final String base
+    ) {
         final Map<String, List<Integer>> clashes = new HashMap<>(16);
         sources.forEach(
             src -> src.path(String.format("//o[@base='%s']", base))
@@ -178,10 +175,34 @@ final class LtInconsistentArgs implements Lint<Map<String, XML>> {
                     o -> {
                         final String program = new ObjectName(new XMLDocument(src.node())).get();
                         final int line = Integer.parseInt(o.attribute("line").text().orElse("0"));
-                        clashes.computeIfAbsent(program, k -> new ArrayList<>()).add(line);
+                        clashes.computeIfAbsent(program, k -> new ListOf<>()).add(line);
                     }
                 )
         );
         return clashes;
+    }
+
+    /**
+     * List of clashes for given object.
+     * @param clashes List of clashes
+     * @param current Current object
+     * @param oline Origin line in given object
+     * @return With which objects, given object clashes, as string expression
+     */
+    private static String objectClashes(
+        final Map<String, List<Integer>> clashes, final String current, final int oline
+    ) {
+        final Collection<String> others = new ListOf<>();
+        clashes.forEach(
+            (program, lines) ->
+                lines.forEach(
+                    line -> {
+                        if (!(program.equals(current) && line == oline)) {
+                            others.add(String.format("%s:%d", program, line));
+                        }
+                    }
+                )
+        );
+        return String.join(", ", others);
     }
 }

--- a/src/main/java/org/eolang/lints/LtInconsistentArgs.java
+++ b/src/main/java/org/eolang/lints/LtInconsistentArgs.java
@@ -49,7 +49,9 @@ final class LtInconsistentArgs implements Lint<Map<String, XML>> {
                         src -> src.path(String.format("//o[@base='%s']", base))
                             .map(o -> Integer.parseInt(o.attribute("line").text().orElse("0")))
                             .forEach(
-                                line ->
+                                line -> {
+                                    System.out.println(new ObjectName(new XMLDocument(src.node())).get());
+                                    System.out.println(line);
                                     defects.add(
                                         new Defect.Default(
                                             this.name(),
@@ -57,11 +59,12 @@ final class LtInconsistentArgs implements Lint<Map<String, XML>> {
                                             new ObjectName(new XMLDocument(src.node())).get(),
                                             line,
                                             String.format(
-                                                "Object '%s' has arguments inconsistency",
+                                                "Object '%s' has arguments inconsistency (the usage clashes with %s",
                                                 base
                                             )
                                         )
-                                    )
+                                    );
+                                }
                             )
                     );
                 }

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-across-programs-with-clash-message.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-across-programs-with-clash-message.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lints:
+  - inconsistent-args
+asserts:
+  - /defects[count(defect[@severity='warning'])=2]
+  - /defects/defect[@program='main' and @line='5']
+  - /defects/defect[@program='app' and @line='3']
+  - /defects/defect[contains(normalize-space(), 'clashes with main:3')]
+  - /defects/defect[contains(normalize-space(), 'clashes with app:3')]
+app.eo: |
+  # App.
+  [] > app
+    Q.org.eolang.txt.text "f" "y" > x
+main.eo: |
+  +alias org.eolang.txt.text
+
+  # Main.
+  [] > main
+    text "f" > y

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-across-programs-with-clash-message.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-across-programs-with-clash-message.yaml
@@ -5,17 +5,16 @@ lints:
   - inconsistent-args
 asserts:
   - /defects[count(defect[@severity='warning'])=2]
-  - /defects/defect[@program='main' and @line='5']
+  - /defects/defect[@program='main' and @line='4']
   - /defects/defect[@program='app' and @line='3']
-  - /defects/defect[contains(normalize-space(), 'clashes with main:3')]
-  - /defects/defect[contains(normalize-space(), 'clashes with app:3')]
+  - /defects/defect[contains(normalize-space(), 'clashes with [main:4]')]
+  - /defects/defect[contains(normalize-space(), 'clashes with [app:3]')]
 app.eo: |
   # App.
   [] > app
     Q.org.eolang.txt.text "f" "y" > x
 main.eo: |
-  +alias org.eolang.txt.text
 
   # Main.
   [] > main
-    text "f" > y
+    Q.org.eolang.txt.text "f" > y


### PR DESCRIPTION
In this PR I've added information about arguments consistency clashes in other objects from found problematic object in `LtInconsistentArgs`.

see #518
History:
- **bug(#518): clashes**
- **bug(#518): clashes**
- **bug(#518): clash information**
