### PR TITLE
bug(#624): `LtInconsistentArgs` understands anonymous objects in path

### DIFF
--- a/src/main/java/org/eolang/lints/LtInconsistentArgs.java
+++ b/src/main/java/org/eolang/lints/LtInconsistentArgs.java
@@ -296,9 +296,6 @@ final class LtInconsistentArgs implements Lint<Map<String, XML>> {
         while (!"object".equals(current.node().getNodeName())) {
             tree.add(LtInconsistentArgs.coordinates(current));
             current = LtInconsistentArgs.parentObject(current);
-            if ("@".equals(tree.get(0)) && tree.size() > 1) {
-                Collections.swap(tree, 0, 1);
-            }
         }
         final String result;
         if (tree.isEmpty()) {

--- a/src/main/java/org/eolang/lints/LtInconsistentArgs.java
+++ b/src/main/java/org/eolang/lints/LtInconsistentArgs.java
@@ -10,7 +10,6 @@ import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/eolang/lints/LtInconsistentArgs.java
+++ b/src/main/java/org/eolang/lints/LtInconsistentArgs.java
@@ -275,18 +275,12 @@ final class LtInconsistentArgs implements Lint<Map<String, XML>> {
      */
     private static String voidFqn(final String base, final Xnav object) {
         final Xnav method = LtInconsistentArgs.parentObject(object);
-        final String coordinates;
-        if (method.attribute("name").text().isPresent()) {
-            coordinates = method.attribute("name").text().get();
-        } else {
-            coordinates = ":anonymous";
-        }
         return String.format(
             "%s%s.%s.∅",
             LtInconsistentArgs.parentTree(
                 method
             ),
-            coordinates,
+            LtInconsistentArgs.coordinates(method),
             base
         );
     }
@@ -300,7 +294,7 @@ final class LtInconsistentArgs implements Lint<Map<String, XML>> {
         final List<String> tree = new ListOf<>();
         Xnav current = LtInconsistentArgs.parentObject(object);
         while (!"object".equals(current.node().getNodeName())) {
-            tree.add(current.attribute("name").text().get());
+            tree.add(LtInconsistentArgs.coordinates(current));
             current = LtInconsistentArgs.parentObject(current);
             if ("@".equals(tree.get(0)) && tree.size() > 1) {
                 Collections.swap(tree, 0, 1);
@@ -352,6 +346,21 @@ final class LtInconsistentArgs implements Lint<Map<String, XML>> {
             result = base.replace(String.format("%s.", new ObjectName(source).get()), "");
         } else {
             result = base;
+        }
+        return result;
+    }
+
+    /**
+     * Object coordinates.
+     * @param object Object
+     * @return Object coordinates
+     */
+    private static String coordinates(final Xnav object) {
+        final String result;
+        if (object.attribute("name").text().isPresent()) {
+            result = object.attribute("name").text().get();
+        } else {
+            result = ":anonymous";
         }
         return result;
     }

--- a/src/main/java/org/eolang/lints/LtInconsistentArgs.java
+++ b/src/main/java/org/eolang/lints/LtInconsistentArgs.java
@@ -10,6 +10,7 @@ import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -274,12 +275,18 @@ final class LtInconsistentArgs implements Lint<Map<String, XML>> {
      */
     private static String voidFqn(final String base, final Xnav object) {
         final Xnav method = LtInconsistentArgs.parentObject(object);
+        final String coordinates;
+        if (method.attribute("name").text().isPresent()) {
+            coordinates = method.attribute("name").text().get();
+        } else {
+            coordinates = ":anonymous";
+        }
         return String.format(
             "%s%s.%s.∅",
             LtInconsistentArgs.parentTree(
                 method
             ),
-            method.attribute("name").text().get(),
+            coordinates,
             base
         );
     }
@@ -295,6 +302,9 @@ final class LtInconsistentArgs implements Lint<Map<String, XML>> {
         while (!"object".equals(current.node().getNodeName())) {
             tree.add(current.attribute("name").text().get());
             current = LtInconsistentArgs.parentObject(current);
+            if ("@".equals(tree.get(0)) && tree.size() > 1) {
+                Collections.swap(tree, 0, 1);
+            }
         }
         final String result;
         if (tree.isEmpty()) {

--- a/src/main/java/org/eolang/lints/VoidXpath.java
+++ b/src/main/java/org/eolang/lints/VoidXpath.java
@@ -42,6 +42,6 @@ final class VoidXpath implements Text {
             IntStream.range(rstart + 1, normalized.size())
                 .mapToObj(normalized::get)
                 .collect(Collectors.joining(".", "$.", ""))
-        );
+        ).replace("[@name=':anonymous']", "");
     }
 }

--- a/src/test/java/org/eolang/lints/VoidXpathTest.java
+++ b/src/test/java/org/eolang/lints/VoidXpathTest.java
@@ -21,7 +21,10 @@ final class VoidXpathTest {
         {
             "main.$.x.∅, //o[@name='main']/o[@base='$.x']",
             "foo.foo.foo.$.x.∅, //o[@name='foo']/o[@name='foo']/o[@name='foo']/o[@base='$.x']",
-            "@.foo.:anonymous.$.x.∅, //o[@name='@']/o[@name='foo']/o/o[@base='$.x']"
+            "@.foo.:anonymous.$.x.∅, //o[@name='@']/o[@name='foo']/o/o[@base='$.x']",
+            // todo: why `@` and `:anonymous` are reverted in the path?
+            // handle ":anonymous.@.@.:anonymous.@.foo.:anonymous.$.x.∅
+            // should be: foo.@.o.o.$.x.∅
         }
     )
     void convertsToXpath(final String fqn, final String xpath) {

--- a/src/test/java/org/eolang/lints/VoidXpathTest.java
+++ b/src/test/java/org/eolang/lints/VoidXpathTest.java
@@ -21,7 +21,7 @@ final class VoidXpathTest {
         {
             "main.$.x.∅, //o[@name='main']/o[@base='$.x']",
             "foo.foo.foo.$.x.∅, //o[@name='foo']/o[@name='foo']/o[@name='foo']/o[@base='$.x']",
-            "@.foo.:anonymous.$.x.∅, //o[@name='@']/o[@name='foo']/o/o[@base='$.x']",
+            "@.foo.:anonymous.$.x.∅, //o[@name='@']/o[@name='foo']/o/o[@base='$.x']"
         }
     )
     void convertsToXpath(final String fqn, final String xpath) {

--- a/src/test/java/org/eolang/lints/VoidXpathTest.java
+++ b/src/test/java/org/eolang/lints/VoidXpathTest.java
@@ -20,7 +20,8 @@ final class VoidXpathTest {
     @CsvSource(
         {
             "main.$.x.∅, //o[@name='main']/o[@base='$.x']",
-            "foo.foo.foo.$.x.∅, //o[@name='foo']/o[@name='foo']/o[@name='foo']/o[@base='$.x']"
+            "foo.foo.foo.$.x.∅, //o[@name='foo']/o[@name='foo']/o[@name='foo']/o[@base='$.x']",
+            "@.foo.:anonymous.$.x.∅, //o[@name='@']/o[@name='foo']/o/o[@base='$.x']"
         }
     )
     void convertsToXpath(final String fqn, final String xpath) {

--- a/src/test/java/org/eolang/lints/VoidXpathTest.java
+++ b/src/test/java/org/eolang/lints/VoidXpathTest.java
@@ -22,9 +22,6 @@ final class VoidXpathTest {
             "main.$.x.∅, //o[@name='main']/o[@base='$.x']",
             "foo.foo.foo.$.x.∅, //o[@name='foo']/o[@name='foo']/o[@name='foo']/o[@base='$.x']",
             "@.foo.:anonymous.$.x.∅, //o[@name='@']/o[@name='foo']/o/o[@base='$.x']",
-            // todo: why `@` and `:anonymous` are reverted in the path?
-            // handle ":anonymous.@.@.:anonymous.@.foo.:anonymous.$.x.∅
-            // should be: foo.@.o.o.$.x.∅
         }
     )
     void convertsToXpath(final String fqn, final String xpath) {

--- a/src/test/java/org/eolang/lints/WpaStory.java
+++ b/src/test/java/org/eolang/lints/WpaStory.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import org.cactoos.map.MapEntry;
 import org.cactoos.map.MapOf;
 import org.eolang.parser.EoSyntax;
+import org.junit.jupiter.api.Assumptions;
 import org.xembly.Directives;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
@@ -58,6 +59,7 @@ final class WpaStory {
     @SuppressWarnings("unchecked")
     public Map<List<String>, Map<XML, Map<String, XML>>> execute() throws IOException {
         final Map<String, Object> loaded = new Yaml().load(this.yaml);
+        Assumptions.assumeTrue(loaded.get("skip") == null);
         final Map<String, XML> programs = new HashMap<>(0);
         loaded.forEach(
             (key, val) -> {

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-in-nested-anonymous-formations.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-in-nested-anonymous-formations.yaml
@@ -3,9 +3,10 @@
 ---
 # yamllint disable rule:line-length
 # @todo #624:60min Enable `catches-inconsistency-in-nested-anonymous-formations` test story.
-#  For now, its disabled because `LtInconsistentArgs` fails to convert parent tree path into
-#  searchable XPath for the XMIR. We should change our logic in both `LtInconsistentArgs#voidFqn()`
-#  and `VoidXpath`. Don't forget to enable `catches-inconsistency-resolving-anonymous-path.yaml`,
+#  For now, its disabled because `LtInconsistentArgs` fails to convert parent tree with anonymous
+#  objects to searchable XPath for the XMIR. We should change our logic in both
+#  `LtInconsistentArgs#voidFqn()` and `VoidXpath`. Don't forget to enable
+#  `catches-inconsistency-resolving-anonymous-path.yaml`,
 #  `catches-inconsistency-when-parent-object-lacks-name.yaml`, and test stories as well.
 skip: true
 lints:

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-in-nested-anonymous-formations.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-in-nested-anonymous-formations.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lints:
+  - inconsistent-args
+asserts:
+  - /defects[count(defect[@severity='warning'])=2]
+  - /defects/defect[@line='7']
+  - /defects/defect[@line='8']
+  - /defects/defect[contains(normalize-space(), 'foo.@.:anonymous.$.x.∅')]
+  - /defects/defect[contains(normalize-space(), 'clashes with [foo:7]')]
+  - /defects/defect[contains(normalize-space(), 'clashes with [foo:8]')]
+foo.eo: |
+  # Foo.
+  [] > foo
+    start > @
+      []
+        i > @
+          []
+            i > @
+              [x]
+                x 0 > x1
+                x 0 1 > x2

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-in-nested-anonymous-formations.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-in-nested-anonymous-formations.yaml
@@ -1,15 +1,21 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+# @todo #624:60min Enable `catches-inconsistency-in-nested-anonymous-formations` test story.
+#  For now, its disabled because `LtInconsistentArgs` fails to convert parent tree path into
+#  searchable XPath for the XMIR. We should change our logic in both `LtInconsistentArgs#voidFqn()`
+#  and `VoidXpath`. Don't forget to enable `catches-inconsistency-resolving-anonymous-path.yaml`,
+#  `catches-inconsistency-when-parent-object-lacks-name.yaml`, and test stories as well.
+skip: true
 lints:
   - inconsistent-args
 asserts:
   - /defects[count(defect[@severity='warning'])=2]
-  - /defects/defect[@line='7']
-  - /defects/defect[@line='8']
-  - /defects/defect[contains(normalize-space(), 'foo.@.:anonymous.$.x.∅')]
-  - /defects/defect[contains(normalize-space(), 'clashes with [foo:7]')]
-  - /defects/defect[contains(normalize-space(), 'clashes with [foo:8]')]
+  - /defects/defect[@line='9']
+  - /defects/defect[@line='10']
+  - /defects/defect[contains(normalize-space(), 'foo.@.:anonymous.@.:anonymous.@.:anonymous.$.x.∅')]
+  - /defects/defect[contains(normalize-space(), 'clashes with [foo:9]')]
+  - /defects/defect[contains(normalize-space(), 'clashes with [foo:10]')]
 foo.eo: |
   # Foo.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-in-nested-anonymous-formations.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-in-nested-anonymous-formations.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+# yamllint disable rule:line-length
 # @todo #624:60min Enable `catches-inconsistency-in-nested-anonymous-formations` test story.
 #  For now, its disabled because `LtInconsistentArgs` fails to convert parent tree path into
 #  searchable XPath for the XMIR. We should change our logic in both `LtInconsistentArgs#voidFqn()`

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-inside-anonymous-with-void-from-top.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-inside-anonymous-with-void-from-top.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lints:
+  - inconsistent-args
+asserts:
+  - /defects[count(defect[@severity='warning'])=2]
+  - /defects/defect[@line='5']
+  - /defects/defect[@line='6']
+  - /defects/defect[contains(normalize-space(), 'clashes with [foo:5]')]
+  - /defects/defect[contains(normalize-space(), 'clashes with [foo:6]')]
+foo.eo: |
+  # Foo.
+  [x] > foo
+    start > @
+      []
+        x 0 > x1
+        x 0 1 > x2

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-resolving-anonymous-path.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-resolving-anonymous-path.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+skip: true
 lints:
   - inconsistent-args
 asserts:

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-resolving-anonymous-path.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-resolving-anonymous-path.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lints:
+  - inconsistent-args
+asserts:
+  - /defects[count(defect[@severity='warning'])=2]
+  - /defects/defect[@line='7']
+  - /defects/defect[@line='8']
+  - /defects/defect[contains(normalize-space(), 'foo.@.:anonymous.$.x.∅')]
+  - /defects/defect[contains(normalize-space(), 'clashes with [foo:7]')]
+  - /defects/defect[contains(normalize-space(), 'clashes with [foo:8]')]
+foo.eo: |
+  # Foo.
+  [x] > foo
+    x 0 > x1
+    x 1 > x2
+    start > @
+      [x]
+        $.x 0 > x1
+        $.x 0 1 > x2

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-when-parent-object-lacks-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-when-parent-object-lacks-name.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+skip: true
 lints:
   - inconsistent-args
 asserts:

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-when-parent-object-lacks-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-when-parent-object-lacks-name.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lints:
+  - inconsistent-args
+asserts:
+  - /defects[count(defect[@severity='warning'])=2]
+  - /defects/defect[@line='5']
+  - /defects/defect[@line='6']
+  - /defects/defect[contains(normalize-space(), 'clashes with [foo:5]')]
+  - /defects/defect[contains(normalize-space(), 'clashes with [foo:6]')]
+foo.eo: |
+  # Foo.
+  [] > foo
+    start > @
+      [x]
+        x 1 > a
+        x 2 2 > b

--- a/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-when-parent-object-lacks-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/wpa/inconsistent-args/catches-inconsistency-when-parent-object-lacks-name.yaml
@@ -14,5 +14,5 @@ foo.eo: |
   [] > foo
     start > @
       [x]
-        x 1 > a
-        x 2 2 > b
+        x 0 > x1
+        x 0 1 > x2


### PR DESCRIPTION
In this PR I've patched `LtInconsistentArgs` to understand anonymous objects in the object path.

see #624
History:
- **bug(#624): test**
- **bug(#624): passes**
- **bug(#624): one more passes**
- **bug(#624): passes more**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of anonymous objects in lint checks, ensuring more accurate detection of argument inconsistencies.
  - Enhanced XPath generation to properly exclude selectors for anonymous objects.

- **Tests**
  - Added new test cases and YAML resources to verify detection of argument inconsistencies, especially in scenarios involving anonymous objects and nested structures.
  - Introduced conditional skipping for certain tests until underlying issues with anonymous object handling are resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->