### PR TITLE
bug(#608): reserved names processing in deep profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -408,11 +408,10 @@
           <plugin>
             <groupId>com.googlecode.maven-download-plugin</groupId>
             <artifactId>download-maven-plugin</artifactId>
-            <version>1.13.0</version>
             <executions>
               <execution>
                 <id>download-home</id>
-                <phase>generate-sources</phase>
+                <phase>initialize</phase>
                 <goals>
                   <goal>wget</goal>
                 </goals>
@@ -431,6 +430,7 @@
             <!-- version from the parent pom -->
             <executions>
               <execution>
+                <id>unzip-home</id>
                 <phase>generate-sources</phase>
                 <configuration>
                   <target>

--- a/pom.xml
+++ b/pom.xml
@@ -406,6 +406,102 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>com.googlecode.maven-download-plugin</groupId>
+            <artifactId>download-maven-plugin</artifactId>
+            <version>1.13.0</version>
+            <executions>
+              <execution>
+                <id>download-home</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>wget</goal>
+                </goals>
+                <configuration>
+                  <url>https://github.com/objectionary/home/archive/refs/heads/master.zip</url>
+                  <outputDirectory>${project.build.directory}/downloaded</outputDirectory>
+                  <outputFileName>home.zip</outputFileName>
+                  <skipCache>true</skipCache>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <!-- version from the parent pom -->
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <configuration>
+                  <target>
+                    <unzip src="${project.build.directory}/downloaded/home.zip" dest="${project.build.directory}/downloaded"/>
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <!-- version from the parent pom -->
+            <executions>
+              <execution>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${project.build.directory}/classes/downloaded/home</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${project.build.directory}/downloaded/home-master</directory>
+                      <filtering>false</filtering>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.gmavenplus</groupId>
+            <artifactId>gmavenplus-plugin</artifactId>
+            <version>4.2.0</version>
+            <configuration>
+              <verbose>true</verbose>
+            </configuration>
+            <executions>
+              <execution>
+                <id>groovy-compile</id>
+                <goals>
+                  <goal>addSources</goal>
+                  <goal>compile</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>groovy-test</id>
+                <goals>
+                  <goal>addTestSources</goal>
+                  <goal>compileTests</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>groovy-execute</id>
+                <phase>process-classes</phase>
+                <goals>
+                  <goal>execute</goal>
+                </goals>
+                <configuration>
+                  <scripts>
+                    <script>src/main/groovy/org/eolang/lints/ReserveNames.groovy</script>
+                  </scripts>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <version>3.5.3</version>
@@ -558,59 +654,6 @@
               <outputDirectory>${project.build.directory}/classes</outputDirectory>
             </configuration>
           </execution>
-          <execution>
-            <id>download-home</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>wget</goal>
-            </goals>
-            <configuration>
-              <url>https://github.com/objectionary/home/archive/refs/heads/master.zip</url>
-              <outputDirectory>${project.build.directory}/downloaded</outputDirectory>
-              <outputFileName>home.zip</outputFileName>
-              <skipCache>true</skipCache>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <!-- version from the parent pom -->
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <configuration>
-              <target>
-                <unzip src="${project.build.directory}/downloaded/home.zip" dest="${project.build.directory}/downloaded"/>
-              </target>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
-        <!-- version from the parent pom -->
-        <executions>
-          <execution>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/classes/downloaded/home</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${project.build.directory}/downloaded/home-master</directory>
-                  <filtering>false</filtering>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -633,42 +676,6 @@
                   <outputDirectory>${project.build.directory}/classes</outputDirectory>
                 </artifactItem>
               </artifactItems>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.gmavenplus</groupId>
-        <artifactId>gmavenplus-plugin</artifactId>
-        <version>4.2.0</version>
-        <configuration>
-          <verbose>true</verbose>
-        </configuration>
-        <executions>
-          <execution>
-            <id>groovy-compile</id>
-            <goals>
-              <goal>addSources</goal>
-              <goal>compile</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>groovy-test</id>
-            <goals>
-              <goal>addTestSources</goal>
-              <goal>compileTests</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>groovy-execute</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>execute</goal>
-            </goals>
-            <configuration>
-              <scripts>
-                <script>src/main/groovy/org/eolang/lints/ReserveNames.groovy</script>
-              </scripts>
             </configuration>
           </execution>
         </executions>

--- a/src/test/java/org/eolang/lints/LtReservedNameTest.java
+++ b/src/test/java/org/eolang/lints/LtReservedNameTest.java
@@ -13,6 +13,7 @@ import org.cactoos.map.MapOf;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -158,6 +159,7 @@ final class LtReservedNameTest {
         );
     }
 
+    @Tag("deep")
     @Test
     void scansReservedFromHome() throws Exception {
         final Lint<XML> lint = new LtReservedName();

--- a/src/test/java/org/eolang/lints/ReservedNamesTest.java
+++ b/src/test/java/org/eolang/lints/ReservedNamesTest.java
@@ -6,12 +6,16 @@ package org.eolang.lints;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link ReservedNames}.
+ * The tests should be executed only in deep profile, since, we reserved name processing
+ * happens only in that profile.
  * @since 0.0.49
  */
+@Tag("deep")
 final class ReservedNamesTest {
 
     @Test


### PR DESCRIPTION
In this PR I've moved home object names processing, from default build lifecycle, to the `deep` profile.

closes #608