### PR TITLE
chore(#536): up download timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -495,6 +495,7 @@
               <url>https://opennlp.sourceforge.net/models-1.5/en-pos-perceptron.bin</url>
               <outputFileName>en-pos-perceptron.bin</outputFileName>
               <outputDirectory>${project.build.directory}/classes</outputDirectory>
+              <readTimeOut>15000</readTimeOut>
             </configuration>
           </execution>
           <execution>
@@ -508,6 +509,7 @@
               <outputDirectory>${project.build.directory}/downloaded</outputDirectory>
               <outputFileName>home.zip</outputFileName>
               <skipCache>true</skipCache>
+              <readTimeOut>15000</readTimeOut>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
I've noticed that pipeline sometimes crashes due to timeout of plugin that downloads resources from the internet

Previously, the value was equal to default = 3 seconds

I raised the value to 15 seconds