### PR TITLE
ci(#550): Pin jmh-benchmark-action to v1 instead of main

### DIFF
--- a/.github/workflows/jmh.yml
+++ b/.github/workflows/jmh.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Run JMH Benchmark Action
-        uses: volodya-lombrozo/jmh-benchmark-action@main
+        uses: volodya-lombrozo/jmh-benchmark-action@v1
         with:
           java-version: "11"
           base-ref: "master"

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ mochawesome-report/
 node_modules/
 target/
 temp/
+.aidy


### PR DESCRIPTION
Pins `jmh-benchmark-action` to stable version `v1` and updates `.gitignore` to exclude `.aidy` files.

Closes #550