### PR TITLE
bug(#686): `DefectMissing` supports line ranges

### DIFF
--- a/src/main/java/org/eolang/lints/DefectMissing.java
+++ b/src/main/java/org/eolang/lints/DefectMissing.java
@@ -47,18 +47,22 @@ final class DefectMissing implements Function<String, Boolean> {
         final boolean missing;
         final String[] split = unlint.split(":", -1);
         final String name = split[0];
-        final Set<String> names;
-        if (this.defects != null) {
-            names = this.defects.keySet();
+        final List<Integer> lines = this.defects.get(name);
+        if (unlint.matches(String.format("%s:\\d+-\\d+", name))) {
+            missing = lines.stream().noneMatch(new UnlintInRange(unlint));
         } else {
-            names = new SetOf<>();
-        }
-        if (split.length > 1) {
-            final List<Integer> lines = this.defects.get(name);
-            missing = (!names.contains(name) || !lines.contains(Integer.parseInt(split[1])))
-                && !this.excluded.contains(name);
-        } else {
-            missing = !names.contains(name) && !this.excluded.contains(name);
+            final Set<String> names;
+            if (this.defects != null) {
+                names = this.defects.keySet();
+            } else {
+                names = new SetOf<>();
+            }
+            if (split.length > 1) {
+                missing = (!names.contains(name) || !lines.contains(Integer.parseInt(split[1])))
+                    && !this.excluded.contains(name);
+            } else {
+                missing = !names.contains(name) && !this.excluded.contains(name);
+            }
         }
         return missing;
     }

--- a/src/main/java/org/eolang/lints/DefectMissing.java
+++ b/src/main/java/org/eolang/lints/DefectMissing.java
@@ -8,19 +8,12 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import org.cactoos.set.SetOf;
 
 /**
  * Is defect missing?
  * @since 0.0.44
- * @todo #671:45min Adjust `DefectMissing` to handle unlints with line ranges.
- *  Currently we don't support such line ranges in this and {@link LtUnlintNonExistingDefectWpa}
- *  lint, but we should, since {@link LtUnlint} supports them. If we will add the support of line
- *  ranges here, `unlint-non-existing-defect` in both scopes should catch up it. Don't forget to
- *  add tests for both scopes.
  */
 final class DefectMissing implements Function<String, Boolean> {
 

--- a/src/main/java/org/eolang/lints/DefectMissing.java
+++ b/src/main/java/org/eolang/lints/DefectMissing.java
@@ -8,7 +8,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import org.cactoos.set.SetOf;
 
 /**
@@ -49,7 +51,7 @@ final class DefectMissing implements Function<String, Boolean> {
         final String name = split[0];
         final List<Integer> lines = this.defects.get(name);
         if (unlint.matches(String.format("%s:\\d+-\\d+", name))) {
-            missing = lines.stream().noneMatch(new UnlintInRange(unlint));
+            missing = !lines.stream().allMatch(new UnlintInRange(unlint));
         } else {
             final Set<String> names;
             if (this.defects != null) {

--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -5,7 +5,6 @@
 package org.eolang.lints;
 
 import com.github.lombrozo.xnav.Xnav;
-import com.google.common.base.Splitter;
 import com.jcabi.xml.XML;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -67,7 +67,7 @@ final class LtUnlint implements Lint<XML> {
         granular.forEach(
             unlint -> {
                 if (unlint.matches(String.format("%s:\\d+-\\d+", lname))) {
-                    problematic.removeIf(line -> LtUnlint.inRange(line, unlint, lname));
+                    problematic.removeIf(new UnlintInRange(unlint));
                 } else if (LtUnlint.LINE_NUMBER.matcher(unlint).matches()) {
                     final List<String> split = new ListOf<>(unlint.split(":"));
                     final int lineno = Integer.parseInt(
@@ -98,20 +98,6 @@ final class LtUnlint implements Lint<XML> {
     @Override
     public String motive() throws IOException {
         return this.origin.motive();
-    }
-
-    /**
-     * Is the line in the unlint range?
-     * @param line The line
-     * @param unlint Unlint expression
-     * @param lint Lint name
-     * @return True - if in range, False - if out of range
-     */
-    private static boolean inRange(final int line, final String unlint, final String lint) {
-        final List<String> range = Splitter.on('-').splitToList(
-            unlint.replace(String.format("%s:", lint), "")
-        );
-        return line >= Integer.parseInt(range.get(0)) && line <= Integer.parseInt(range.get(1));
     }
 
 }

--- a/src/main/java/org/eolang/lints/UnlintInRange.java
+++ b/src/main/java/org/eolang/lints/UnlintInRange.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import com.google.common.base.Splitter;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Does unlint in the range?
+ * @since 0.0.54
+ */
+final class UnlintInRange implements Predicate<Integer> {
+
+    /**
+     * The unlint expression.
+     */
+    private final String unlint;
+
+    /**
+     * Ctor.
+     * @param unlt The unlint expression
+     */
+    UnlintInRange(final String unlt) {
+        this.unlint = unlt;
+    }
+
+    @Override
+    public boolean test(final Integer line) {
+        final String lint = this.unlint.replace("+unlint", "").split(":")[0];
+        final List<String> range = Splitter.on('-').splitToList(
+            this.unlint.replace(String.format("%s:", lint), "")
+        );
+        return line >= Integer.parseInt(range.get(0)) && line <= Integer.parseInt(range.get(1));
+    }
+}

--- a/src/main/java/org/eolang/lints/UnlintInRange.java
+++ b/src/main/java/org/eolang/lints/UnlintInRange.java
@@ -7,6 +7,7 @@ package org.eolang.lints;
 import com.google.common.base.Splitter;
 import java.util.List;
 import java.util.function.Predicate;
+import org.cactoos.list.ListOf;
 
 /**
  * Does unlint in the range?
@@ -29,7 +30,9 @@ final class UnlintInRange implements Predicate<Integer> {
 
     @Override
     public boolean test(final Integer line) {
-        final String lint = this.unlint.replace("+unlint", "").split(":")[0];
+        final String lint = new ListOf<>(
+            Splitter.on(':').split(this.unlint.replace("+unlint", ""))
+        ).get(0);
         final List<String> range = Splitter.on('-').splitToList(
             this.unlint.replace(String.format("%s:", lint), "")
         );

--- a/src/test/java/org/eolang/lints/DefectMissingTest.java
+++ b/src/test/java/org/eolang/lints/DefectMissingTest.java
@@ -56,7 +56,8 @@ final class DefectMissingTest {
         MatcherAssert.assertThat(
             "Defect should be missing, but it was not",
             new DefectMissing(new MapOf<>("div-by-zero", new ListOf<>(3, 6)), new ListOf<>())
-                .apply("div-by-zero:3-6")
+                .apply("div-by-zero:3-6"),
+            Matchers.equalTo(false)
         );
     }
 
@@ -65,7 +66,8 @@ final class DefectMissingTest {
         MatcherAssert.assertThat(
             "Defect should be missing, but it was not",
             new DefectMissing(new MapOf<>("something", new ListOf<>(3, 6)), new ListOf<>())
-                .apply("something:3-10")
+                .apply("something:3-10"),
+            Matchers.equalTo(false)
         );
     }
 }

--- a/src/test/java/org/eolang/lints/DefectMissingTest.java
+++ b/src/test/java/org/eolang/lints/DefectMissingTest.java
@@ -39,4 +39,33 @@ final class DefectMissingTest {
             Matchers.equalTo(true)
         );
     }
+
+    @Test
+    void returnsTrueWhenLineOutOfRange() {
+        MatcherAssert.assertThat(
+            "Defect should not be missing, but it was",
+            new DefectMissing(new MapOf<>("app", new ListOf<>(1, 3, 5)), new ListOf<>()).apply(
+                "app:6-15"
+            ),
+            Matchers.equalTo(true)
+        );
+    }
+
+    @Test
+    void returnsFalseWhenLineInTheRange() {
+        MatcherAssert.assertThat(
+            "Defect should be missing, but it was not",
+            new DefectMissing(new MapOf<>("div-by-zero", new ListOf<>(3, 6)), new ListOf<>())
+                .apply("div-by-zero:3-6")
+        );
+    }
+
+    @Test
+    void returnsFalseWhenRangeCoversTheLine() {
+        MatcherAssert.assertThat(
+            "Defect should be missing, but it was not",
+            new DefectMissing(new MapOf<>("something", new ListOf<>(3, 6)), new ListOf<>())
+                .apply("something:3-10")
+        );
+    }
 }

--- a/src/test/java/org/eolang/lints/DefectMissingTest.java
+++ b/src/test/java/org/eolang/lints/DefectMissingTest.java
@@ -43,7 +43,7 @@ final class DefectMissingTest {
     @Test
     void returnsTrueWhenLineOutOfRange() {
         MatcherAssert.assertThat(
-            "Defect should not be missing, but it was",
+            "Defect should be missing, but it was not",
             new DefectMissing(new MapOf<>("app", new ListOf<>(1, 3, 5)), new ListOf<>()).apply(
                 "app:6-15"
             ),
@@ -54,7 +54,7 @@ final class DefectMissingTest {
     @Test
     void returnsFalseWhenLineInTheRange() {
         MatcherAssert.assertThat(
-            "Defect should be missing, but it was not",
+            "Defect should not be missing, but it was",
             new DefectMissing(new MapOf<>("div-by-zero", new ListOf<>(3, 6)), new ListOf<>())
                 .apply("div-by-zero:3-6"),
             Matchers.equalTo(false)
@@ -64,10 +64,20 @@ final class DefectMissingTest {
     @Test
     void returnsFalseWhenRangeCoversTheLine() {
         MatcherAssert.assertThat(
-            "Defect should be missing, but it was not",
+            "Defect should not be missing, but it was",
             new DefectMissing(new MapOf<>("something", new ListOf<>(3, 6)), new ListOf<>())
                 .apply("something:3-10"),
             Matchers.equalTo(false)
+        );
+    }
+
+    @Test
+    void returnsTrueIfSomeLineIsOutOfRange() {
+        MatcherAssert.assertThat(
+            "Defect should be missing, but it was not",
+            new DefectMissing(new MapOf<>("noisy-lint", new ListOf<>(4, 6)), new ListOf<>())
+                .apply("noisy-lint:6-10"),
+            Matchers.equalTo(true)
         );
     }
 }

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -174,4 +174,28 @@ final class LtUnlintNonExistingDefectTest {
             Matchers.hasSize(Matchers.greaterThan(0))
         );
     }
+
+    @Test
+    void allowsUnlintForDefectsInTheLineRange() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are not empty, but they should",
+            new LtUnlintNonExistingDefect(
+                new ListOf<>(new LtAsciiOnly()),
+                new ListOf<>()
+            ).defects(
+                new EoSyntax(
+                    String.join(
+                        "\n",
+                        "+unlint ascii-only:3-5",
+                        "",
+                        "# 应用程序.",
+                        "[] > app",
+                        "  # 主函数.",
+                        "  [] > main"
+                    )
+                ).parsed()
+            ),
+            Matchers.emptyIterable()
+        );
+    }
 }

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -186,7 +186,7 @@ final class LtUnlintNonExistingDefectTest {
                 new EoSyntax(
                     String.join(
                         "\n",
-                        "+unlint ascii-only:3-5",
+                        "+unlint ascii-only:4-6",
                         "",
                         "# 应用程序.",
                         "[] > app",
@@ -210,17 +210,16 @@ final class LtUnlintNonExistingDefectTest {
                 new EoSyntax(
                     String.join(
                         "\n",
-                        "+unlint ascii-only:6-10",
-                        // it thinks that [6-10] and lines [4, 6] is not missing, though we are missing 4
+                        "+unlint ascii-only:7-10",
                         "",
                         "# 应用程序.",
-                        "[] > app",
+                        "[] > main",
                         "  # 你好，杰夫!",
                         "  [] > say-hello"
                     )
                 ).parsed()
             ),
-            Matchers.iterableWithSize(2)
+            Matchers.iterableWithSize(1)
         );
     }
 }

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -200,7 +200,7 @@ final class LtUnlintNonExistingDefectTest {
     }
 
     @Test
-    void catchesUnlintsWithOutOfRangeLines() throws IOException {
+    void catchesUnlintWithOutOfRangeLines() throws IOException {
         MatcherAssert.assertThat(
             "Defects are empty, but they should not",
             new LtUnlintNonExistingDefect(

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -198,4 +198,29 @@ final class LtUnlintNonExistingDefectTest {
             Matchers.emptyIterable()
         );
     }
+
+    @Test
+    void catchesUnlintsWithOutOfRangeLines() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are empty, but they should not",
+            new LtUnlintNonExistingDefect(
+                new ListOf<>(new LtAsciiOnly()),
+                new ListOf<>()
+            ).defects(
+                new EoSyntax(
+                    String.join(
+                        "\n",
+                        "+unlint ascii-only:6-10",
+                        // it thinks that [6-10] and lines [4, 6] is not missing, though we are missing 4
+                        "",
+                        "# 应用程序.",
+                        "[] > app",
+                        "  # 你好，杰夫!",
+                        "  [] > say-hello"
+                    )
+                ).parsed()
+            ),
+            Matchers.iterableWithSize(2)
+        );
+    }
 }

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectWpaTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectWpaTest.java
@@ -235,4 +235,87 @@ final class LtUnlintNonExistingDefectWpaTest {
             Matchers.hasSize(Matchers.greaterThan(0))
         );
     }
+
+    @Test
+    void allowsUnlintForDefectsInTheLineRange() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are not empty, but they should",
+            new LtUnlintNonExistingDefectWpa(
+                new ListOf<>(new LtInconsistentArgs()),
+                new ListOf<>()
+            ).defects(
+                new MapOf<>(
+                    "main",
+                    new EoSyntax(
+                        String.join(
+                            "\n",
+                            "+unlint inconsistent-args:5-7",
+                            "",
+                            "# Main.",
+                            "[] > main",
+                            "  fork > parent",
+                            "  fork parent > child",
+                            "  fork child parent > subchild"
+                        )
+                    ).parsed()
+                )
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void catchesUnlintWithOutOfRangeLines() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are empty, but they should not",
+            new LtUnlintNonExistingDefectWpa(
+                new ListOf<>(new LtInconsistentArgs()),
+                new ListOf<>()
+            ).defects(
+                new MapOf<>(
+                    "main",
+                    new EoSyntax(
+                        String.join(
+                            "\n",
+                            "+unlint inconsistent-args:12-44",
+                            "",
+                            "# Semaphore.",
+                            "[] > sem",
+                            "  p 1 > lock-one",
+                            "  p 1 1 > lock-more"
+                        )
+                    ).parsed()
+                )
+            ),
+            Matchers.iterableWithSize(1)
+        );
+    }
+
+    @Test
+    void catchesUnlintWithSomeLineOutOfRange() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are empty, but they should not",
+            new LtUnlintNonExistingDefectWpa(
+                new ListOf<>(new LtInconsistentArgs()),
+                new ListOf<>()
+            ).defects(
+                new MapOf<>(
+                    "main",
+                    new EoSyntax(
+                        String.join(
+                            "\n",
+                            "+unlint inconsistent-args:1-5",
+                            "",
+                            "# Object that represents Jeffrey from a real world.",
+                            "[] > jeff",
+                            "  send 0 > content",
+                            "  send content \"boss@google.com\" > emailed",
+                            "  send emailed > @"
+                        )
+                    ).parsed()
+                )
+            ),
+            Matchers.iterableWithSize(1)
+        );
+    }
 }

--- a/src/test/java/org/eolang/lints/UnlintInRangeTest.java
+++ b/src/test/java/org/eolang/lints/UnlintInRangeTest.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Tests for {@link UnlintInRange}.l
+ *
+ * @since 0.0.54
+ */
+final class UnlintInRangeTest {
+
+    @ParameterizedTest
+    @CsvSource(
+        {
+            "foo:1-3,1,true",
+            "app:1-3,2,true",
+            "x:1-3,3,true",
+            "xyz:1-3,4,false",
+            "bar:55-199,200,false",
+            "jiang:32-42,13,false"
+        }
+    )
+    void returnsTrueIfLineInRange(
+        final String unlint, final Integer line, final boolean expected
+    ) {
+        MatcherAssert.assertThat(
+            "The result does not match with expected",
+            new UnlintInRange(unlint).test(line),
+            Matchers.equalTo(expected)
+        );
+    }
+}

--- a/src/test/java/org/eolang/lints/UnlintInRangeTest.java
+++ b/src/test/java/org/eolang/lints/UnlintInRangeTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 /**
- * Tests for {@link UnlintInRange}.l
+ * Tests for {@link UnlintInRange}.
  *
  * @since 0.0.54
  */


### PR DESCRIPTION
In this PR I've updated `DefectMissing` to support line ranges, in order to enable line ranges in the `unlint-non-existing-defect` in both scopes: Single XMIR, and WPA.

closes #686

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for suppressing defects using unlints that specify a range of line numbers.
* **Bug Fixes**
  * Improved handling of unlints with line ranges to ensure correct defect suppression and detection.
* **Tests**
  * Introduced comprehensive tests to verify unlints with line ranges, including edge cases and partial overlaps.
  * Added parameterized tests to validate line range parsing and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->