### PR TITLE
bug(#518): `ScopedDefects` to categorize lint scopes in the stdout

### DIFF
--- a/src/main/java/org/eolang/lints/Program.java
+++ b/src/main/java/org/eolang/lints/Program.java
@@ -123,7 +123,7 @@ public final class Program {
         final Collection<Defect> messages = new ArrayList<>(0);
         for (final Lint<Map<String, XML>> lint : this.lints) {
             try {
-                messages.addAll(lint.defects(this.pkg));
+                messages.addAll(new ScopedDefects(lint.defects(this.pkg), "WPA"));
             } catch (final IOException exception) {
                 throw new IllegalStateException(
                     String.format(

--- a/src/main/java/org/eolang/lints/ScopedDefects.java
+++ b/src/main/java/org/eolang/lints/ScopedDefects.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import org.cactoos.collection.CollectionEnvelope;
+import org.cactoos.iterable.Mapped;
+import org.cactoos.list.ListOf;
+
+/**
+ * Defects, marked with their scopes.
+ *
+ * @since 0.0.48
+ */
+final class ScopedDefects extends CollectionEnvelope<Defect> {
+    /**
+     * Ctor.
+     *
+     * @param origin Origin defects
+     * @param marker Marker
+     */
+    ScopedDefects(final Iterable<Defect> origin, final String marker) {
+        super(
+            new ListOf<>(
+                new Mapped<>(
+                    defect -> new DfContext(
+                        new Defect.Default(
+                            defect.rule(),
+                            defect.severity(),
+                            defect.program(),
+                            defect.line(),
+                            String.format("%s (%s)", defect.text(), marker),
+                            defect.experimental()
+                        ),
+                        defect.context()
+                    ),
+                    origin
+                )
+            )
+        );
+    }
+}

--- a/src/main/java/org/eolang/lints/ScopedDefects.java
+++ b/src/main/java/org/eolang/lints/ScopedDefects.java
@@ -26,11 +26,11 @@ final class ScopedDefects extends CollectionEnvelope<Defect> {
                 new Mapped<>(
                     defect -> new DfContext(
                         new Defect.Default(
-                            defect.rule(),
+                            String.format("%s (%s)", defect.rule(), marker),
                             defect.severity(),
                             defect.program(),
                             defect.line(),
-                            String.format("%s (%s)", defect.text(), marker),
+                            defect.text(),
                             defect.experimental()
                         ),
                         defect.context()

--- a/src/main/java/org/eolang/lints/Source.java
+++ b/src/main/java/org/eolang/lints/Source.java
@@ -92,7 +92,7 @@ public final class Source {
         try {
             final Collection<Defect> messages = new ArrayList<>(0);
             for (final Lint<XML> lint : this.lints) {
-                messages.addAll(lint.defects(this.xmir));
+                messages.addAll(new ScopedDefects(lint.defects(this.xmir), "Single"));
             }
             return messages;
         } catch (final IOException ex) {

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -177,6 +177,33 @@ final class ProgramTest {
         );
     }
 
+    @Test
+    void outputsInformationAboutWpaScope() throws IOException {
+        MatcherAssert.assertThat(
+            "Found defects don't contain information about WPA scope, but they should",
+            new Program(
+                new MapOf<>(
+                    "foo",
+                    new EoSyntax(
+                        String.join(
+                            "\n",
+                            "# Foo",
+                            "[] > foo"
+                        )
+                    ).parsed()
+                )
+            ).defects(),
+            Matchers.hasItem(
+                Matchers.hasToString(
+                    Matchers.allOf(
+                        Matchers.containsString("unit-test-missing WARNING"),
+                        Matchers.containsString("(WPA)")
+                    )
+                )
+            )
+        );
+    }
+
     private Path withSource(final Path dir, final String name,
         final String text) throws IOException {
         final Path path = dir.resolve(name);

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -195,10 +195,7 @@ final class ProgramTest {
             ).defects(),
             Matchers.hasItem(
                 Matchers.hasToString(
-                    Matchers.allOf(
-                        Matchers.containsString("unit-test-missing WARNING"),
-                        Matchers.containsString("(WPA)")
-                    )
+                    Matchers.containsString("unit-test-missing (WPA) WARNING")
                 )
             )
         );

--- a/src/test/java/org/eolang/lints/ProgramTest.java
+++ b/src/test/java/org/eolang/lints/ProgramTest.java
@@ -165,7 +165,7 @@ final class ProgramTest {
                 Matchers.hasItem(
                     Matchers.hasToString(
                         Matchers.allOf(
-                            Matchers.containsString("unlint-non-existing-defect WARNING"),
+                            Matchers.containsString("unlint-non-existing-defect"),
                             Matchers.containsString(
                                 String.format("Unlinting rule '%s' doesn't make sense,", lid)
                             ),

--- a/src/test/java/org/eolang/lints/ScopedDefectsTest.java
+++ b/src/test/java/org/eolang/lints/ScopedDefectsTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 final class ScopedDefectsTest {
 
     @Test
-    void appendsScopeToMessage() {
+    void appendsScopeToRuleName() {
         final String marker = "X!";
         MatcherAssert.assertThat(
             String.format(
@@ -38,7 +38,7 @@ final class ScopedDefectsTest {
             ),
             Matchers.hasItem(
                 Matchers.hasToString(
-                    "[foo boom-lint ERROR]:42 Foo bar! (X!)"
+                    "[foo boom-lint (X!) ERROR]:42 Foo bar!"
                 )
             )
         );

--- a/src/test/java/org/eolang/lints/ScopedDefectsTest.java
+++ b/src/test/java/org/eolang/lints/ScopedDefectsTest.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ScopedDefects}.
+ *
+ * @since 0.0.48
+ */
+final class ScopedDefectsTest {
+
+    @Test
+    void appendsScopeToMessage() {
+        final String marker = "X!";
+        MatcherAssert.assertThat(
+            String.format(
+                "Modified defects do not contain marker: \"%s\", but they should",
+                marker
+            ),
+            new ScopedDefects(
+                new ListOf<>(
+                    new Defect.Default(
+                        "boom-lint",
+                        Severity.ERROR,
+                        "foo",
+                        42,
+                        "Foo bar!"
+                    )
+                ),
+                marker
+            ),
+            Matchers.hasItem(
+                Matchers.hasToString(
+                    "[foo boom-lint ERROR]:42 Foo bar! (X!)"
+                )
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -359,6 +359,31 @@ final class SourceTest {
     }
 
     @Test
+    void outputsInformationAboutSingleScope() throws IOException {
+        MatcherAssert.assertThat(
+            "Found defects don't contain information about Single scope, but they should",
+            new Source(
+                new EoSyntax(
+                    String.join(
+                        "\n",
+                        "# Foo",
+                        "[] > foo"
+                    )
+                ).parsed()
+            ).defects(),
+            Matchers.hasItem(
+                Matchers.hasToString(
+                    Matchers.allOf(
+                        Matchers.containsString("comment-without-dot WARNING"),
+                        Matchers.containsString(":2"),
+                        Matchers.containsString("(Single)")
+                    )
+                )
+            )
+        );
+    }
+
+    @Test
     @Tag("benchmark")
     @ExtendWith(MktmpResolver.class)
     @ExtendWith(MayBeSlow.class)

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -193,7 +193,7 @@ final class SourceTest {
                 Matchers.hasItem(
                     Matchers.hasToString(
                         Matchers.allOf(
-                            Matchers.containsString("alias-too-long ERROR"),
+                            Matchers.containsString("alias-too-long"),
                             Matchers.containsString("The alias has too many parts"),
                             Matchers.containsString(":3")
                         )
@@ -325,7 +325,7 @@ final class SourceTest {
                 Matchers.hasItem(
                     Matchers.hasToString(
                         Matchers.allOf(
-                            Matchers.containsString("unlint-non-existing-defect WARNING"),
+                            Matchers.containsString("unlint-non-existing-defect"),
                             Matchers.containsString(
                                 String.format("Unlinting rule '%s' doesn't make sense,", lid)
                             ),

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -374,9 +374,8 @@ final class SourceTest {
             Matchers.hasItem(
                 Matchers.hasToString(
                     Matchers.allOf(
-                        Matchers.containsString("comment-without-dot WARNING"),
-                        Matchers.containsString(":2"),
-                        Matchers.containsString("(Single)")
+                        Matchers.containsString("comment-without-dot (Single) WARNING"),
+                        Matchers.containsString(":2")
                     )
                 )
             )


### PR DESCRIPTION
In this PR I've added new class `ScopedDefects` to classify Defect messages by appending scope to their rule name.

see #518
History:
- **bug(#518): test first**
- **bug(#518): ScopedDefects**
