### PR TITLE
bug(#630): exclude `junit-vintage-engine` from `opencsv`

### DIFF
--- a/.github/workflows/deep.yml
+++ b/.github/workflows/deep.yml
@@ -12,7 +12,7 @@ name: deep
       - master
 jobs:
   deep:
-    timeout-minutes: 15
+    timeout-minutes: 20
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,12 @@
       <groupId>com.opencsv</groupId>
       <artifactId>opencsv</artifactId>
       <version>5.11.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>


### PR DESCRIPTION
In this PR I've excluded old version of `junit-vintage-engine` from `opencsv` dependency to align with all other JUnit versions (`5.13.0`) and make build green again.

closes #630

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated dependency configuration to exclude unnecessary testing components, improving build management.
  - Increased workflow job timeout to enhance process reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->