### PR TITLE
bug(#516): check void matches in `anonymous-formation`

### DIFF
--- a/src/main/resources/org/eolang/lints/names/anonymous-formation.xsl
+++ b/src/main/resources/org/eolang/lints/names/anonymous-formation.xsl
@@ -3,19 +3,28 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
  * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="anonymous-formation" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:eo="https://www.eolang.org" id="anonymous-formation" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:function name="eo:matches-any-void" as="xs:boolean">
+    <xsl:param name="text" as="xs:string"/>
+    <xsl:param name="patterns" as="xs:string*"/>
+    <xsl:sequence select="some $pattern in $patterns satisfies matches($text, $pattern)"/>
+  </xsl:function>
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="//o[not(@name) and not(@base) and not(eo:has-data(.) and parent::o[@base='Q.org.eolang.bytes'])]">
-<!--        <xsl:for-each select="/o[@base='∅']">-->
-          <!-- build the list of regexes for void: '\$(\.\^)+\.$void\.\w+' -->
-<!--        </xsl:for-each>-->
-        <xsl:for-each select=".//o[starts-with(@base, '$.^.') and not(matches(@base, '\$(\.\^)+\.i\.\w+'))]">
+        <xsl:variable name="voids" select="o[@base='∅']"/>
+        <xsl:variable name="allowed" as="xs:string*">
+          <xsl:for-each select="$voids">
+            <xsl:sequence select="concat('\$(\.\^)+\.', @name, '\.\w+')" />
+          </xsl:for-each>
+        </xsl:variable>
+        <!-- check that @base does not match any regexes produced above -->
+        <xsl:for-each select=".//o[starts-with(@base, '$.^.') and not(eo:matches-any-void(@base, $allowed))]">
           <defect>
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">
@@ -30,7 +39,7 @@
               <xsl:text>warning</xsl:text>
             </xsl:attribute>
             <xsl:text>It is not recommended to have anonymous formation accessing undefined object </xsl:text>
-            <xsl:value-of select="eo:escape(translate(@base, '$.^.', ''))"/>
+            <xsl:value-of select="eo:escape(replace(@base, '^\$(\.\^)+\.', ''))"/>
             <xsl:text> inside the formation</xsl:text>
           </defect>
         </xsl:for-each>

--- a/src/main/resources/org/eolang/lints/names/anonymous-formation.xsl
+++ b/src/main/resources/org/eolang/lints/names/anonymous-formation.xsl
@@ -12,7 +12,10 @@
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="//o[not(@name) and not(@base) and not(eo:has-data(.) and parent::o[@base='Q.org.eolang.bytes'])]">
-        <xsl:for-each select=".//o[starts-with(@base, '$.^.')]">
+<!--        <xsl:for-each select="/o[@base='∅']">-->
+          <!-- build the list of regexes for void: '\$(\.\^)+\.$void\.\w+' -->
+<!--        </xsl:for-each>-->
+        <xsl:for-each select=".//o[starts-with(@base, '$.^.') and not(matches(@base, '\$(\.\^)+\.i\.\w+'))]">
           <defect>
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/lints/names/anonymous-formation.xsl
+++ b/src/main/resources/org/eolang/lints/names/anonymous-formation.xsl
@@ -17,13 +17,11 @@
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="//o[not(@name) and not(@base) and not(eo:has-data(.) and parent::o[@base='Q.org.eolang.bytes'])]">
-        <xsl:variable name="voids" select="o[@base='∅']"/>
         <xsl:variable name="allowed" as="xs:string*">
-          <xsl:for-each select="$voids">
-            <xsl:sequence select="concat('\$(\.\^)+\.', @name, '\.\w+')" />
+          <xsl:for-each select="o[@base='∅']">
+            <xsl:sequence select="concat('\$(\.\^)+\.', @name, '\.\w+')"/>
           </xsl:for-each>
         </xsl:variable>
-        <!-- check that @base does not match any regexes produced above -->
         <xsl:for-each select=".//o[starts-with(@base, '$.^.') and not(eo:matches-any-void(@base, $allowed))]">
           <defect>
             <xsl:variable name="line" select="eo:lineno(@line)"/>

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-accessing-its-own-void-in-auto.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-accessing-its-own-void-in-auto.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/anonymous-formation.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] > go-tests
+    # This unit test is supposed to check the functionality of the corresponding object.
+    [] > tests-goto-jumps-backwards
+      eq. > @
+        malloc.of
+          8
+          [i]
+            seq > @
+              *
+                i.put 1
+                go.to
+                  [g] >>
+                    seq > @
+                      *
+                        i.put (i.as-number.plus 1)
+                        if.
+                          i.as-number.lt 10
+                          g.backward
+                          true
+                i
+        10

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-accessing-its-own-void-with-dot-notation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-accessing-its-own-void-with-dot-notation.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/anonymous-formation.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # App.
+  [] > main
+    x > @
+      [i]
+        seq > @
+          i.put 1

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-accessing-its-own-void-with-dot-notation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-accessing-its-own-void-with-dot-notation.yaml
@@ -11,4 +11,5 @@ input: |
     x > @
       [i]
         seq > @
-          i.put 1
+          *
+            i.put 1

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-accessing-its-own-void.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-accessing-its-own-void.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/anonymous-formation.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # App.
+  [] > main
+    x > @
+      [i]
+        seq > @
+          i

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/catches-anonymous-accessing-undefined-with-proper-message.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/catches-anonymous-accessing-undefined-with-proper-message.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/anonymous-formation.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='19']
+  - /defects/defect[1][normalize-space()='It is not recommended to have anonymous formation accessing undefined object "aaaa.as-number.lt" inside the formation']
+input: |
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] > go-tests
+    # This unit test is supposed to check the functionality of the corresponding object.
+    [] > tests-goto-jumps-backwards
+      42 > aaaa
+      eq. > @
+        malloc.of
+          8
+          [i]
+            seq > @
+              *
+                i.put 1
+                go.to
+                  [g] >>
+                    seq > @
+                      *
+                        42
+                        if.
+                          aaaa.as-number.lt 10
+                          g.backward
+                          true
+                i
+        10


### PR DESCRIPTION
In this PR I've fixed the bug with false positives when anonymous formation accessed its own void attributes in the deeper scopes.

see #516
History:
- **bug(#516): passes on access its own voids**
- **bug(#516): passes too**
- **bug(#516): adjust seq steps**
- **bug(#516): catchy test**
- **bug(#516): hardcode void**
- **bug(#516): passes**
- **bug(#516): clean for qulice**
