### PR TITLE
bug(#606): `redundant-object` usage regex supports dot chaining

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
@@ -11,7 +11,7 @@
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="//o[@name and @name != '@' and @base and @base != '∅']">
-        <xsl:variable name="usage" select="concat('^\$(?:\.\^)*\.', @name, '(?:\.\w+)?$')"/>
+        <xsl:variable name="usage" select="concat('^\$(?:\.\^)*\.', @name, '(?:\.[\w-]+)*$')"/>
         <xsl:if test="count(//o[matches(@base, $usage)])&lt;=1">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-reused-via-dot-notation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-reused-via-dot-notation.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/redundant-object.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # Foo.
+  [] > foo
+    and. > @
+      str.length.eq 12
+      str.as-bytes.size.eq 16
+    "Hello, друг!" > str

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/catches-redundant-with-dot-notation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/catches-redundant-with-dot-notation.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/redundant-object.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=2]
+  - /defects/defect[@line='6']
+  - /defects/defect[@line='7']
+input: |
+  # Foo.
+  [] > foo
+    and. > @
+      str.length.eq 12
+      py.as-bytes.size.eq 16
+    "Hello, друг!" > str
+    "你好，伙计" > py


### PR DESCRIPTION
In this PR I've fixed the bug with `redundant-object` lint, where usage regex was not match object chaining via 2+ `.`. For instance: `$.str.as-bytes.size.eq`. Now we count it as an object usage.

see #606