### PR TITLE
bug(#609): `redundant-object` allows top object being unused

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
@@ -10,7 +10,8 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[@name and @name != '@' and @base and @base != '∅']">
+      <xsl:variable name="top" select="/object/o/generate-id()"/>
+      <xsl:for-each select="//o[generate-id() != $top and @name and @name != '@' and @base and @base != '∅']">
         <xsl:variable name="usage" select="concat('^\$(?:\.\^)*\.', @name, '(?:\.[\w-]+)*$')"/>
         <xsl:if test="count(//o[matches(@base, $usage)])&lt;=1 and not(@name and o[1]/@base = 'Q.org.eolang.dataized')">
           <xsl:element name="defect">

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-top-unused.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-top-unused.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/redundant-object.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # Foo.
+  42 > foo


### PR DESCRIPTION
In this PR I've updated `redundant-object` not to complain about top object being unused.

see #609
History:
- **bug(#609): test**
- **bug(#609): check id**
