### PR TITLE
chore(#215): test timeout depends on os

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
     <skipITs/>
     <!-- This is the flag that allows to skip all tests -->
     <skipTests/>
+    <test.timeout>45s</test.timeout>
   </properties>
   <dependencies>
     <dependency>
@@ -324,6 +325,11 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <!-- version from the parent pom -->
             <configuration>
+              <systemPropertyVariables>
+                <junit.jupiter.execution.timeout.test.method.default>
+                  ${test.timeout}
+                </junit.jupiter.execution.timeout.test.method.default>
+              </systemPropertyVariables>
               <excludedGroups>!benchmark</excludedGroups>
               <excludes>
                 <exclude>
@@ -395,6 +401,11 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <version>3.5.3</version>
             <configuration>
+              <systemPropertyVariables>
+                <junit.jupiter.execution.timeout.test.method.default>
+                  ${test.timeout}
+                </junit.jupiter.execution.timeout.test.method.default>
+              </systemPropertyVariables>
               <excludedGroups>benchmark</excludedGroups>
               <excludes>
                 <exclude>
@@ -448,6 +459,28 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>mac</id>
+      <activation>
+        <os>
+          <family>mac</family>
+        </os>
+      </activation>
+      <properties>
+        <test.timeout>15s</test.timeout>
+      </properties>
+    </profile>
+    <profile>
+      <id>unix</id>
+      <activation>
+        <os>
+          <family>unix</family>
+        </os>
+      </activation>
+      <properties>
+        <test.timeout>15s</test.timeout>
+      </properties>
+    </profile>
   </profiles>
   <build>
     <pluginManagement>
@@ -484,6 +517,11 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <!-- version from the parent pom -->
         <configuration>
+          <systemPropertyVariables>
+            <junit.jupiter.execution.timeout.test.method.default>
+              ${test.timeout}
+            </junit.jupiter.execution.timeout.test.method.default>
+          </systemPropertyVariables>
           <skipTests>${skipUTs}</skipTests>
           <excludedGroups>benchmark,deep</excludedGroups>
           <excludes>

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,7 +1,0 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
-# SPDX-License-Identifier: MIT
-
-# @todo #107:45min Configure default timeout for tests running on windows to 10s and 3s on other platforms.
-#  Currently, it fails with the 3s timeout on windows platform. Let's try to configure
-#  test default timeout exclusively for windows, and keep 3s for other platforms.
-junit.jupiter.execution.timeout.test.method.default = 45s


### PR DESCRIPTION
In this pull request, I set the test timeout values to 15 seconds for Unix and Mac, and 45 seconds for other os. I did this for all test runs(including benchmarks and others), and I’m not sure if this is the right approach. I also tried to make profile handling more elegant, but I didn’t understand how to do it https://stackoverflow.com/questions/79610681/how-to-create-profile-unix-or-mac-and-profile-other-os-in-maven