### PR TITLE
bug(#669): `anonymous-objects-inside-formation` lint

### DIFF
--- a/src/main/resources/org/eolang/lints/errors/anonymous-objects-inside-formation.xsl
+++ b/src/main/resources/org/eolang/lints/errors/anonymous-objects-inside-formation.xsl
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="anonymous-objects-inside-formation" version="2.0">
+  <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[eo:abstract(.) and o[not(@name)]]">
+        <xsl:element name="defect">
+          <xsl:variable name="line" select="eo:lineno(@line)"/>
+          <xsl:attribute name="line">
+            <xsl:value-of select="$line"/>
+          </xsl:attribute>
+          <xsl:if test="$line = '0'">
+            <xsl:attribute name="context">
+              <xsl:value-of select="eo:defect-context(.)"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:attribute name="severity">
+            <xsl:text>error</xsl:text>
+          </xsl:attribute>
+          <xsl:text>It is prohibited to have formations like </xsl:text>
+          <xsl:value-of select="eo:escape(@name)"/>
+          <xsl:text> that contain anonymous objects inside</xsl:text>
+        </xsl:element>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/errors/anonymous-objects-inside-formation.md
+++ b/src/main/resources/org/eolang/motives/errors/anonymous-objects-inside-formation.md
@@ -1,0 +1,29 @@
+# Anonymous Objects Inside Formation
+
+In [XMIR], Formation cannot contain inner objects without a name.
+
+Incorrect:
+
+```xml
+<object>
+  <o line="1" name="li">
+    <o line="2">
+      <o line="3" base="Q.org.eolang.x" name="somewhat"/>
+    </o>
+  </o>
+</object>
+```
+
+Correct:
+
+```xml
+<object>
+  <o line="1" name="li">
+    <o line="2">
+      <o line="3" base="Q.org.eolang.x" name="somewhat"/>
+    </o>
+  </o>
+</object>
+```
+
+[XMIR]: https://news.eolang.org/2022-11-25-xmir-guide.html

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-objects-inside-formation/allows-named-objects-insdie.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-objects-inside-formation/allows-named-objects-insdie.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/errors/anonymous-objects-inside-formation.xsl
+asserts:
+  - /defects[count(defect)=0]
+document: |
+  <object>
+    <o line="1" name="li">
+      <o line="2" name="nested">
+        <o line="3" base="Q.org.eolang.x" name="somewhat"/>
+      </o>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-objects-inside-formation/catches-anonymous.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-objects-inside-formation/catches-anonymous.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/errors/anonymous-objects-inside-formation.xsl
+asserts:
+  - /defects[count(defect[@severity='error'])=1]
+  - /defects/defect[@line='1']
+document: |
+  <object>
+    <o line="1" name="li">
+      <o line="2">
+        <o line="3" base="Q.org.eolang.x" name="somewhat"/>
+      </o>
+    </o>
+  </object>


### PR DESCRIPTION
In this PR I've added new lint: `anonymous-objects-inside-formation` in order to catch formations that have anonymous objects inside.

see #669