### PR TITLE
bug(#530): validate EO snippets for errors in YAML packs

### DIFF
--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -18,8 +18,8 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import matchers.DefectsMatcher;
 import org.cactoos.io.ReaderOf;
@@ -142,7 +142,7 @@ final class LtByXslTest {
     void catchesLostYamls() throws IOException {
         Files.walk(Paths.get("src/test/resources/org/eolang/lints"))
             .filter(Files::isRegularFile)
-            .filter(path -> path.toString().endsWith(".yaml"))
+            .filter(LtByXslTest.yamls())
             .map(path -> path.getParent().getParent().toString())
             .collect(Collectors.toSet())
             .forEach(
@@ -291,7 +291,7 @@ final class LtByXslTest {
     void validatesPacksAgainstXsdSchema() throws IOException {
         Files.walk(Paths.get("src/test/resources/org/eolang/lints/packs/single"))
             .filter(Files::isRegularFile)
-            .filter(p -> p.toString().endsWith(".yaml"))
+            .filter(LtByXslTest.yamls())
             .map(
                 (Function<Path, Map<Path, Map<String, Object>>>)
                     p ->
@@ -364,7 +364,7 @@ final class LtByXslTest {
     void validatesEoPacksForErrors() throws IOException {
         Files.walk(Paths.get("src/test/resources/org/eolang/lints/packs/single"))
             .filter(Files::isRegularFile)
-            .filter(p -> p.toString().endsWith(".yaml"))
+            .filter(LtByXslTest.yamls())
             .map(
                 (Function<Path, Map<Path, Map<String, Object>>>)
                     p ->
@@ -400,5 +400,14 @@ final class LtByXslTest {
                     }
                 }
             );
+    }
+
+    /**
+     * Filter YAML files.
+     * @return Predicate
+     */
+    @SuppressWarnings("UnnecessaryLambda")
+    private static Predicate<Path> yamls() {
+        return path -> path.toString().endsWith(".yaml");
     }
 }

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -359,7 +359,7 @@ final class LtByXslTest {
 
     @SuppressWarnings("StreamResourceLeak")
     @Tag("deep")
-    @Timeout(90L)
+    @Timeout(180L)
     @Test
     void validatesEoPacksForErrors() throws IOException {
         Files.walk(Paths.get("src/test/resources/org/eolang/lints/packs/single"))

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.lints;
 
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.log.Logger;
 import com.jcabi.manifests.Manifests;
 import com.jcabi.matchers.XhtmlMatchers;
@@ -358,7 +359,7 @@ final class LtByXslTest {
 
     @SuppressWarnings("StreamResourceLeak")
     @Tag("deep")
-    @Timeout(60L)
+    @Timeout(90L)
     @Test
     void validatesEoPacksForErrors() throws IOException {
         Files.walk(Paths.get("src/test/resources/org/eolang/lints/packs/single"))
@@ -382,9 +383,11 @@ final class LtByXslTest {
                                 "EO snippet in '%s' pack contains errors, but it should not",
                                 location
                             ),
-                            new EoSyntax(
-                                (String) pack.values().stream().findFirst().get().get("input")
-                            ).parsed().nodes("/object[errors]").isEmpty(),
+                            new Xnav(
+                                new EoSyntax(
+                                    (String) pack.values().stream().findFirst().get().get("input")
+                                ).parsed().inner()
+                            ).path("/object[errors]").findAny().isEmpty(),
                             Matchers.equalTo(true)
                         );
                     } catch (final IOException exception) {

--- a/src/test/java/org/eolang/lints/WpaStory.java
+++ b/src/test/java/org/eolang/lints/WpaStory.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.lints;
 
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
@@ -63,7 +64,9 @@ final class WpaStory {
                 if (key.endsWith(".eo")) {
                     try {
                         final String name = key.substring(0, key.length() - 3);
-                        programs.put(name, new EoSyntax((String) val).parsed());
+                        programs.put(
+                            name, WpaStory.checkForErrors(name, new EoSyntax((String) val).parsed())
+                        );
                     } catch (final IOException exception) {
                         throw new IllegalStateException(
                             "Failed to parse EO syntax", exception
@@ -110,5 +113,17 @@ final class WpaStory {
                 "Failed to create XML document from defects", exception
             );
         }
+    }
+
+    private static XML checkForErrors(final String name, final XML xmir) {
+        if (new Xnav(xmir.inner()).path("/object[errors]").findAny().isEmpty()) {
+            return xmir;
+        }
+        throw new IllegalStateException(
+            String.format(
+                "Parsed EO snippet '%s' contains errors, but it should not:\n %s",
+                name, xmir
+            )
+        );
     }
 }

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-accessing-defined-object-inside.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-accessing-defined-object-inside.yaml
@@ -9,7 +9,7 @@ input: |
   # App.
   [] > app
     "Hello" > t
-    malloc.of
+    malloc.of > @
       64
       [m]
         "boom" > x

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-formation-with-correct-access.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-formation-with-correct-access.yaml
@@ -7,8 +7,9 @@ asserts:
   - /defects[count(defect[@severity='warning'])=0]
 input: |
   # Main.
-  malloc.of
-    64
-    [m]
-      QQ.io.stdout > @
-        "foo"
+  [] > main
+    malloc.of > @
+      64
+      [m]
+        QQ.io.stdout > @
+          "foo"

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-using-defined-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-using-defined-object.yaml
@@ -9,7 +9,7 @@ input: |
   # App.
   [] > app
     "Hello" > t
-    malloc.of
+    malloc.of > @
       64
       [m]
         QQ.io.stdout > @

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-named-formation-via-autonamed.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-named-formation-via-autonamed.yaml
@@ -7,8 +7,9 @@ asserts:
   - /defects[count(defect[@severity='warning'])=0]
 input: |
   # Main.
-  malloc.of
-    64
-    [m] >>
-      QQ.io.stdout > @
-        "foo"
+  [] > main
+    malloc.of > @
+      64
+      [m] >>
+        QQ.io.stdout > @
+          "foo"

--- a/src/test/resources/org/eolang/lints/packs/single/duplicate-aliases/catches-alias-duplicates.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/duplicate-aliases/catches-alias-duplicates.yaml
@@ -13,4 +13,4 @@ input: |
 
   # No comments.
   [] > main
-    (stdout "Hello, world!").print
+    (stdout "Hello, world!").print > @

--- a/src/test/resources/org/eolang/lints/packs/single/duplicate-metas/catches-duplicate-metas.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/duplicate-metas/catches-duplicate-metas.yaml
@@ -15,4 +15,4 @@ input: |
 
   # No comments.
   [] > main
-    (stdout "Hello, world!").print
+    (stdout "Hello, world!").print > @

--- a/src/test/resources/org/eolang/lints/packs/single/duplicate-names/multi-anonymous.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/duplicate-names/multi-anonymous.yaml
@@ -6,6 +6,9 @@ sheets:
 asserts:
   - /defects[count(defect)=0]
 input: |
-  *
-    [x] (x.zz > xzz)
-    [x] (x.tt > xtt)
+  # Foo.
+  [] > foo
+    x > @
+      *
+        [x] (x.zz > xzz)
+        [x] (x.tt > xtt)

--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-rt-parts/catches-incorrect-rt-parts.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-rt-parts/catches-incorrect-rt-parts.yaml
@@ -16,4 +16,5 @@ input: |
   +rt
   +rt good good
 
+  # Foo.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/mandatory-package/catches-mandatory-package-meta.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/mandatory-package/catches-mandatory-package-meta.yaml
@@ -12,4 +12,4 @@ input: |
 
   # No comments.
   [] > main
-    (stdout "Hello, world!").print
+    (stdout "Hello, world!").print > @

--- a/src/test/resources/org/eolang/lints/packs/single/many-free-attributes/catches-many-free-attrs.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/many-free-attributes/catches-many-free-attrs.yaml
@@ -11,36 +11,36 @@ input: |
   [a b c d e f] > with-many
     something > @
 
-  # No comments.
-  [x y z] > main
     # No comments.
-    [v] > zz /int
-    # No comments.
-    [v] > yy /int
-    # No comments.
-    [v] > uu /int
-    # No comments.
-    [v] > ff /int
-    # No comments.
-    [v] > oo /int
-    # No comments
-    [v] > pp /int
-
-  # No comments
-  [] > not-many-free-attributes
-    # No comments
-    [] > empty1
-      true > @
-    # No comments
-    [] > empty2
-      true > @
-    # No comments
-    [] > empty3
-      true > @
-    # No comments
-    [] > empty4
-      true > @
-    # No comments
-    [] > empty5
-      true > @
-    true > @
+    [x y z] > main
+      # No comments.
+      [v] > zz ?
+      # No comments.
+      [v] > yy ?
+      # No comments.
+      [v] > uu ?
+      # No comments.
+      [v] > ff ?
+      # No comments.
+      [v] > oo ?
+      # No comments
+      [v] > pp ?
+    
+      # No comments
+      [] > not-many-free-attributes
+        # No comments
+        [] > empty1
+          true > @
+        # No comments
+        [] > empty2
+          true > @
+        # No comments
+        [] > empty3
+          true > @
+        # No comments
+        [] > empty4
+          true > @
+        # No comments
+        [] > empty5
+          true > @
+        true > @

--- a/src/test/resources/org/eolang/lints/packs/single/many-free-attributes/catches-many-free-attrs.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/many-free-attributes/catches-many-free-attrs.yaml
@@ -25,7 +25,7 @@ input: |
       [v] > oo ?
       # No comments
       [v] > pp ?
-    
+
       # No comments
       [] > not-many-free-attributes
         # No comments

--- a/src/test/resources/org/eolang/lints/packs/single/package-contains-multiple-parts/catches-package-contains-multiple-parts.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/package-contains-multiple-parts/catches-package-contains-multiple-parts.yaml
@@ -20,4 +20,5 @@ input: |
   +package привет, как дела?
   +package
 
+  # Foo.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/self-referencing/self-referencing-no-catch.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/self-referencing/self-referencing-no-catch.yaml
@@ -10,8 +10,8 @@ input: |
   [] > first
     5.plus a > a
     ^.size > size
-  # No comments.
-  [size] > more
     # No comments.
-    [] > inner
-      ^.size > size
+    [size] > more
+      # No comments.
+      [] > inner
+        ^.size > size

--- a/src/test/resources/org/eolang/lints/packs/single/unique-metas/allows-single-package.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unique-metas/allows-single-package.yaml
@@ -10,4 +10,4 @@ input: |
 
   # No comments.
   [] > main
-    (stdout "Hello, world!").print
+    (stdout "Hello, world!").print > @

--- a/src/test/resources/org/eolang/lints/packs/single/unique-metas/catches-home-duplicate.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unique-metas/catches-home-duplicate.yaml
@@ -12,4 +12,4 @@ input: |
 
   # No comments.
   [] > main
-    (stdout "Hello, world!").print
+    (stdout "Hello, world!").print > @

--- a/src/test/resources/org/eolang/lints/packs/single/unique-metas/catches-package-duplicate.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unique-metas/catches-package-duplicate.yaml
@@ -12,4 +12,4 @@ input: |
 
   # No comments.
   [] > main
-    (stdout "Hello, world!").print
+    (stdout "Hello, world!").print > @

--- a/src/test/resources/org/eolang/lints/packs/single/unknown-metas/catches-unknown-metas.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unknown-metas/catches-unknown-metas.yaml
@@ -21,4 +21,5 @@ input: |
   +unlint test
   +probe
 
+  # Foo.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/unknown-rt/allows-good-rt.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unknown-rt/allows-good-rt.yaml
@@ -9,4 +9,6 @@ input: |
   +rt jvm org.eolang:eo-runtime:0.0.0
   +rt node path
   +rt
+
+  # Foo.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/unknown-rt/catches-unknown-rt.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unknown-rt/catches-unknown-rt.yaml
@@ -12,4 +12,6 @@ input: |
   +rt test test
   +rt привет, как дела?
   +rt foo
+
+  # Foo.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/unsorted-metas/catches-metas-unsorted.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unsorted-metas/catches-metas-unsorted.yaml
@@ -12,4 +12,4 @@ input: |
 
   # No comments.
   [] > main
-    (stdout "Hello, world!").print
+    (stdout "Hello, world!").print > @

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/allows-percentage-sign.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/allows-percentage-sign.yaml
@@ -8,6 +8,6 @@ asserts:
 input: |
   # App.
   [] > app
-    org.eolang.txt.sprintf
+    QQ.txt.sprintf > @
       "Water constitutes 0.023%% of Earth mass, which is %d tons"
       * 1.4e18

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/allows-consistent-arguments.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/allows-consistent-arguments.yaml
@@ -7,6 +7,6 @@ asserts:
   - /defects[count(defect)=0]
 foo.eo: |
   # App.
-  [] > app.
+  [] > app
     foo 42 > x
     foo 52 > spb

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-across-programs-with-clash-message.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-across-programs-with-clash-message.yaml
@@ -5,16 +5,15 @@ lints:
   - inconsistent-args
 asserts:
   - /defects[count(defect[@severity='warning'])=2]
-  - /defects/defect[@program='main' and @line='4']
+  - /defects/defect[@program='main' and @line='3']
   - /defects/defect[@program='app' and @line='3']
-  - /defects/defect[contains(normalize-space(), 'clashes with [main:4]')]
+  - /defects/defect[contains(normalize-space(), 'clashes with [main:3]')]
   - /defects/defect[contains(normalize-space(), 'clashes with [app:3]')]
 app.eo: |
   # App.
   [] > app
     Q.org.eolang.txt.text "f" "y" > x
 main.eo: |
-
   # Main.
   [] > main
     Q.org.eolang.txt.text "f" > y

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-across-programs-with-clash-message.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-across-programs-with-clash-message.yaml
@@ -5,8 +5,8 @@ lints:
   - inconsistent-args
 asserts:
   - /defects[count(defect[@severity='warning'])=2]
-  - /defects/defect[@program='main' and @line='3']
-  - /defects/defect[@program='app' and @line='3']
+  - /defects/defect[@object='main' and @line='3']
+  - /defects/defect[@object='app' and @line='3']
   - /defects/defect[contains(normalize-space(), 'clashes with [main:3]')]
   - /defects/defect[contains(normalize-space(), 'clashes with [app:3]')]
 app.eo: |

--- a/src/test/resources/org/eolang/lints/packs/wpa/incorrect-number-of-attributes/allows-correct-attributes-in-vertical-application.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/incorrect-number-of-attributes/allows-correct-attributes-in-vertical-application.yaml
@@ -14,6 +14,6 @@ b.eo: |
 usage.eo: |
   # Usage of A and B objects with vertical application.
   [] > app
-    b
+    b > @
       0
       a 0

--- a/src/test/resources/org/eolang/lints/packs/wpa/incorrect-number-of-attributes/allows-correct-number-of-attributes-in-same-program.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/incorrect-number-of-attributes/allows-correct-number-of-attributes-in-same-program.yaml
@@ -8,7 +8,5 @@ asserts:
 single.eo: |
   # A with one attribute.
   [pos] > a
-
-  # B uses A properly.
-  [] > b
-    a 52
+    [] > b
+      a 52 > @

--- a/src/test/resources/org/eolang/lints/packs/wpa/incorrect-number-of-attributes/allows-correct-number-of-attributes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/incorrect-number-of-attributes/allows-correct-number-of-attributes.yaml
@@ -11,4 +11,4 @@ foo.eo: |
 app.eo: |
   # App uses foo properly.
   [a b] > app
-    foo 1
+    foo 1 > @

--- a/src/test/resources/org/eolang/lints/packs/wpa/object-is-not-unique/allows-non-unique-multiple-objects-in-different-packages.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/object-is-not-unique/allows-non-unique-multiple-objects-in-different-packages.yaml
@@ -9,17 +9,9 @@ mul.eo: |
   # Multiple objects here.
   [] > foo
     52 > inn
-
-  # Test.
-  [] > bar
-    52 > inn
 baz-packaged.eo: |
   +package mul
 
   # Multiple objects here.
   [] > foo
-    52 > inn
-
-  # Test.
-  [] > bar
     52 > inn


### PR DESCRIPTION
In this pull I've added error checks for all EO snippets we have in YAML test packs in both scopes: single and WPA.

closes #530
History:
- **bug(#530): validatesEoPacksForErrors**
- **bug(#530): Xnav**
- **bug(#530): error check in WpaStory**
- **bug(#530): clean**
