### PR TITLE
fix(#577): duplicate-names-in-diff-context will not trigger on specials

### DIFF
--- a/src/main/resources/org/eolang/funcs/special-name.xsl
+++ b/src/main/resources/org/eolang/funcs/special-name.xsl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+  ~ SPDX-License-Identifier: MIT
+  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="special-name" version="2.0">
+  <xsl:import href="/org/eolang/parser/_specials.xsl"/>
+  <xsl:function name="eo:special" as="xs:boolean">
+    <xsl:param name="name"/>
+    <xsl:sequence select="$name = '@' or $name = $eo:lambda or contains($name, $eo:cactoos)"/>
+  </xsl:function>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/misc/duplicate-names-in-diff-context.xsl
+++ b/src/main/resources/org/eolang/lints/misc/duplicate-names-in-diff-context.xsl
@@ -6,10 +6,11 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="duplicate-names-in-diff-context">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:import href="/org/eolang/funcs/special-name.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[@name!='@']">
+      <xsl:for-each select="//o[not(eo:special(@name))]">
         <xsl:variable name="namesakes" select="//o[@name=current()/@name]"/>
         <xsl:if test="count($namesakes)&gt;1">
           <defect>
@@ -23,15 +24,21 @@
               </xsl:attribute>
             </xsl:if>
             <xsl:attribute name="severity">warning</xsl:attribute>
-            <xsl:text>Object </xsl:text>
+            <xsl:text>Object "</xsl:text>
             <xsl:value-of select="@name"/>
-            <xsl:text> has same name as object on line </xsl:text>
-            <xsl:for-each select="$namesakes[@line != current()/@line]">
-              <xsl:if test="position()&gt;1">
-                <xsl:text>, </xsl:text>
+            <xsl:text>" has same name as </xsl:text>
+            <xsl:variable name="lines" select="$namesakes[@line and (not(current()/@line) or @line != current()/@line)]/@line"/>
+            <xsl:variable name="empty" select="count($lines) != count($namesakes) - 1"/>
+            <xsl:if test="count($lines) &gt; 0">
+              <xsl:text>objects on lines </xsl:text>
+              <xsl:value-of select="string-join($lines, ', ')"/>
+              <xsl:if test="$empty">
+                <xsl:text> and </xsl:text>
               </xsl:if>
-              <xsl:value-of select="@line"/>
-            </xsl:for-each>
+            </xsl:if>
+            <xsl:if test="$empty">
+              <xsl:text>other objects in file</xsl:text>
+            </xsl:if>
           </defect>
         </xsl:if>
       </xsl:for-each>

--- a/src/test/resources/org/eolang/lints/packs/single/duplicate-names-in-diff-context/allows-special-names.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/duplicate-names-in-diff-context/allows-special-names.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/duplicate-names-in-diff-context.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # Foo.
+  [] > foo
+    [] > bar ?
+    [] > buz ?
+    [] > x
+      y > @
+    [] > z
+      z > @

--- a/src/test/resources/org/eolang/lints/packs/single/duplicate-names-in-diff-context/prints-context-when-lines-empty.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/duplicate-names-in-diff-context/prints-context-when-lines-empty.yaml
@@ -8,9 +8,11 @@ asserts:
 document: |
   <object>
     <o>
-      <o name="foo"/>
-    </o>
-    <o>
-      <o name="foo"/>
+      <o>
+        <o name="foo"/>
+      </o>
+      <o>
+        <o name="foo"/>
+      </o>
     </o>
   </object>

--- a/src/test/resources/org/eolang/lints/packs/single/duplicate-names-in-diff-context/prints-context-when-lines-empty.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/duplicate-names-in-diff-context/prints-context-when-lines-empty.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/duplicate-names-in-diff-context.xsl
+asserts:
+  - /defects[count(defect[@context and @severity='warning'])=2]
+document: |
+  <object>
+    <o>
+      <o name="foo"/>
+    </o>
+    <o>
+      <o name="foo"/>
+    </o>
+  </object>


### PR DESCRIPTION
In this pull request, I fixed a bug where the `duplicate-names-in-diff-context` lint was incorrectly warning about the name `lambda`. I also tweaked its logic so it works when `line` values are empty - previously, it was throwing an error in that case