### PR TITLE
bug(#647): exclude `junit-platform-launcher` from `groovy-all`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,10 @@
           <groupId>org.codehaus.groovy</groupId>
           <artifactId>groovy-groovysh</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.junit.platform</groupId>
+          <artifactId>junit-platform-launcher</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -254,6 +258,12 @@
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
       <version>9.8</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <version>1.13.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
In this PR I've excluded problematic dependency `junit-platform-launcher` from `groovy-all` in order to resolve runtime dependency conflict and make the build clean.

closes #647

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management to explicitly control the version of a testing library, ensuring more consistent test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->