### PR TITLE
bug(#578): void attribute exclusion in `duplicate-names-in-diff-context`

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/duplicate-names-in-diff-context.xsl
+++ b/src/main/resources/org/eolang/lints/misc/duplicate-names-in-diff-context.xsl
@@ -10,8 +10,8 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[not(eo:special(@name))]">
-        <xsl:variable name="namesakes" select="//o[@name=current()/@name]"/>
+      <xsl:for-each select="//o[not(eo:special(@name)) and not(@base='∅')]">
+        <xsl:variable name="namesakes" select="//o[@name=current()/@name and not(@base='∅')]"/>
         <xsl:if test="count($namesakes)&gt;1">
           <defect>
             <xsl:variable name="line" select="eo:lineno(@line)"/>

--- a/src/test/resources/org/eolang/lints/packs/single/duplicate-names-in-diff-context/allows-duplicates-in-voids.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/duplicate-names-in-diff-context/allows-duplicates-in-voids.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/duplicate-names-in-diff-context.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # Foo.
+  [bar] > foo
+    [] > empty
+      error "Bar cannot be empty" > bar


### PR DESCRIPTION
In this PR I've updated `duplicate-names-in-diff-context` to exclude void attributes from analysis.

see #578
History:
- **bug(#578): test case**
- **bug(#578): passes**
