### PR TITLE
feat(#556): auto-fix architecture

### DIFF
--- a/src/main/java/org/eolang/lints/Defect.java
+++ b/src/main/java/org/eolang/lints/Defect.java
@@ -6,6 +6,7 @@ package org.eolang.lints;
 
 import com.jcabi.manifests.Manifests;
 import java.util.Objects;
+import org.eolang.lints.fix.Fix;
 
 /**
  * A single defect found.
@@ -103,6 +104,13 @@ public interface Defect {
     boolean experimental();
 
     /**
+     * Information on how to fix this defect.
+     *
+     * @return Fix info.
+     */
+    Fix fix();
+
+    /**
      * Default implementation of {@link Defect}.
      * <p>
      * Provides a standard implementation with basic functionality.
@@ -143,6 +151,11 @@ public interface Defect {
         private final boolean experiment;
 
         /**
+         * How to fix.
+         */
+        private final Fix fix;
+
+        /**
          * Ctor.
          * @param rule Rule name
          * @param severity Severity level
@@ -155,7 +168,7 @@ public interface Defect {
             final String rule, final Severity severity,
             final String object, final int line, final String text
         ) {
-            this(rule, severity, object, line, text, false);
+            this(rule, severity, object, line, text, false, new Fix());
         }
 
         /**
@@ -175,7 +188,7 @@ public interface Defect {
         public Default(
             final String rule, final Severity severity,
             final String object, final int line, final String text,
-            final boolean exprmnt
+            final boolean exprmnt, final Fix fix
         ) {
             this.rle = rule;
             this.sev = severity;
@@ -183,6 +196,7 @@ public interface Defect {
             this.lineno = line;
             this.txt = text;
             this.experiment = exprmnt;
+            this.fix = fix;
         }
 
         @Override
@@ -235,6 +249,11 @@ public interface Defect {
         @Override
         public boolean experimental() {
             return this.experiment;
+        }
+
+        @Override
+        public Fix fix() {
+            return this.fix;
         }
 
         @Override

--- a/src/main/java/org/eolang/lints/DfContext.java
+++ b/src/main/java/org/eolang/lints/DfContext.java
@@ -4,6 +4,8 @@
  */
 package org.eolang.lints;
 
+import org.eolang.lints.fix.Fix;
+
 /**
  * Defect with context.
  * @since 0.0.40
@@ -58,6 +60,11 @@ final class DfContext implements Defect {
     @Override
     public String version() {
         return this.origin.version();
+    }
+
+    @Override
+    public Fix fix() {
+        return this.origin.fix();
     }
 
     @Override

--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -20,6 +20,9 @@ import org.cactoos.Input;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.text.IoCheckedText;
 import org.cactoos.text.TextOf;
+import org.eolang.lints.fix.Edit;
+import org.eolang.lints.fix.File;
+import org.eolang.lints.fix.Fix;
 import org.eolang.parser.ObjectName;
 
 /**
@@ -98,6 +101,7 @@ final class LtByXsl implements Lint<XML> {
                     String.format("No severity reported by %s", this.rule)
                 );
             }
+            final Optional<String> message = xml.element("message").text();
             defects.add(
                 new DfContext(
                     new Defect.Default(
@@ -105,8 +109,18 @@ final class LtByXsl implements Lint<XML> {
                         Severity.parsed(sever.get()),
                         new ObjectName(xmir).get(),
                         this.lineno(xml),
-                        xml.text().get(),
-                        LtByXsl.experimental(xml)
+                        message.orElseGet(() -> xml.text().get()),
+                        LtByXsl.experimental(xml),
+                        message.map(
+                                ignored ->
+                                    new Fix(
+                                        new File(
+                                            xmir.xpath("/@source/text()").get(0),
+                                            new Edit(xml.element("edit"))
+                                        )
+                                    )
+                            )
+                            .orElseGet(Fix::new)
                     ),
                     xml.attribute("context").text().orElse("")
                 )

--- a/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
+++ b/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
@@ -19,6 +19,10 @@ import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
 import org.cactoos.text.IoCheckedText;
 import org.cactoos.text.TextOf;
+import org.eolang.lints.fix.Edit;
+import org.eolang.lints.fix.File;
+import org.eolang.lints.fix.Fix;
+import org.eolang.lints.fix.Position;
 import org.eolang.parser.ObjectName;
 
 /**
@@ -82,7 +86,7 @@ final class LtUnlintNonExistingDefect implements Lint<XML> {
                         )
                         )
                         .map(xnav -> xnav.text().get())
-                        .collect(Collectors.toList())
+                        .map(Integer::parseInt)
                         .forEach(
                             line ->
                                 defects.add(
@@ -90,10 +94,21 @@ final class LtUnlintNonExistingDefect implements Lint<XML> {
                                         this.name(),
                                         Severity.WARNING,
                                         new ObjectName(xmir).get(),
-                                        Integer.parseInt(line),
+                                        line,
                                         String.format(
                                             "Unlinting rule '%s' doesn't make sense, since there are no defects with it",
                                             unlint
+                                        ),
+                                        false,
+                                        new Fix(
+                                            new File(
+                                                new ObjectSource(xmir).get(),
+                                                new Edit(
+                                                    new Position(line, 0),
+                                                    new Position(line + 1, 0),
+                                                    ""
+                                                )
+                                            )
                                         )
                                     )
                                 )

--- a/src/main/java/org/eolang/lints/ObjectSource.java
+++ b/src/main/java/org/eolang/lints/ObjectSource.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XML;
+
+final class ObjectSource {
+    private final Xnav xnav;
+
+    ObjectSource(XML xml) {
+        this.xnav = new Xnav(xml.inner());
+    }
+
+    String get() {
+        return xnav.attribute("source").text().orElse("");
+    }
+}

--- a/src/main/java/org/eolang/lints/ScopedDefects.java
+++ b/src/main/java/org/eolang/lints/ScopedDefects.java
@@ -31,7 +31,8 @@ final class ScopedDefects extends CollectionEnvelope<Defect> {
                             defect.object(),
                             defect.line(),
                             defect.text(),
-                            defect.experimental()
+                            defect.experimental(),
+                            defect.fix()
                         ),
                         defect.context()
                     ),

--- a/src/main/java/org/eolang/lints/fix/Create.java
+++ b/src/main/java/org/eolang/lints/fix/Create.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints.fix;
+
+import com.github.lombrozo.xnav.Xnav;
+
+public class Create {
+    private final String path;
+
+    private final boolean overwrite;
+
+    private final boolean ignoreIfExists;
+
+    public Create(String path, boolean overwrite, boolean ignoreIfExists) {
+        this.path = path;
+        this.overwrite = overwrite;
+        this.ignoreIfExists = ignoreIfExists;
+    }
+
+    public Create(Xnav xnav) {
+        this(
+            xnav.element("path").text().get(),
+            Boolean.parseBoolean(xnav.element("overwrite").text().orElse("")),
+            Boolean.parseBoolean(xnav.element("ignoreIfExists").text().orElse(""))
+        );
+    }
+
+    public String path() {
+        return this.path;
+    }
+
+    public boolean overwrite() {
+        return this.overwrite;
+    }
+
+    public boolean ignoreIfExists() {
+        return this.ignoreIfExists;
+    }
+}

--- a/src/main/java/org/eolang/lints/fix/Delete.java
+++ b/src/main/java/org/eolang/lints/fix/Delete.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints.fix;
+
+import com.github.lombrozo.xnav.Xnav;
+
+public class Delete {
+    private final String path;
+
+    private final boolean recursive;
+
+    private final boolean ignoreIfNotExists;
+
+    public Delete(String path, boolean recursive, boolean ignoreIfNotExists) {
+        this.path = path;
+        this.recursive = recursive;
+        this.ignoreIfNotExists = ignoreIfNotExists;
+    }
+
+    public Delete(final Xnav xnav) {
+        this(
+            xnav.element("path").text().get(),
+            Boolean.parseBoolean(xnav.element("recursive").text().orElse("")),
+            Boolean.parseBoolean(xnav.element("ignoreIfNotExists").text().orElse(""))
+        );
+    }
+
+    public String path() {
+        return this.path;
+    }
+
+    public boolean recursive() {
+        return this.recursive;
+    }
+
+    public boolean ignoreIfNotExists() {
+        return this.ignoreIfNotExists;
+    }
+}

--- a/src/main/java/org/eolang/lints/fix/Edit.java
+++ b/src/main/java/org/eolang/lints/fix/Edit.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints.fix;
+
+import com.github.lombrozo.xnav.Xnav;
+
+public class Edit {
+    private final Position start;
+
+    private final Position end;
+
+    private final String newText;
+
+    public Edit(final Position start, final Position end, final String newText) {
+        this.start = start;
+        this.end = end;
+        this.newText = newText;
+    }
+
+    public Edit(Xnav xnav) {
+        this(
+            new Position(xnav.element("start")),
+            new Position(xnav.element("end")),
+            xnav.element("newText").text().get()
+        );
+    }
+
+    public Position start() {
+        return this.start;
+    }
+
+    public Position end() {
+        return this.end;
+    }
+
+    public String newText() {
+        return this.newText;
+    }
+}

--- a/src/main/java/org/eolang/lints/fix/File.java
+++ b/src/main/java/org/eolang/lints/fix/File.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints.fix;
+
+import com.github.lombrozo.xnav.Xnav;
+import java.util.Arrays;
+import java.util.Collection;
+
+public class File {
+    private final String path;
+    private final Collection<Edit> edits;
+
+    public File(final String path, final Edit... edits) {
+        this.path = path;
+        this.edits = Arrays.asList(edits);
+    }
+
+    public File(final Xnav xnav) {
+        this(
+            xnav.attribute("path").text().get(),
+            xnav.path("edit").map(Edit::new).toArray(Edit[]::new)
+        );
+    }
+
+    public String path() {
+        return this.path;
+    }
+
+    public Collection<Edit> edits() {
+        return this.edits;
+    }
+}

--- a/src/main/java/org/eolang/lints/fix/Fix.java
+++ b/src/main/java/org/eolang/lints/fix/Fix.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints.fix;
+
+import com.github.lombrozo.xnav.Xnav;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Fix {
+    private final Collection<File> files;
+
+    private final Collection<Create> creates;
+
+    private final Collection<Delete> deletes;
+
+    private final Collection<Rename> renames;
+
+    public Fix(Collection<File> files, Collection<Create> creates, Collection<Delete> deletes, Collection<Rename> renames) {
+        this.files = files;
+        this.creates = creates;
+        this.deletes = deletes;
+        this.renames = renames;
+    }
+
+    public Fix() {
+        this(
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+    }
+
+    public Fix(File file) {
+        this(
+            Collections.singletonList(file),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+    }
+
+    public Fix(Xnav fix) {
+        this(
+            fix.path("file").map(File::new).collect(Collectors.toList()),
+            fix.path("create").map(Create::new).collect(Collectors.toList()),
+            fix.path("delete").map(Delete::new).collect(Collectors.toList()),
+            fix.path("rename").map(Rename::new).collect(Collectors.toList())
+        );
+    }
+
+    public Collection<File> files() {
+        return this.files;
+    }
+
+    public Collection<Create> creates() {
+        return this.creates;
+    }
+
+    public Collection<Delete> deletes() {
+        return this.deletes;
+    }
+
+    public Collection<Rename> renames() {
+        return this.renames;
+    }
+}

--- a/src/main/java/org/eolang/lints/fix/Position.java
+++ b/src/main/java/org/eolang/lints/fix/Position.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints.fix;
+
+import com.github.lombrozo.xnav.Xnav;
+
+public class Position {
+    private final int line;
+
+    private final int character;
+
+    public Position(final int line, final int character) {
+        this.line = line;
+        this.character = character;
+    }
+
+    public Position(Xnav xnav) {
+        this(
+            Integer.parseInt(xnav.attribute("line").text().get()),
+            Integer.parseInt(xnav.attribute("character").text().get())
+        );
+    }
+
+    public int line() {
+        return this.line;
+    }
+
+    public int character() {
+        return this.character;
+    }
+}

--- a/src/main/java/org/eolang/lints/fix/Rename.java
+++ b/src/main/java/org/eolang/lints/fix/Rename.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints.fix;
+
+import com.github.lombrozo.xnav.Xnav;
+
+public class Rename {
+    private final String oldPath;
+    private final String newPath;
+    private final boolean overwrite;
+    private final boolean ignoreIfExists;
+
+    public Rename(String oldPath, String newPath, boolean overwrite, boolean ignoreIfExists) {
+        this.oldPath = oldPath;
+        this.newPath = newPath;
+        this.overwrite = overwrite;
+        this.ignoreIfExists = ignoreIfExists;
+    }
+
+    public Rename(Xnav xnav) {
+        this(
+            xnav.element("oldPath").text().get(),
+            xnav.element("newPath").text().get(),
+            Boolean.parseBoolean(xnav.element("overwrite").text().orElse("")),
+            Boolean.parseBoolean(xnav.element("ignoreIfExists").text().orElse(""))
+        );
+    }
+
+    public String oldPath() {
+        return this.oldPath;
+    }
+
+    public String newPath() {
+        return this.newPath;
+    }
+
+    public boolean overwrite() {
+        return this.overwrite;
+    }
+
+    public boolean ignoreIfExists() {
+        return this.ignoreIfExists;
+    }
+}

--- a/src/main/resources/org/eolang/lints/aliases/empty-alias.xsl
+++ b/src/main/resources/org/eolang/lints/aliases/empty-alias.xsl
@@ -10,7 +10,7 @@
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="/object/metas/meta[head='alias' and not(part[1]/text())]">
-        <xsl:element name="defect">
+        <defect>
           <xsl:variable name="line" select="eo:lineno(@line)"/>
           <xsl:attribute name="line">
             <xsl:value-of select="$line"/>
@@ -23,8 +23,19 @@
           <xsl:attribute name="severity">
             <xsl:text>error</xsl:text>
           </xsl:attribute>
-          <xsl:text>The alias doesn't have a tail</xsl:text>
-        </xsl:element>
+          <message>
+            <xsl:text>The alias doesn't have a tail</xsl:text>
+          </message>
+          <edit>
+            <start character="0">
+              <xsl:attribute name="line" select="$line"/>
+            </start>
+            <end character="0">
+              <xsl:attribute name="line" select="number($line) + 1"/>
+            </end>
+            <newText/>
+          </edit>
+        </defect>
       </xsl:for-each>
     </defects>
   </xsl:template>

--- a/src/test/java/matchers/DefectsMatcher.java
+++ b/src/test/java/matchers/DefectsMatcher.java
@@ -30,13 +30,17 @@ public final class DefectsMatcher extends BaseMatcher<XML> {
     public boolean matches(final Object xml) {
         final Collection<Defect> defects = new ArrayList<>(0);
         for (final XML defect : ((XML) xml).nodes("/defects/defect")) {
+            final String text = defect.xpath("text()")
+                .stream()
+                .findFirst()
+                .orElse(defect.xpath("message/text()").get(0));
             defects.add(
                 new Defect.Default(
                     "unknown",
                     Severity.parsed(defect.xpath("@severity").get(0)),
                     "unknown",
                     Integer.parseInt(defect.xpath("@line").get(0)),
-                    defect.xpath("text()").get(0)
+                    text
                 )
             );
         }

--- a/src/test/java/matchers/DefectsMatcher.java
+++ b/src/test/java/matchers/DefectsMatcher.java
@@ -33,7 +33,7 @@ public final class DefectsMatcher extends BaseMatcher<XML> {
             final String text = defect.xpath("text()")
                 .stream()
                 .findFirst()
-                .orElse(defect.xpath("message/text()").get(0));
+                .orElseGet(() -> defect.xpath("/message/text()").get(0));
             defects.add(
                 new Defect.Default(
                     "unknown",

--- a/src/test/java/matchers/DefectsMatcher.java
+++ b/src/test/java/matchers/DefectsMatcher.java
@@ -33,7 +33,7 @@ public final class DefectsMatcher extends BaseMatcher<XML> {
             final String text = defect.xpath("text()")
                 .stream()
                 .findFirst()
-                .orElseGet(() -> defect.xpath("/message/text()").get(0));
+                .orElseGet(() -> defect.xpath("message/text()").get(0));
             defects.add(
                 new Defect.Default(
                     "unknown",

--- a/src/test/java/org/eolang/lints/DefectTest.java
+++ b/src/test/java/org/eolang/lints/DefectTest.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.lints;
 
+import org.eolang.lints.fix.Fix;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -72,7 +73,8 @@ final class DefectTest {
                 "f.12",
                 42,
                 "This is wrong",
-                true
+                true,
+                new Fix()
             ).experimental(),
             Matchers.equalTo(true)
         );


### PR DESCRIPTION
1. I didn’t find any clear standard format for describing code fixes, so I went with the LSP `DocumentChanges` format. It’s reasonably clean, supports all kinds of edits, and integrates well with our LSP server. For `eoc`, though, we’ll likely need to parse and apply changes manually([question](https://stackoverflow.com/questions/79608933/how-to-execute-lsp-codeaction-in-local-file-system-in-java)). Hopefully, it won’t be too complex

2. I originally planned to use the `lsp4j` library, hoping it would support easy (de)serialization. But it uses a complex `GSON` setup, and `gson-xml` failed to handle it. So I decided to recreate the `DocumentChanges` structure with our own data classes

3. Added the `fix` package to hold data classes describing fixes

    3.1. Initially, I made all classes interfaces with `Default` implementations(similar to the `Defect` data class). 
    But later realized that was overkill - no one would realistically extend these. So I switched to plain Java data 
    classes. Now, creating a fix is simpler:
    ```java
    new Fix(
      new File(
          new ObjectSource(xmir).get(),
          new Edit(
              new Position(line, 0),
              new Position(line + 1, 0),
              ""
          )
      )
    )
    ```
    instead of
    ```java
    new Fix.Default(
      new File.Default(
          new ObjectSource(xmir).get(),
          new Edit.Default(
              new Position.Default(line, 0),
              new Position.Default(line + 1, 0),
              ""
          )
      )
    )
    ```

    3.2. I’m aware that we aim to keep the public API as minimal as possible, and a public fix package doesn't quite align with that. Still, putting all these classes into `org.eolang.lints` would look messy. Likewise, moving `Fix` to `org.eolang.lints` and nesting the rest as inner classes would be ugly. I considered keeping only interfaces and implementing them via anonymous classes where needed, but that would be too verbose. This might be worth a separate discussion [here](https://github.com/objectionary/lints/issues/583).


4. By default, linters still don’t offer fixes and behave as before. But to add fix support:
    4.1. For Java-based linters, just pass fix data into the constructor(like [this](https://github.com/Marat-Tim/lints/blob/407b72c8b20c59d42c5153195e248b716c7acb40/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java#L103))
    4.2. For XSL linters, move the message to a `<message>` tag and put the fix info in an `<edit>` tag(like [this](https://github.com/Marat-Tim/lints/blob/407b72c8b20c59d42c5153195e248b716c7acb40/src/main/resources/org/eolang/lints/aliases/empty-alias.xsl#L29)). I assumed XSL linters won’t need file creation or multi-file edits, so one edit per case should be enough