### PR TITLE
bug(#663): `formation-with-as-attributes` lint

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/formation-with-as-attributes.xsl
+++ b/src/main/resources/org/eolang/lints/critical/formation-with-as-attributes.xsl
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="formation-with-as-attributes" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[@as and not(../@base)]">
+        <defect>
+          <xsl:variable name="line" select="eo:lineno(@line)"/>
+          <xsl:attribute name="line">
+            <xsl:value-of select="$line"/>
+          </xsl:attribute>
+          <xsl:if test="$line = '0'">
+            <xsl:attribute name="context">
+              <xsl:value-of select="eo:defect-context(.)"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:attribute name="severity">critical</xsl:attribute>
+          <xsl:text>The usage of "as" attribute is prohibited in the formations</xsl:text>
+        </defect>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/critical/formation-with-as-attributes.md
+++ b/src/main/resources/org/eolang/motives/critical/formation-with-as-attributes.md
@@ -1,0 +1,22 @@
+# Formation With `@as` Attributes
+
+In [XMIR], it is prohibited to have `@as` attributes inside the formation. The
+only valid usage for them is object application.
+
+Incorrect:
+
+```xml
+<o name="foo">
+  <o as='due'/>
+</o>
+```
+
+Correct:
+
+```xml
+<o name="foo" base="Q.org.eolang.f">
+  <o as='due'/>
+</o>
+```
+
+[XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html

--- a/src/test/resources/org/eolang/lints/packs/single/formation-with-as-attributes/allows-as-attributes-in-application.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/formation-with-as-attributes/allows-as-attributes-in-application.yaml
@@ -6,6 +6,8 @@ sheets:
 asserts:
   - /defects[count(defect)=0]
 document: |
-  <o name='happl' base='Q.org.eolang.f' line='1'>
-    <o as='boom' line='2'/>
-  </o>
+  <object>
+    <o name='happl' base='Q.org.eolang.f' line='1'>
+      <o as='boom' line='2'/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/formation-with-as-attributes/allows-as-attributes-in-application.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/formation-with-as-attributes/allows-as-attributes-in-application.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/critical/formation-with-as-attributes.xsl
+asserts:
+  - /defects[count(defect)=0]
+document: |
+  <o name='happl' base='Q.org.eolang.f' line='1'>
+    <o as='boom' line='2'/>
+  </o>

--- a/src/test/resources/org/eolang/lints/packs/single/formation-with-as-attributes/catches-anonymous-formation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/formation-with-as-attributes/catches-anonymous-formation.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/critical/formation-with-as-attributes.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=1]
+  - /defects/defect[@line='2']
+document: |
+  <o line='1'>
+    <o as='due' line='2'/>
+  </o>

--- a/src/test/resources/org/eolang/lints/packs/single/formation-with-as-attributes/catches-anonymous-formation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/formation-with-as-attributes/catches-anonymous-formation.yaml
@@ -5,8 +5,10 @@ sheets:
   - /org/eolang/lints/critical/formation-with-as-attributes.xsl
 asserts:
   - /defects[count(defect[@severity='critical'])=1]
-  - /defects/defect[@line='2']
+  - /defects/defect[@line='3']
 document: |
-  <o line='1'>
-    <o as='due' line='2'/>
-  </o>
+  <object>
+    <o line='2'>
+      <o as='due' line='3'/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/formation-with-as-attributes/catches-each-as-attribute-inside-formation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/formation-with-as-attributes/catches-each-as-attribute-inside-formation.yaml
@@ -9,8 +9,10 @@ asserts:
   - /defects/defect[@line='3']
   - /defects/defect[@line='4']
 document: |
-  <o name='foo' line='1'>
-    <o as='b' line='2'/>
-    <o as='c' line='3'/>
-    <o as='d' line='4'/>
-  </o>
+  <object>
+    <o name='foo' line='1'>
+      <o as='b' line='2'/>
+      <o as='c' line='3'/>
+      <o as='d' line='4'/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/formation-with-as-attributes/catches-each-as-attribute-inside-formation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/formation-with-as-attributes/catches-each-as-attribute-inside-formation.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/critical/formation-with-as-attributes.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=3]
+  - /defects/defect[@line='2']
+  - /defects/defect[@line='3']
+  - /defects/defect[@line='4']
+document: |
+  <o name='foo' line='1'>
+    <o as='b' line='2'/>
+    <o as='c' line='3'/>
+    <o as='d' line='4'/>
+  </o>

--- a/src/test/resources/org/eolang/lints/packs/single/formation-with-as-attributes/catches-formation-with-as-attributes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/formation-with-as-attributes/catches-formation-with-as-attributes.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/critical/formation-with-as-attributes.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=1]
+document: |
+  <o name='a'>
+    <o as='b'/>
+  </o>

--- a/src/test/resources/org/eolang/lints/packs/single/formation-with-as-attributes/catches-formation-with-as-attributes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/formation-with-as-attributes/catches-formation-with-as-attributes.yaml
@@ -6,6 +6,8 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='critical'])=1]
 document: |
-  <o name='a'>
-    <o as='b'/>
-  </o>
+  <object>
+    <o name='a'>
+      <o as='b'/>
+    </o>
+  </object>


### PR DESCRIPTION
In this PR I've implemented `formation-with-as-attributes` lint, that issues defect with `CRITICAL` severity, if formation (object without `@base`) has nested objects with `@as` attribute.

see #663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new lint rule to detect and report improper usage of "as" attributes within formations in EO code.
  * Added documentation explaining the rule and correct usage of "as" attributes in EO formations.

* **Tests**
  * Added multiple test cases to verify correct detection of defects related to "as" attributes in various formation scenarios.
  * Included tests to ensure that valid uses of "as" attributes are not incorrectly flagged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->