### PR TITLE
bug(#607): `redundant-object` respects constants

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
@@ -12,7 +12,7 @@
     <defects>
       <xsl:for-each select="//o[@name and @name != '@' and @base and @base != '∅']">
         <xsl:variable name="usage" select="concat('^\$(?:\.\^)*\.', @name, '(?:\.\w+)?$')"/>
-        <xsl:if test="count(//o[matches(@base, $usage)])&lt;=1">
+        <xsl:if test="count(//o[matches(@base, $usage)])&lt;=1 and not(@name and o[1]/@base = 'Q.org.eolang.dataized')">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/respects-constants.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/respects-constants.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/redundant-object.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # Foo.
+  [] > foo
+    start > @
+      string "Jeff" > name!


### PR DESCRIPTION
In this PR I've updated `redundant-object` lint to not complain about object constants, like `name!`.

see #607