### PR TITLE
bug(#525): `Defect.program()` -> `Defect.object()`

### DIFF
--- a/src/main/java/org/eolang/lints/Defect.java
+++ b/src/main/java/org/eolang/lints/Defect.java
@@ -45,15 +45,15 @@ public interface Defect {
     Severity severity();
 
     /**
-     * Name of the program with defect.
+     * Name of the object with defect.
      * <p>
-     * Returns the name of the program where the defect was found.
+     * Returns the name of the object where the defect was found.
      * </p>
      *
      * @return Name of it, taken from the {@code @name} attribute of
-     *  the {@code program} element in XMIR
+     *  the {@code object} element in XMIR
      */
-    String program();
+    String object();
 
     /**
      * Line where the defect was found.
@@ -123,9 +123,9 @@ public interface Defect {
         private final Severity sev;
 
         /**
-         * Name of the program.
+         * Name of the object.
          */
-        private final String prg;
+        private final String oname;
 
         /**
          * Line number with the defect.
@@ -146,16 +146,16 @@ public interface Defect {
          * Ctor.
          * @param rule Rule name
          * @param severity Severity level
-         * @param program Name of the program
+         * @param object Name of the object
          * @param line Line number
          * @param text Description of the defect
          * @checkstyle ParameterNumberCheck (5 lines)
          */
         public Default(
             final String rule, final Severity severity,
-            final String program, final int line, final String text
+            final String object, final int line, final String text
         ) {
-            this(rule, severity, program, line, text, false);
+            this(rule, severity, object, line, text, false);
         }
 
         /**
@@ -166,7 +166,7 @@ public interface Defect {
          *
          * @param rule Rule name
          * @param severity Severity level
-         * @param program Name of the program
+         * @param object Name of the object
          * @param line Line number
          * @param text Description of the defect
          * @param exprmnt Experimental?
@@ -174,12 +174,12 @@ public interface Defect {
          */
         public Default(
             final String rule, final Severity severity,
-            final String program, final int line, final String text,
+            final String object, final int line, final String text,
             final boolean exprmnt
         ) {
             this.rle = rule;
             this.sev = severity;
-            this.prg = program;
+            this.oname = object;
             this.lineno = line;
             this.txt = text;
             this.experiment = exprmnt;
@@ -188,7 +188,7 @@ public interface Defect {
         @Override
         public String toString() {
             final StringBuilder text = new StringBuilder(0)
-                .append('[').append(this.prg).append(' ')
+                .append('[').append(this.oname).append(' ')
                 .append(this.rle).append(' ')
                 .append(this.sev).append(']');
             if (this.lineno > 0) {
@@ -208,8 +208,8 @@ public interface Defect {
         }
 
         @Override
-        public String program() {
-            return this.prg;
+        public String object() {
+            return this.oname;
         }
 
         @Override
@@ -247,7 +247,7 @@ public interface Defect {
                 result = this.lineno == defect.lineno
                     && Objects.equals(this.rle, defect.rle)
                     && this.sev == defect.sev
-                    && Objects.equals(this.prg, defect.prg)
+                    && Objects.equals(this.oname, defect.oname)
                     && Objects.equals(this.txt, defect.txt);
             }
             return result;
@@ -255,7 +255,7 @@ public interface Defect {
 
         @Override
         public int hashCode() {
-            return Objects.hash(this.rle, this.sev, this.prg, this.lineno, this.txt);
+            return Objects.hash(this.rle, this.sev, this.oname, this.lineno, this.txt);
         }
     }
 

--- a/src/main/java/org/eolang/lints/DfContext.java
+++ b/src/main/java/org/eolang/lints/DfContext.java
@@ -41,8 +41,8 @@ final class DfContext implements Defect {
     }
 
     @Override
-    public String program() {
-        return this.origin.program();
+    public String object() {
+        return this.origin.object();
     }
 
     @Override

--- a/src/main/java/org/eolang/lints/LtWpaUnlint.java
+++ b/src/main/java/org/eolang/lints/LtWpaUnlint.java
@@ -40,12 +40,12 @@ final class LtWpaUnlint implements Lint<Map<String, XML>> {
     public Collection<Defect> defects(final Map<String, XML> map) throws IOException {
         final Collection<Defect> defects = new ArrayList<>(0);
         for (final Defect defect : this.origin.defects(map)) {
-            final XML xmir = map.get(defect.program());
+            final XML xmir = map.get(defect.object());
             if (xmir == null) {
                 throw new IllegalArgumentException(
                     Logger.format(
                         "The \"%s\" defect was found in \"%s\", but this source is not in scope (%[list]s), how come?",
-                        defect.rule(), defect.program(), map.keySet()
+                        defect.rule(), defect.object(), map.keySet()
                     )
                 );
             }

--- a/src/main/java/org/eolang/lints/ScopedDefects.java
+++ b/src/main/java/org/eolang/lints/ScopedDefects.java
@@ -28,7 +28,7 @@ final class ScopedDefects extends CollectionEnvelope<Defect> {
                         new Defect.Default(
                             String.format("%s (%s)", defect.rule(), marker),
                             defect.severity(),
-                            defect.program(),
+                            defect.object(),
                             defect.line(),
                             defect.text(),
                             defect.experimental()

--- a/src/test/java/org/eolang/lints/DefectTest.java
+++ b/src/test/java/org/eolang/lints/DefectTest.java
@@ -32,7 +32,7 @@ final class DefectTest {
     }
 
     @Test
-    void printsProgramName() {
+    void printsObjectName() {
         final String program = "a.b.c.bar";
         MatcherAssert.assertThat(
             "toString() doesn't show program name",

--- a/src/test/java/org/eolang/lints/WpaStory.java
+++ b/src/test/java/org/eolang/lints/WpaStory.java
@@ -96,7 +96,7 @@ final class WpaStory {
         final Directives directives = new Directives().add("defects");
         defects.forEach(
             d -> directives.add("defect")
-                .attr("program", d.program())
+                .attr("object", d.object())
                 .attr("line", d.line())
                 .attr("severity", d.severity().toString().toLowerCase(Locale.ROOT))
                 .attr("context", d.context())

--- a/src/test/resources/org/eolang/lints/packs/wpa/atom-is-not-unique/catches-atom-fqn-duplicates-within-same-package.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/atom-is-not-unique/catches-atom-fqn-duplicates-within-same-package.yaml
@@ -5,7 +5,7 @@ lints:
   - atom-is-not-unique
 asserts:
   - /defects[count(defect[@severity='error'])=2]
-  - /defects/defect[@program='xyz.app' and @line='5']
+  - /defects/defect[@object='xyz.app' and @line='5']
 foo-packaged.eo: |
   +package xyz
 

--- a/src/test/resources/org/eolang/lints/packs/wpa/atom-is-not-unique/catches-atom-fqn-duplicates.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/atom-is-not-unique/catches-atom-fqn-duplicates.yaml
@@ -5,7 +5,7 @@ lints:
   - atom-is-not-unique
 asserts:
   - /defects[count(defect[@severity='error'])=2]
-  - /defects/defect[@program='foo' and @line='3']
+  - /defects/defect[@object='foo' and @line='3']
   - /defects/defect[normalize-space()='Atom with FQN "Ф.foo.at" is duplicated, original was found in "foo"']
 foo.eo: |
   # Foo.

--- a/src/test/resources/org/eolang/lints/packs/wpa/atom-is-not-unique/catches-duplicates-in-single-program.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/atom-is-not-unique/catches-duplicates-in-single-program.yaml
@@ -5,8 +5,8 @@ lints:
   - atom-is-not-unique
 asserts:
   - /defects[count(defect[@severity='error'])=2]
-  - /defects/defect[@program='single' and @line='5']
-  - /defects/defect[@program='single' and @line='3']
+  - /defects/defect[@object='single' and @line='5']
+  - /defects/defect[@object='single' and @line='3']
   - /defects/defect[1][normalize-space()='Atom "Ф.single.foo" is duplicated']
   - /defects/defect[2][normalize-space()='Atom "Ф.single.foo" is duplicated']
 single.eo: |

--- a/src/test/resources/org/eolang/lints/packs/wpa/atom-is-not-unique/catches-nested-duplicates.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/atom-is-not-unique/catches-nested-duplicates.yaml
@@ -5,8 +5,8 @@ lints:
   - atom-is-not-unique
 asserts:
   - /defects[count(defect[@severity='error'])=2]
-  - /defects/defect[@program='top' and @line='7']
-  - /defects/defect[@program='top' and @line='6']
+  - /defects/defect[@object='top' and @line='7']
+  - /defects/defect[@object='top' and @line='6']
 nested.eo: |
   # Top object with nested atoms inside.
   [] > top

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-arguments-inconsistency.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-arguments-inconsistency.yaml
@@ -5,8 +5,8 @@ lints:
   - inconsistent-args
 asserts:
   - /defects[count(defect[@severity='warning'])=2]
-  - /defects/defect[@program='foo' and @line='3']
-  - /defects/defect[@program='foo' and @line='4']
+  - /defects/defect[@object='foo' and @line='3']
+  - /defects/defect[@object='foo' and @line='4']
 foo.eo: |
   # Foo.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-across-programs-with-alias.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-across-programs-with-alias.yaml
@@ -5,8 +5,8 @@ lints:
   - inconsistent-args
 asserts:
   - /defects[count(defect[@severity='warning'])=2]
-  - /defects/defect[@program='main' and @line='5']
-  - /defects/defect[@program='app' and @line='3']
+  - /defects/defect[@object='main' and @line='5']
+  - /defects/defect[@object='app' and @line='3']
 app.eo: |
   # App.
   [] > app

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-across-programs-with-clash-message.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-across-programs-with-clash-message.yaml
@@ -5,8 +5,8 @@ lints:
   - inconsistent-args
 asserts:
   - /defects[count(defect[@severity='warning'])=2]
-  - /defects/defect[@program='main' and @line='4']
-  - /defects/defect[@program='app' and @line='3']
+  - /defects/defect[@object='main' and @line='4']
+  - /defects/defect[@object='app' and @line='3']
   - /defects/defect[contains(normalize-space(), 'clashes with [main:4]')]
   - /defects/defect[contains(normalize-space(), 'clashes with [app:3]')]
 app.eo: |

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-across-programs.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-across-programs.yaml
@@ -5,8 +5,8 @@ lints:
   - inconsistent-args
 asserts:
   - /defects[count(defect[@severity='warning'])=2]
-  - /defects/defect[@program='app' and @line='3']
-  - /defects/defect[@program='main' and @line='3']
+  - /defects/defect[@object='app' and @line='3']
+  - /defects/defect[@object='main' and @line='3']
 app.eo: |
   # App.
   [] > app

--- a/src/test/resources/org/eolang/lints/packs/wpa/incorrect-alias/catches-broken-alias.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/incorrect-alias/catches-broken-alias.yaml
@@ -5,7 +5,7 @@ lints:
   - incorrect-alias
 asserts:
   - /defects[count(defect[@severity='critical'])=1]
-  - /defects/defect[@program='ttt.bar' and @line='1']
+  - /defects/defect[@object='ttt.bar' and @line='1']
 bar.eo: |
   +alias foo
   +package ttt

--- a/src/test/resources/org/eolang/lints/packs/wpa/incorrect-number-of-attributes/catches-incorrect-attributes-in-vertical-application.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/incorrect-number-of-attributes/catches-incorrect-attributes-in-vertical-application.yaml
@@ -5,7 +5,7 @@ lints:
   - incorrect-number-of-attributes
 asserts:
   - /defects[count(defect[@severity='error'])=1]
-  - /defects/defect[@program='usage' and @line='5']
+  - /defects/defect[@object='usage' and @line='5']
   - /defects/defect[1][normalize-space()='The object "Q.org.eolang.a" expects 2 arguments, while 1 provided']
 foo.eo: |
   # A.

--- a/src/test/resources/org/eolang/lints/packs/wpa/incorrect-number-of-attributes/catches-incorrect-number-of-attributes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/incorrect-number-of-attributes/catches-incorrect-number-of-attributes.yaml
@@ -5,7 +5,7 @@ lints:
   - incorrect-number-of-attributes
 asserts:
   - /defects[count(defect[@severity='error'])=1]
-  - /defects/defect[@program='app' and @line='3']
+  - /defects/defect[@object='app' and @line='3']
   - /defects/defect[1][normalize-space()='The object "Q.org.eolang.foo" expects 1 arguments, while 2 provided']
 foo.eo: |
   # Foo with one attribute.

--- a/src/test/resources/org/eolang/lints/packs/wpa/object-is-not-unique/catches-duplicates.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/object-is-not-unique/catches-duplicates.yaml
@@ -5,7 +5,7 @@ lints:
   - object-is-not-unique
 asserts:
   - /defects[count(defect[@severity='error'])=2]
-  - /defects/defect[@program='foo' and @line='2']
+  - /defects/defect[@object='foo' and @line='2']
   - /defects/defect[1][normalize-space()='The object name "foo" is not unique, original object was found in "foo"']
 foo.eo: |
   # Foo.


### PR DESCRIPTION
In this PR I've updated terminology in the `Defect` class, from `Defect.program()` to `Defect.object()`, so it synced with 
new XMIR semantics.

closes #525