### PR TITLE
bug(#635): SPDX header consistency in `incorrect-spdx`

### DIFF
--- a/src/main/resources/org/eolang/lints/metas/incorrect-spdx.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-spdx.xsl
@@ -13,7 +13,7 @@
       <xsl:for-each select="/object/metas/meta[head/text()='spdx' and count(part) &gt; 1]">
         <xsl:variable name="meta-tail" select="tail"/>
         <xsl:variable name="header" select="normalize-space(substring-before(concat($meta-tail, ' '), ' '))"/>
-        <xsl:if test="$header!='SPDX-FileCopyrightText' and $header!='SPDX-License-Identifier:'">
+        <xsl:if test="$header!='SPDX-FileCopyrightText:' and $header!='SPDX-License-Identifier:'">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -79,7 +79,7 @@ final class SourceTest {
                         "+package com.example",
                         "+version 0.0.0",
                         // REUSE-IgnoreStart
-                        "+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com",
+                        "+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com",
                         "+spdx SPDX-License-Identifier: MIT",
                         // REUSE-IgnoreEnd
                         "",

--- a/src/test/resources/org/eolang/lints/canonical.eo
+++ b/src/test/resources/org/eolang/lints/canonical.eo
@@ -2,7 +2,7 @@
 +home https://www.eolang.org
 +package canonical
 +version 0.0.0
-+spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unused-void-attr
 

--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-spdx/passes-on-good-spdx-metas.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-spdx/passes-on-good-spdx-metas.yaml
@@ -6,7 +6,7 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='warning'])=0]
 input: |
-  +spdx SPDX-FileCopyrightText foo
+  +spdx SPDX-FileCopyrightText: foo
   +spdx SPDX-License-Identifier: MIT
 
   # Foo.


### PR DESCRIPTION
In this PR I've made SPDX headers consistent in `incorrect-spdx` lint. Now, both SPDX headers should contain colon (`:`).

see #635