### PR TITLE
bug(#585): `phi-is-not-first` handles multiple `\phi`

### DIFF
--- a/src/main/resources/org/eolang/lints/names/phi-is-not-first.xsl
+++ b/src/main/resources/org/eolang/lints/names/phi-is-not-first.xsl
@@ -10,12 +10,12 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:apply-templates select="//o[o[@name='@'] and o[@name='@']/preceding-sibling::o[not(@base='∅')]]" mode="unordered"/>
+      <xsl:apply-templates select="//o[@name='@'][preceding-sibling::o[not(@base='∅')]]" mode="unordered"/>
     </defects>
   </xsl:template>
-  <xsl:template match="o" mode="unordered">
+  <xsl:template match="o[@name='@']" mode="unordered">
     <defect>
-      <xsl:variable name="line" select="eo:lineno(o[@name='@']/@line)"/>
+      <xsl:variable name="line" select="eo:lineno(@line)"/>
       <xsl:attribute name="line">
         <xsl:value-of select="$line"/>
       </xsl:attribute>

--- a/src/test/resources/org/eolang/lints/packs/single/phi-is-not-first/allows-double-phi.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/phi-is-not-first/allows-double-phi.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/phi-is-not-first.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # No comments.
+  [] > foo
+    y > @
+    x > @
+    z > hey

--- a/src/test/resources/org/eolang/lints/packs/single/phi-is-not-first/catches-both-phi.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/phi-is-not-first/catches-both-phi.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/phi-is-not-first.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=2]
+  - /defects/defect[@line='4']
+  - /defects/defect[@line='5']
+input: |
+  # No comments.
+  [] > foo
+    y > bar
+    x > @
+    z > @

--- a/src/test/resources/org/eolang/lints/packs/single/phi-is-not-first/catches-double-phi.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/phi-is-not-first/catches-double-phi.yaml
@@ -4,7 +4,8 @@
 sheets:
   - /org/eolang/lints/names/phi-is-not-first.xsl
 asserts:
-  - /defects[count(defect)=0]
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='4']
 input: |
   # No comments.
   [] > foo


### PR DESCRIPTION
In this PR I've updated `phi-is-not-first` lint to handle cases, when multiple `@` are in the source.

see #585
History:
- **bug(#585): test**
- **bug(#585): handles double phi**
