### PR TITLE
ci(#jmh-benchmark-action): update JMH benchmark action to parametrized version

### DIFF
--- a/.github/workflows/jmh.yml
+++ b/.github/workflows/jmh.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Run JMH Benchmark Action
-        uses: volodya-lombrozo/jmh-benchmark-action@main
+        uses: volodya-lombrozo/jmh-benchmark-action@9_parametrized_table
         with:
           java-version: "11"
           base-ref: "master"

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ mochawesome-report/
 node_modules/
 target/
 temp/
+.aidy


### PR DESCRIPTION
Updates JMH benchmark action to use `@9_parametrized_table` version 

