### PR TITLE
bug(#636): `duplicate-names-in-diff-context` allows duplicates in tests

### DIFF
--- a/src/main/resources/org/eolang/funcs/special-name.xsl
+++ b/src/main/resources/org/eolang/funcs/special-name.xsl
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="special-name" version="2.0">
-  <xsl:import href="/org/eolang/parser/_specials.xsl"/>
+  <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:function name="eo:special" as="xs:boolean">
     <xsl:param name="name"/>
     <xsl:sequence select="$name = '@' or $name = $eo:lambda or contains($name, $eo:cactoos)"/>

--- a/src/main/resources/org/eolang/lints/misc/duplicate-names-in-diff-context.xsl
+++ b/src/main/resources/org/eolang/lints/misc/duplicate-names-in-diff-context.xsl
@@ -10,8 +10,8 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[not(eo:special(@name)) and not(@base='∅')]">
-        <xsl:variable name="namesakes" select="//o[@name=current()/@name and not(@base='∅')]"/>
+      <xsl:for-each select="//o[not(ancestor::o[eo:test-attr(.)]) and not(eo:special(@name)) and not(@base='∅')]">
+        <xsl:variable name="namesakes" select="//o[not(ancestor::o[eo:test-attr(.)]) and @name=current()/@name and not(@base='∅')]"/>
         <xsl:if test="count($namesakes)&gt;1">
           <defect>
             <xsl:variable name="line" select="eo:lineno(@line)"/>

--- a/src/test/resources/org/eolang/lints/packs/single/duplicate-names-in-diff-context/allows-duplicate-names-in-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/duplicate-names-in-diff-context/allows-duplicate-names-in-tests.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/duplicate-names-in-diff-context.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # Foo.
+  [] > foo
+    [] +> works-well
+      42 > i
+    [] +> works-very-well
+      52 > i

--- a/src/test/resources/org/eolang/lints/packs/single/duplicate-names-in-diff-context/catches-duplicates-except-in-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/duplicate-names-in-diff-context/catches-duplicates-except-in-tests.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+# yamllint disable rule:line-length
 sheets:
   - /org/eolang/lints/misc/duplicate-names-in-diff-context.xsl
 asserts:

--- a/src/test/resources/org/eolang/lints/packs/single/duplicate-names-in-diff-context/catches-duplicates-except-in-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/duplicate-names-in-diff-context/catches-duplicates-except-in-tests.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/duplicate-names-in-diff-context.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=2]
+  - /defects/defect[@line='4']
+  - /defects/defect[@line='6']
+  - /defects/defect[contains(normalize-space(), 'has the same name as the objects on the lines 4')]
+  - /defects/defect[contains(normalize-space(), 'has the same name as the objects on the lines 6')]
+input: |
+  # Foo.
+  [] > foo
+    [] > x1
+      7 > bar
+    [] > x2
+      "each win requires mastery" > bar
+    [] +> works-well
+      42 > bar
+    [] +> works-very-well
+      52 > bar


### PR DESCRIPTION
In this PR I've updated `duplicate-names-in-diff-context` to allow duplicate names, if they are inside tests.

see #636

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate name detection to exclude objects within test-attribute contexts, reducing false positives in linting results.

* **Tests**
  * Added new test cases to verify that duplicate names are allowed within tests and correctly flagged elsewhere.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->