### PR TITLE
chore(#540): add vale to check md

### DIFF
--- a/.github/styles/config/vocabularies/Custom/accept.txt
+++ b/.github/styles/config/vocabularies/Custom/accept.txt
@@ -14,3 +14,4 @@ JVM(s)?
 XMIR
 SPDX
 ASCII
+inlined

--- a/.github/styles/config/vocabularies/Custom/accept.txt
+++ b/.github/styles/config/vocabularies/Custom/accept.txt
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+[Aa]ttr(s)?
+[Mm]eta(s)?
+[Rr]untime(s)?
+[Dd]ecoratee
+FQN(s)?
+[Ll]int(s)?
+([Uu]n)?lint(s)?
+[Mm]eta(s)?
+[Aa]rg(s)?
+[Ff]ormatter(s)?
+JVM(s)?
+XMIR
+SPDX
+ASCII

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+name: vale
+'on': [ pull_request ]
+jobs:
+  vale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: errata-ai/vale-action@v2.1.1
+        with:
+          files: 'src/main/resources/org/eolang/motives'
+          fail_on_error: 'true'
+          reporter: 'github-pr-review'
+          filter_mode: 'nofilter'

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 name: vale
-'on': [ pull_request ]
+'on': [pull_request]
 jobs:
   vale:
     runs-on: ubuntu-latest

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,29 @@
+; SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+; SPDX-License-Identifier: MIT
+
+StylesPath = .github/styles
+Vocab = Custom
+MinAlertLevel = suggestion
+Packages = Google, Microsoft, proselint
+
+[*.md]
+;; @todo #540:60min Add a new style package - `write-good` - to both this list and the package list.
+;; Then fix all the issues it reports(there will be a lot).
+;; It’s better to run Vale locally to find issues,
+;; since the GitHub Action outputs the list in a less readable format when there are many errors.
+;; format due to the large number of errors.
+BasedOnStyles = Vale, Google, Microsoft, proselint
+
+Microsoft.Passive = No
+Google.Passive = No
+Microsoft.We = No
+Google.We = No
+Google.Will = No
+Microsoft.Vocab = No
+Google.Parens = No
+
+[src/main/resources/org/eolang/motives/critical/same-line-names.md]
+Google.Units = No
+
+[src/main/resources/org/eolang/motives/atoms/not-empty-atom.md]
+Google.Units = No

--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ Also, if you have [xcop](https://github.com/yegor256/xcop) installed, make sure
 it is version `0.8.0`+.
 If you want the code to be checked using
 [error-prone](https://errorprone.info/), use Java 17+
+If you want to check [markdown files](src/main/resources/org/eolang/motives)
+using [vale](https://vale.sh/docs/install),
+just install it and make sure it's in your `PATH`
 
 [XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html
 [EO]: https://www.eolang.org

--- a/build-scripts/validate-markdown.xml
+++ b/build-scripts/validate-markdown.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<project name="validate-markdown" default="validate">
+  <target name="validate">
+    <property environment="env"/>
+    <available file="vale" filepath="${env.PATH}" property="vale.present"/>
+    <if>
+      <equals arg1="${vale.present}" arg2="true"/>
+      <then>
+        <condition property="os.windows">
+          <os family="windows"/>
+        </condition>
+        <if>
+          <equals arg1="${os.windows}" arg2="true"/>
+          <then>
+            <exec executable="cmd" failonerror="true">
+              <arg line="/c vale"/>
+              <arg line="sync"/>
+            </exec>
+            <exec executable="cmd" failonerror="true">
+              <arg line="/c vale"/>
+              <arg line="src/main/resources/org/eolang/motives"/>
+            </exec>
+          </then>
+          <else>
+            <exec executable="vale" failonerror="true">
+              <arg line="sync"/>
+            </exec>
+            <exec executable="vale" failonerror="true">
+              <arg line="src/main/resources/org/eolang/motives"/>
+            </exec>
+          </else>
+        </if>
+      </then>
+      <else>
+        <echo message="Vale is not available in PATH"/>
+      </else>
+    </if>
+  </target>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -341,6 +341,26 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <!-- version from the parent pom -->
+            <executions>
+              <execution>
+                <id>validate-markdown</id>
+                <phase>verify</phase>
+                <configuration>
+                  <target>
+                    <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath"/>
+                    <ant antfile="${basedir}/build-scripts/validate-markdown.xml" target="validate"/>
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/src/main/resources/org/eolang/motives/aliases/alias-too-long.md
+++ b/src/main/resources/org/eolang/motives/aliases/alias-too-long.md
@@ -1,4 +1,4 @@
-# Alias Too Long
+# Alias too long
 
 Object's alias must have **2 parts at max**.
 

--- a/src/main/resources/org/eolang/motives/aliases/broken-alias-first.md
+++ b/src/main/resources/org/eolang/motives/aliases/broken-alias-first.md
@@ -1,4 +1,4 @@
-# Broken Alias (First Part)
+# Broken alias (first part)
 
 The first part of the `+alias` meta may only contain the name
 of the object, not its FQN. For example, here is how it may look
@@ -18,7 +18,7 @@ object used later in the code. It will automatically be replaced
 with `org.eolang.io.stdout`.
 
 The error may also indicate incorrect usage of the `<meta>` element
-in XMIR. The alias defined above must look like this, in XMIR:
+in XMIR. The alias defined preceding must look like this, in XMIR:
 
 ```xml
 <object>

--- a/src/main/resources/org/eolang/motives/aliases/broken-alias-second.md
+++ b/src/main/resources/org/eolang/motives/aliases/broken-alias-second.md
@@ -1,4 +1,4 @@
-# Broken Alias (Second Part)
+# Broken alias (second part)
 
 The second part of the `+alias` meta may only contain FQN
 (fully qualified name) of the object. For example, here is how it may look

--- a/src/main/resources/org/eolang/motives/aliases/duplicate-aliases.md
+++ b/src/main/resources/org/eolang/motives/aliases/duplicate-aliases.md
@@ -1,4 +1,4 @@
-# Duplicate Aliases
+# Duplicate aliases
 
 Object's aliases must not be duplicated.
 

--- a/src/main/resources/org/eolang/motives/aliases/empty-alias.md
+++ b/src/main/resources/org/eolang/motives/aliases/empty-alias.md
@@ -1,4 +1,4 @@
-# Empty Alias
+# Empty alias
 
 Object's alias must be not empty.
 

--- a/src/main/resources/org/eolang/motives/aliases/unused-alias.md
+++ b/src/main/resources/org/eolang/motives/aliases/unused-alias.md
@@ -1,4 +1,4 @@
-# Unused Alias
+# Unused alias
 
 All defined object's aliases must be in use.
 

--- a/src/main/resources/org/eolang/motives/atoms/atom-and-base.md
+++ b/src/main/resources/org/eolang/motives/atoms/atom-and-base.md
@@ -1,4 +1,4 @@
-# Atom and Base
+# Atom and base
 
 In [XMIR], atom object can not have `@base` attribute.
 

--- a/src/main/resources/org/eolang/motives/atoms/atom-in-atom.md
+++ b/src/main/resources/org/eolang/motives/atoms/atom-in-atom.md
@@ -1,5 +1,5 @@
-# Atom in Atom
+# Atom in atom
 
-In [XMIR], object is an atom must not have atoms as child objects (attributes).
+In [XMIR], object is an atom must not have atoms as child objects(attributes).
 
 [XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html

--- a/src/main/resources/org/eolang/motives/atoms/atom-without-rt.md
+++ b/src/main/resources/org/eolang/motives/atoms/atom-without-rt.md
@@ -1,4 +1,4 @@
-# Atom Without `rt` Meta
+# Atom without `rt` meta
 
 Defined atom must have `+rt` meta.
 

--- a/src/main/resources/org/eolang/motives/atoms/lambda-with-inners.md
+++ b/src/main/resources/org/eolang/motives/atoms/lambda-with-inners.md
@@ -1,6 +1,6 @@
-# Lambda With Inners
+# Lambda with inner object
 
-In [XMIR], atom object cannot have inner objects inside lambda object.
+In [XMIR], atom object can't have inner objects inside lambda object.
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/atoms/not-empty-atom.md
+++ b/src/main/resources/org/eolang/motives/atoms/not-empty-atom.md
@@ -1,7 +1,7 @@
-# Not Empty Atom
+# Not empty atom
 
 In [XMIR], atom(object, that have inner object with `@name` equal to `λ`)
-should not have inner object with `@base` not equal to `∅`.
+shouldn't have inner object with `@base` not equal to `∅`.
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/atoms/rt-without-atoms.md
+++ b/src/main/resources/org/eolang/motives/atoms/rt-without-atoms.md
@@ -1,4 +1,4 @@
-# `+rt` Without Atoms
+# `+rt` without atoms
 
 Special `+rt` meta must be used only with atoms.
 

--- a/src/main/resources/org/eolang/motives/comments/ascii-only.md
+++ b/src/main/resources/org/eolang/motives/comments/ascii-only.md
@@ -1,4 +1,4 @@
-# ASCII-Only Characters in Comment
+# ASCII-Only characters in comment
 
 All comments must include only ASCII characters.
 

--- a/src/main/resources/org/eolang/motives/comments/comment-not-capitalized.md
+++ b/src/main/resources/org/eolang/motives/comments/comment-not-capitalized.md
@@ -1,4 +1,4 @@
-# Comment Not Capitalized
+# Comment not capitalized
 
 Comment must start with the capital letter.
 

--- a/src/main/resources/org/eolang/motives/comments/comment-too-short.md
+++ b/src/main/resources/org/eolang/motives/comments/comment-too-short.md
@@ -1,4 +1,4 @@
-# Comment Too Short
+# Comment too short
 
 Comment must be 32+ characters long.
 

--- a/src/main/resources/org/eolang/motives/comments/comment-without-dot.md
+++ b/src/main/resources/org/eolang/motives/comments/comment-without-dot.md
@@ -1,4 +1,4 @@
-# Comment Without Dot
+# Comment without dot
 
 Comment must end with a dot.
 

--- a/src/main/resources/org/eolang/motives/critical/application-duality.md
+++ b/src/main/resources/org/eolang/motives/critical/application-duality.md
@@ -1,7 +1,7 @@
-# Application Duality
+# Application duality
 
-In EO, it is not supported to have an application with and without binding at
-the same time, so it is prohibited in the [XMIR] too.
+In EO, it isn't supported to have an app with and without binding at
+the same time, so it's prohibited in the [XMIR] too.
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/critical/atom-with-data.md
+++ b/src/main/resources/org/eolang/motives/critical/atom-with-data.md
@@ -1,4 +1,4 @@
-# Atom With Data
+# Atom with data
 
 Each atom in [XMIR], must not have the text data inside.
 

--- a/src/main/resources/org/eolang/motives/critical/bytes-without-data.md
+++ b/src/main/resources/org/eolang/motives/critical/bytes-without-data.md
@@ -1,4 +1,4 @@
-# Bytes Without Data
+# Bytes without data
 
 Each object `<o/>` in [XMIR], with its parent base containing
 `Q.org.eolang.bytes` must have text data inside.

--- a/src/main/resources/org/eolang/motives/critical/duplicate-names.md
+++ b/src/main/resources/org/eolang/motives/critical/duplicate-names.md
@@ -1,4 +1,4 @@
-# Duplicate Names
+# Duplicate names
 
 Object's name must not be duplicated.
 

--- a/src/main/resources/org/eolang/motives/critical/formation-with-as-attributes.md
+++ b/src/main/resources/org/eolang/motives/critical/formation-with-as-attributes.md
@@ -1,7 +1,7 @@
-# Formation With `@as` Attributes
+# Formation with `@as` attributes
 
-In [XMIR], it is prohibited to have `@as` attributes inside the formation. The
-only valid usage for them is object application.
+In [XMIR], it's prohibited to have `@as` attributes inside the formation. The
+only valid usage for them is object app.
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/critical/incorrect-alias.md
+++ b/src/main/resources/org/eolang/motives/critical/incorrect-alias.md
@@ -1,4 +1,4 @@
-# Incorrect Alias
+# Incorrect alias
 
 Special meta `+alias` must point to existing file in the dir, outlined by
 `+package` meta.

--- a/src/main/resources/org/eolang/motives/critical/name-outside-of-abstract-object.md
+++ b/src/main/resources/org/eolang/motives/critical/name-outside-of-abstract-object.md
@@ -1,4 +1,4 @@
-# `@name` Outside of Abstract Object
+# `@name` outside of abstract object
 
 The `@name` attribute may only be present in `<o/>` in [XMIR], only if the
 parent of the object has `@abstract` attribute.

--- a/src/main/resources/org/eolang/motives/critical/named-object-abstract-nested.md
+++ b/src/main/resources/org/eolang/motives/critical/named-object-abstract-nested.md
@@ -1,6 +1,6 @@
-# Named Object Abstract Nested
+# Named object abstract nested
 
-In [XMIR], named objects cannot be nested deeper than one level inside an
+In [XMIR], named objects can't be nested deeper than one level inside an
 abstract object.
 
 Incorrect:

--- a/src/main/resources/org/eolang/motives/critical/object-has-data.md
+++ b/src/main/resources/org/eolang/motives/critical/object-has-data.md
@@ -1,4 +1,4 @@
-# Object Has Data
+# Object has data
 
 Each object `<o/>` in [XMIR] must not have the data, unless it's base is
 `org.eolang.bytes` (or just `bytes` for short).

--- a/src/main/resources/org/eolang/motives/critical/package-without-tail.md
+++ b/src/main/resources/org/eolang/motives/critical/package-without-tail.md
@@ -1,4 +1,4 @@
-# `+package` Without Tail
+# `+package` without tail
 
 Special `+package` meta must have a tail.
 

--- a/src/main/resources/org/eolang/motives/critical/pos-without-line.md
+++ b/src/main/resources/org/eolang/motives/critical/pos-without-line.md
@@ -1,4 +1,4 @@
-# `@pos` Without `@line`
+# `@pos` without `@line`
 
 In [XMIR], each `<o/>` that has `@pos` attribute, must have `@line` attribute
 as well.

--- a/src/main/resources/org/eolang/motives/critical/same-line-names.md
+++ b/src/main/resources/org/eolang/motives/critical/same-line-names.md
@@ -1,4 +1,4 @@
-# Same Line Names
+# Same line names
 
 @todo #19:35min Document motives for `same-line-names` lint.
  Currently, we don't have a test case for this `same-line-names` lint.

--- a/src/main/resources/org/eolang/motives/critical/schema-is-absent.md
+++ b/src/main/resources/org/eolang/motives/critical/schema-is-absent.md
@@ -1,4 +1,4 @@
-# Schema Is Absent
+# Schema is absent
 
 [XMIR] document must have `xsi:noNamespaceSchemaLocation` inside it.
 

--- a/src/main/resources/org/eolang/motives/critical/self-referencing.md
+++ b/src/main/resources/org/eolang/motives/critical/self-referencing.md
@@ -1,4 +1,4 @@
-# Self Referencing
+# Self referencing
 
 Object must not refer to itself.
 

--- a/src/main/resources/org/eolang/motives/critical/unknown-rt.md
+++ b/src/main/resources/org/eolang/motives/critical/unknown-rt.md
@@ -3,7 +3,7 @@
 Special `+rt` meta must use only allowed values at it's first part. Currently,
 the following runtimes are supported:
 
-* [jvm](https://github.com/objectionary/eo)
+* [JVM](https://github.com/objectionary/eo)
 * [node](https://github.com/objectionary/eo2js)
 
 Incorrect:

--- a/src/main/resources/org/eolang/motives/critical/void-attributes-not-higher-than-other.md
+++ b/src/main/resources/org/eolang/motives/critical/void-attributes-not-higher-than-other.md
@@ -1,4 +1,4 @@
-# Void Attributes (`∅`) Not Higher Than Other
+# Void attributes `∅` not higher than other
 
 In [XMIR], all void attributes must be placed on top of other non-void
 attributes.

--- a/src/main/resources/org/eolang/motives/design/no-attribute-formation.md
+++ b/src/main/resources/org/eolang/motives/design/no-attribute-formation.md
@@ -1,4 +1,4 @@
-# No Attribute Formation
+# No attribute formation
 
 It's not recommended to have formation without void attributes. Such formations
 are similar to [Utility classes] in Java.
@@ -19,7 +19,7 @@ Correct:
   x > sbp
 ```
 
-It is also correct having an "attribute-free" formation, but only if its parent
+It's also correct having an "attribute-free" formation, but only if its parent
 is a formation as well:
 
 ```eo

--- a/src/main/resources/org/eolang/motives/errors/abstract-decoratee.md
+++ b/src/main/resources/org/eolang/motives/errors/abstract-decoratee.md
@@ -1,4 +1,4 @@
-# Abstract Decoratee
+# Abstract decoratee
 
 Abstract object shouldn't be used as a decoratee.
 

--- a/src/main/resources/org/eolang/motives/errors/anonymous-objects-inside-formation.md
+++ b/src/main/resources/org/eolang/motives/errors/anonymous-objects-inside-formation.md
@@ -1,6 +1,6 @@
-# Anonymous Objects Inside Formation
+# Anonymous objects inside formation
 
-In [XMIR], Formation cannot contain inner objects without a name.
+In [XMIR], Formation can't contain inner objects without a name.
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/errors/atom-is-not-unique.md
+++ b/src/main/resources/org/eolang/motives/errors/atom-is-not-unique.md
@@ -1,4 +1,4 @@
-# Atom is not unique
+# Atom isn't unique
 
 All atom FQNs across all `.eo` files must not be duplicated.
 

--- a/src/main/resources/org/eolang/motives/errors/decorated-formation.md
+++ b/src/main/resources/org/eolang/motives/errors/decorated-formation.md
@@ -1,7 +1,7 @@
 # Decorated formation
 
 A formation shouldn't be used as a decoratee. It means that abstract object
-should not have `@` as its name.
+shouldn't have `@` as its name.
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/errors/empty-object.md
+++ b/src/main/resources/org/eolang/motives/errors/empty-object.md
@@ -1,4 +1,4 @@
-# Empty Object
+# Empty object
 
 In the [XMIR], objects without any attributes: neither void nor attached are
 prohibited.

--- a/src/main/resources/org/eolang/motives/errors/external-weak-typed-atoms.md
+++ b/src/main/resources/org/eolang/motives/errors/external-weak-typed-atoms.md
@@ -1,6 +1,6 @@
-# External Weak Typed Atoms
+# External weak typed atoms
 
-Weak typing `/?` does not allowed outside of `org.eolang` package.
+Weak typing `/?` doesn't allowed outside of `org.eolang` package.
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/errors/global-noname.md
+++ b/src/main/resources/org/eolang/motives/errors/global-noname.md
@@ -1,4 +1,4 @@
-# Global Noname
+# Global no name
 
 Global object must have a name.
 

--- a/src/main/resources/org/eolang/motives/errors/incorrect-number-of-attributes.md
+++ b/src/main/resources/org/eolang/motives/errors/incorrect-number-of-attributes.md
@@ -1,4 +1,4 @@
-# Incorrect Number Of Attributes
+# Incorrect number of attributes
 
 The number of provided attributes to the object should match with the number of
 its declared attributes.

--- a/src/main/resources/org/eolang/motives/errors/lt-incorrect-unlint.md
+++ b/src/main/resources/org/eolang/motives/errors/lt-incorrect-unlint.md
@@ -1,7 +1,7 @@
 # Incorrect unlints
 
-The meta part of the object should not contain +unlint point on non-existent
-lint, as it is useless
+The meta part of the object shouldn't contain +unlint point on non-existent
+lint, as it's useless
 
 Incorrect:
 
@@ -9,7 +9,7 @@ Incorrect:
 +unlint abracadabra
 ```
 
-Because lint with name "abracadabra" does not exist(perhaps at some
+Because lint with name "abracadabra" doesn't exist(perhaps at some
 point this lint will be added and this example will become correct :) )
 
 Correct:
@@ -18,4 +18,4 @@ Correct:
 +unlint ascii-only
 ```
 
-Because lint with name "ascii-only" exist
+Because lint with name `ascii-only` exist

--- a/src/main/resources/org/eolang/motives/errors/many-void-attributes.md
+++ b/src/main/resources/org/eolang/motives/errors/many-void-attributes.md
@@ -1,4 +1,4 @@
-# Many Void Attributes
+# Many void attributes
 
 Object must have at **max 5** void  attributes.
 

--- a/src/main/resources/org/eolang/motives/errors/noname-attribute.md
+++ b/src/main/resources/org/eolang/motives/errors/noname-attribute.md
@@ -1,4 +1,4 @@
-# Noname Attribute
+# No name attribute
 
 Each object's attribute must have a name.
 

--- a/src/main/resources/org/eolang/motives/errors/object-is-not-unique.md
+++ b/src/main/resources/org/eolang/motives/errors/object-is-not-unique.md
@@ -1,4 +1,4 @@
-# Object Is Not Unique
+# Object isn't unique
 
 High-level object names must be unique across the package.
 

--- a/src/main/resources/org/eolang/motives/errors/signed-binding-indexes.md
+++ b/src/main/resources/org/eolang/motives/errors/signed-binding-indexes.md
@@ -1,6 +1,6 @@
-# Signed Binding Indexes
+# Signed binding indexes
 
-Binding index of application must not be a signed number.
+Binding index of app must not be a signed number.
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/lines/error-line-out-of-listing.md
+++ b/src/main/resources/org/eolang/motives/lines/error-line-out-of-listing.md
@@ -1,6 +1,6 @@
-# Error Line Out Of Listing
+# Error line out of listing
 
-Line number inside `<error/>` in [XMIR] cannot be bigger than amount of lines
+Line number inside `<error/>` in [XMIR] can't be bigger than amount of lines
 in the listing.
 
 Incorrect:

--- a/src/main/resources/org/eolang/motives/lines/meta-line-out-of-listing.md
+++ b/src/main/resources/org/eolang/motives/lines/meta-line-out-of-listing.md
@@ -1,6 +1,6 @@
-# Meta Line Out Of Listing
+# Meta line out of listing
 
-Line number inside `<meta/>` in [XMIR] cannot be bigger than amount of lines
+Line number inside `<meta/>` in [XMIR] can't be bigger than amount of lines
 in the listing.
 
 Incorrect:

--- a/src/main/resources/org/eolang/motives/lines/object-line-out-of-listing.md
+++ b/src/main/resources/org/eolang/motives/lines/object-line-out-of-listing.md
@@ -1,6 +1,6 @@
-# Object Line Out Of Listing
+# Object line out of listing
 
-Line number inside `<o/>` in [XMIR] cannot be bigger than amount of lines
+Line number inside `<o/>` in [XMIR] can't be bigger than amount of lines
 in the listing.
 
 Incorrect:

--- a/src/main/resources/org/eolang/motives/metas/architect-duplicate.md
+++ b/src/main/resources/org/eolang/motives/metas/architect-duplicate.md
@@ -1,4 +1,4 @@
-# Architect Duplicate
+# Architect duplicate
 
 Each `.eo` file must have only one architect.
 

--- a/src/main/resources/org/eolang/motives/metas/duplicate-metas.md
+++ b/src/main/resources/org/eolang/motives/metas/duplicate-metas.md
@@ -1,4 +1,4 @@
-# Duplicate Metas
+# Duplicate metas
 
 Metas must not be duplicated.
 

--- a/src/main/resources/org/eolang/motives/metas/empty-spdx-tail.md
+++ b/src/main/resources/org/eolang/motives/metas/empty-spdx-tail.md
@@ -1,6 +1,6 @@
-# Empty `+spdx` Tail
+# Empty `+spdx` tail
 
-The special meta attribute `+spdx` cannot have an empty tail.
+The special meta attribute `+spdx` can't have an empty tail.
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/metas/incorrect-architect.md
+++ b/src/main/resources/org/eolang/motives/metas/incorrect-architect.md
@@ -1,6 +1,6 @@
 # Incorrect `+architect`
 
-Architect's email must follow regex:
+Architect's email must follow regular expression:
 
 ```regexp
 ^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}$

--- a/src/main/resources/org/eolang/motives/metas/incorrect-home.md
+++ b/src/main/resources/org/eolang/motives/metas/incorrect-home.md
@@ -1,6 +1,6 @@
 # Incorrect `+home`
 
-Special meta `+home` must follow regex:
+Special meta `+home` must follow regular expression:
 
 ```regexp
 ^(?:http(s)?://)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#\[\]@!$&'()*+,;=]+$

--- a/src/main/resources/org/eolang/motives/metas/incorrect-jvm-rt-location.md
+++ b/src/main/resources/org/eolang/motives/metas/incorrect-jvm-rt-location.md
@@ -1,4 +1,4 @@
-# Incorrect `+rt` jvm location
+# Incorrect `+rt` JVM location
 
 The location of JVM runtime should follow the regexp:
 

--- a/src/main/resources/org/eolang/motives/metas/incorrect-spdx.md
+++ b/src/main/resources/org/eolang/motives/metas/incorrect-spdx.md
@@ -20,7 +20,7 @@ Correct:
 [] > foo
 ```
 
-In [XMIR], spdx meta should look like this:
+In [XMIR], `spdx` meta should look like this:
 
 ```xml
 <metas>

--- a/src/main/resources/org/eolang/motives/metas/mandatory-spdx.md
+++ b/src/main/resources/org/eolang/motives/metas/mandatory-spdx.md
@@ -18,7 +18,7 @@ Correct:
 [] > foo
 ```
 
-In [XMIR], spdx meta should look like this:
+In [XMIR], `spdx` meta should look like this:
 
 ```xml
 <meta>

--- a/src/main/resources/org/eolang/motives/metas/unknown-metas.md
+++ b/src/main/resources/org/eolang/motives/metas/unknown-metas.md
@@ -1,4 +1,4 @@
-# Unknown Metas
+# Unknown metas
 
 The following metas are supported:
 

--- a/src/main/resources/org/eolang/motives/metas/unsorted-metas.md
+++ b/src/main/resources/org/eolang/motives/metas/unsorted-metas.md
@@ -1,4 +1,4 @@
-# Unsorted Metas
+# Unsorted metas
 
 Metas must be alphabetically ordered.
 

--- a/src/main/resources/org/eolang/motives/metas/zero-version.md
+++ b/src/main/resources/org/eolang/motives/metas/zero-version.md
@@ -1,4 +1,4 @@
-# Zero Version
+# Zero version
 
 Objects inside `src/(main|test)` must use `0.0.0` version during the
 development.

--- a/src/main/resources/org/eolang/motives/misc/inconsistent-args.md
+++ b/src/main/resources/org/eolang/motives/misc/inconsistent-args.md
@@ -1,4 +1,4 @@
-# Inconsistent Args
+# Inconsistent args
 
 Objects with the same `@base` should have the same amount of arguments passed
 in it.

--- a/src/main/resources/org/eolang/motives/misc/one-high-level-object.md
+++ b/src/main/resources/org/eolang/motives/misc/one-high-level-object.md
@@ -1,4 +1,4 @@
-# One High-Level Object
+# One high-level object
 
 Every `.eo` file must have only one high-level object inside.
 

--- a/src/main/resources/org/eolang/motives/misc/redundant-object.md
+++ b/src/main/resources/org/eolang/motives/misc/redundant-object.md
@@ -1,6 +1,6 @@
-# Redundant Object
+# Redundant object
 
-If named object used only once, it's treated as "redundant", and can be
+If named object used only once, it's treated as "redundant" and can be
 inlined.
 
 Incorrect:

--- a/src/main/resources/org/eolang/motives/misc/sparse-decoration.md
+++ b/src/main/resources/org/eolang/motives/misc/sparse-decoration.md
@@ -1,4 +1,4 @@
-# Sparse Decoration
+# Sparse decoration
 
 Sparse decoration of the base object is prohibited.
 
@@ -12,7 +12,7 @@ Incorrect:
 Correct:
 
 ```eo
-[] > decorates-application
+[] > decorates-app
   if > @
     true
     5
@@ -24,7 +24,7 @@ Correct:
   five > @
 ```
 
-Also, it is possible to have sparse decoration in tests:
+Also, it's possible to have sparse decoration in tests:
 
 ```eo
 # This is my unit test.

--- a/src/main/resources/org/eolang/motives/misc/sprintf-without-formatters.md
+++ b/src/main/resources/org/eolang/motives/misc/sprintf-without-formatters.md
@@ -1,4 +1,4 @@
-# `Q.org.eolang.txt.sprintf` Without Formatters
+# `Q.org.eolang.txt.sprintf` without formatters
 
 The use of `Q.org.eolang.txt.sprintf` object makes no sense if there is no
 formatters in template string.

--- a/src/main/resources/org/eolang/motives/misc/test-object-is-not-verb-in-singular.md
+++ b/src/main/resources/org/eolang/motives/misc/test-object-is-not-verb-in-singular.md
@@ -1,4 +1,4 @@
-# Test Object is not Verb in Singular
+# Test object isn't verb in singular
 
 Test object name should start with verb in singular form.
 

--- a/src/main/resources/org/eolang/motives/misc/unlint-non-existing-defect.md
+++ b/src/main/resources/org/eolang/motives/misc/unlint-non-existing-defect.md
@@ -1,4 +1,4 @@
-# `+unlint` Of Non-Existing Defect
+# `+unlint` of non-existing defect
 
 Special `+unlint` meta should be used only to suppress an existing defects.
 

--- a/src/main/resources/org/eolang/motives/misc/unused-void-attr.md
+++ b/src/main/resources/org/eolang/motives/misc/unused-void-attr.md
@@ -1,4 +1,4 @@
-# Unused Void Attr
+# Unused void attr
 
 Declared void attribute should be used inside the formation.
 

--- a/src/main/resources/org/eolang/motives/names/anonymous-formation.md
+++ b/src/main/resources/org/eolang/motives/names/anonymous-formation.md
@@ -1,6 +1,6 @@
-# Anonymous Formation
+# Anonymous formation
 
-Anonymous formation should not access object, undefined inside the formation.
+Anonymous formation shouldn't access object, undefined inside the formation.
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/names/compound-name.md
+++ b/src/main/resources/org/eolang/motives/names/compound-name.md
@@ -1,6 +1,6 @@
-# Attribute name should not be compound
+# Attribute name shouldn't be compound
 
-In the code, all objects that are not formations
+In the code, all objects that aren't formations
 should have a single word in their name.
 This is because if the name is compound,
 it means the context in the program is too large,

--- a/src/main/resources/org/eolang/motives/names/duplicate-as-attribute.md
+++ b/src/main/resources/org/eolang/motives/names/duplicate-as-attribute.md
@@ -1,6 +1,6 @@
 # Duplicate `@as` Attribute
 
-In [XMIR], object should not have `@as` attributes duplicated inside.
+In [XMIR], object shouldn't have `@as` attributes duplicated inside.
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/names/object-does-not-match-filename.md
+++ b/src/main/resources/org/eolang/motives/names/object-does-not-match-filename.md
@@ -1,6 +1,6 @@
-# Object does not match Filename
+# Object doesn't match filename
 
-Every `.eo` file should not have different name than object, which may confuse
+Every `.eo` file shouldn't have different name than object, which may confuse
 the readers.
 
 Incorrect:

--- a/src/main/resources/org/eolang/motives/names/phi-is-not-first.md
+++ b/src/main/resources/org/eolang/motives/names/phi-is-not-first.md
@@ -1,4 +1,4 @@
-# `@` Is Not First
+# `@` isn't first
 
 The `@` attribute should always go first.
 

--- a/src/main/resources/org/eolang/motives/names/reserved-name.md
+++ b/src/main/resources/org/eolang/motives/names/reserved-name.md
@@ -1,6 +1,6 @@
-# Reserved Name
+# Reserved name
 
-Each object name should not duplicate already reserved names in `org.eolang.*`
+Each object name shouldn't duplicate already reserved names in `org.eolang.*`
 objects [located in home][home].
 
 Incorrect:

--- a/src/main/resources/org/eolang/motives/refs/line-is-absent.md
+++ b/src/main/resources/org/eolang/motives/refs/line-is-absent.md
@@ -1,4 +1,4 @@
-# `@line` Is Absent
+# `@line` is absent
 
 In [XMIR], each `<o/>` with it's `@base`, must have `@line` attribute as well.
 

--- a/src/main/resources/org/eolang/motives/tests/unit-test-missing.md
+++ b/src/main/resources/org/eolang/motives/tests/unit-test-missing.md
@@ -1,4 +1,4 @@
-# Unit Test Missing
+# Unit test missing
 
 Each live object should have unit tests inside.
 

--- a/src/main/resources/org/eolang/motives/tests/unit-test-without-phi.md
+++ b/src/main/resources/org/eolang/motives/tests/unit-test-without-phi.md
@@ -1,4 +1,4 @@
-# Unit Test Without Phi
+# Unit test without phi
 
 Unit test must have `@` attribute.
 

--- a/src/test/java/org/eolang/lints/LtAsciiOnlyTest.java
+++ b/src/test/java/org/eolang/lints/LtAsciiOnlyTest.java
@@ -55,7 +55,7 @@ final class LtAsciiOnlyTest {
     void explainsMotive() throws Exception {
         MatcherAssert.assertThat(
             "The motive doesn't contain expected string",
-            new LtAsciiOnly().motive().contains("# ASCII-Only Characters in Comment"),
+            new LtAsciiOnly().motive().contains("# ASCII-Only characters in comment"),
             new IsEqual<>(true)
         );
     }


### PR DESCRIPTION
In this pull request, I added the Vale tool to check text in markdown files. I thought it’s better to have it not only in GitHub Actions, but also integrated into the build process - if installed locally. However, I didn’t add it to the `mvn` job on purpose, since a build shouldn’t fail because of text issues. I fixed all existing errors and added commonly used words to a custom dictionary. If you think some words shouldn’t be in the dictionary and should be fixed instead - let me know. Also curious to hear your thoughts: is it better to show errors as comments in the pull request(might get spammy), or in the job logs(harder to view)?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced automated style and prose checking for Markdown files using Vale, integrated with CI and build scripts.
  * Added configuration files and vocabulary customization for style consistency.

* **Documentation**
  * Standardized capitalization and improved wording across all Markdown documentation for clarity and consistency.
  * Updated README with instructions for using Vale to check Markdown files.

* **Tests**
  * Adjusted test assertions to match updated documentation capitalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->