### PR TITLE
bug(#595): report failures in `benchmark.yml`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -64,3 +64,12 @@ jobs:
           assignees: yegor256
           base: master
           sign-commits: true
+  report:
+    name: Create issue on failure
+    needs: build
+    if: failure() && github.event.pull_request == null
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: jayqi/failed-build-issue-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In this PR I've added failure reporting in `benchmark.yml`, with the help of `failed-build-issue-action`.

see #595