### PR TITLE
feat(#108): `@` must be at top level

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/phi-not-at-top-level.xsl
+++ b/src/main/resources/org/eolang/lints/misc/phi-not-at-top-level.xsl
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+  ~ SPDX-License-Identifier: MIT
+  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="phi-not-at-top-level">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[@name = '@' and preceding-sibling::o[o[@base = '$.@']]]">
+        <defect>
+          <xsl:variable name="line" select="eo:lineno(@line)"/>
+          <xsl:attribute name="line">
+            <xsl:value-of select="$line"/>
+          </xsl:attribute>
+          <xsl:if test="$line = '0'">
+            <xsl:attribute name="context">
+              <xsl:value-of select="eo:defect-context(.)"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:attribute name="severity">warning</xsl:attribute>
+          <xsl:text>Phi attribute must be at the top level of attributes in a formation</xsl:text>
+        </defect>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/misc/phi-not-at-top-level.xsl
+++ b/src/main/resources/org/eolang/lints/misc/phi-not-at-top-level.xsl
@@ -9,7 +9,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[@name = '@' and preceding-sibling::o[o[@base = '$.@']]]">
+      <xsl:for-each select="//o[@name = '@' and @pos and ancestor::o[not(@base)][1][@pos] and number(@pos) - 2 != number(ancestor::o[not(@base)][1][@pos]/@pos)]">
         <defect>
           <xsl:variable name="line" select="eo:lineno(@line)"/>
           <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/motives/misc/phi-not-at-top-level.md
+++ b/src/main/resources/org/eolang/motives/misc/phi-not-at-top-level.md
@@ -1,0 +1,27 @@
+# Attribute `@` must be at top level in formation
+
+Since the decorated object is key piece of information in the code,
+it's better to keep it at the top level of attributes in formation.
+In other words, the `@` attribute shouldn't belong to an object that's
+itself an attribute of the formation.
+If such structure is needed, it’s better to move the `@`
+declaration higher and use the name `@` to create object.
+
+Incorrect:
+
+```eo
+# Comment.
+[] > app
+  foo > x
+    bar > @
+```
+
+Correct:
+
+```eo
+# Comment.
+[] > app
+  bar > @
+  foo > x
+    @
+```

--- a/src/test/resources/org/eolang/lints/packs/single/phi-not-at-top-level/allows-phi-after-it-usage.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/phi-not-at-top-level/allows-phi-after-it-usage.yaml
@@ -8,6 +8,6 @@ asserts:
 input: |
   # No comments.
   [] > app
-    bar > @
     foo > x
       @
+    bar > @

--- a/src/test/resources/org/eolang/lints/packs/single/phi-not-at-top-level/allows-phi-on-top-level.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/phi-not-at-top-level/allows-phi-on-top-level.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/phi-not-at-top-level.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # No comments.
+  [] > app
+    baz > y
+    bar > @
+    foo > x
+      @

--- a/src/test/resources/org/eolang/lints/packs/single/phi-not-at-top-level/catches-phi-as-sub-attr-when-many-attrs.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/phi-not-at-top-level/catches-phi-as-sub-attr-when-many-attrs.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/phi-not-at-top-level.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='6']
+input: |
+  # No comments.
+  [] > app
+    a > b
+    c > d
+      e > f
+        g > @
+      h
+    i > j

--- a/src/test/resources/org/eolang/lints/packs/single/phi-not-at-top-level/catches-phi-as-sub-attr.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/phi-not-at-top-level/catches-phi-as-sub-attr.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/phi-not-at-top-level.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='4']
+input: |
+  # No comments.
+  [] > app
+    foo > x
+      bar > @

--- a/src/test/resources/org/eolang/lints/packs/single/phi-not-at-top-level/catches-phi-in-very-nested-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/phi-not-at-top-level/catches-phi-in-very-nested-object.yaml
@@ -4,10 +4,13 @@
 sheets:
   - /org/eolang/lints/misc/phi-not-at-top-level.xsl
 asserts:
-  - /defects[count(defect[@severity='warning'])=0]
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='5']
 input: |
   # No comments.
   [] > app
-    bar > @
-    foo > x
-      @
+    a > x
+      b
+        c > @
+          d
+            e


### PR DESCRIPTION
I'm not sure we can rely on the order of objects within a single tag, or that using `@` in inner objects will always result in an element with `base='$.@'`
But if that’s not guaranteed, it seems like implementing this lint may not be possible