### PR TITLE
feat(#698):  JAR command line functionality

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.compile.nullAnalysis.mode": "disabled"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "disabled"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -755,6 +755,39 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.5.0</version>
+        <configuration>
+            <archive>
+                <manifest>
+                    <mainClass>org.eolang.lints.Main</mainClass>
+                </manifest>
+            </archive>
+            <descriptorRefs>
+                <descriptorRef>jar-with-dependencies</descriptorRef>
+            </descriptorRefs>
+        </configuration>
+        <executions>
+            <execution>
+                <phase>package</phase>
+                <goals>
+                    <goal>single</goal>
+                </goals>
+            </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.qulice</groupId>
+        <artifactId>qulice-maven-plugin</artifactId>
+        <version>0.24.0</version>
+        <configuration>
+            <excludes>
+                <exclude>checkstyle:/design/UseUtilityClass</exclude>
+            </excludes>
+        </configuration>
+    </plugin>
     </plugins>
   </build>
 </project>

--- a/src/main/java/org/eolang/lints/Main.java
+++ b/src/main/java/org/eolang/lints/Main.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.stream.Stream;
+
+/**
+ * CLI entry point for lints analyzer.
+ *
+ * @since 0.2.0
+ */
+@SuppressWarnings("PMD.UseUtilityClass")
+final class Main {
+    /**
+     * Utility class constructor.
+     */
+    private Main() {
+        // Constructor is private to prevent instantiation
+    }
+
+    /**
+     * Entry point.
+     * @param args Command line arguments
+     * @throws IOException If fails to read files
+     */
+    @SuppressWarnings("PMD.SystemPrintln")
+    public static void main(final String[] args) throws IOException {
+        if (args.length == 0) {
+            System.err.println("Usage: java -jar lints.jar <path-to-xmir-file>");
+            System.exit(1);
+        }
+        final Path path = FileSystems.getDefault().getPath(args[0]);
+        if (Files.isDirectory(path)) {
+            processDirectory(path);
+        } else {
+            processFile(path);
+        }
+    }
+
+    /**
+     * Process single XMIR file.
+     * @param file Path to XMIR file
+     * @throws IOException On read error
+     */
+    @SuppressWarnings({"PMD.SystemPrintln", "PMD.SystemPrintf"})
+    private static void processFile(final Path file) throws IOException {
+        System.out.printf("Analyzing %s:%n", file);
+        final Collection<Defect> defects = new Source(file).defects();
+        if (defects.isEmpty()) {
+            System.out.println("✔ No defects found");
+        } else {
+            defects.forEach(d -> System.out.printf("✖ %s%n", d));
+        }
+    }
+
+    /**
+     * Process directory with XMIR files.
+     * @param dir Path to directory
+     * @throws IOException On read error
+     */
+    @SuppressWarnings({"PMD.SystemPrintln", "PMD.SystemPrintf"})
+    private static void processDirectory(final Path dir) throws IOException {
+        try (Stream<Path> stream = Files.walk(dir)) {
+            stream
+                .filter(
+                    p -> p.toString().endsWith(".xmir")
+                )
+                .forEach(
+                    p -> {
+                        try {
+                            Main.processFile(p);
+                        } catch (final IOException ex) {
+                            System.err.printf(
+                                "Failed to process %s: %s%n",
+                                p,
+                                ex.getMessage()
+                            );
+                        }
+                    }
+                );
+        }
+    }
+}

--- a/src/test/resources/test.xmir
+++ b/src/test/resources/test.xmir
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<program xmlns="https://www.eolang.org/xmir">
+  <objects>
+    <o name="app" line="2" pos="0">
+      <o name="foo" line="3" pos="2">
+        <o base="∅" line="3" name="x" pos="3"/>
+        <o base=".stdout" line="4" name="@" pos="9">
+          <o base=".io" line="4" pos="6">
+            <o base="QQ" line="4" pos="4"/>
+          </o>
+          <o base=".sprintf" line="5" pos="12">
+            <o base=".txt" line="5" pos="8">
+              <o base="QQ" line="5" pos="6"/>
+            </o>
+            <!-- Для строковых данных используем base="bytes" -->
+            <o base="bytes" line="6" pos="8">
+              <o>48-65-6C-6C-6F-2C-20-25-73-0A</o> <!-- "Hello, %s\n" в hex -->
+            </o>
+            <o base="x" line="7" pos="10"/>
+          </o>
+        </o>
+      </o>
+      <o base="foo" line="8" name="@" pos="2">
+        <o base="bytes" line="9" pos="4">
+          <o>77-6F-72-6C-64-21</o> <!-- "world!" в hex -->
+        </o>
+      </o>
+    </o>
+  </objects>
+  <listing># App with proper aliases and data
++home https://github.com/objectionary/eo
++alias stdout org.eolang.io.stdout
++alias txt org.eolang.txt
+
+[] &gt; app
+  [x] &gt; foo
+    stdout &gt; @
+      txt.sprintf
+        "Hello, %s\n"
+        x
+  foo &gt; @
+    "world!"</listing>
+  <metas>
+    <meta name="dob" value="2024-12-27T11:00:08"/>
+    <meta name="spdx">SPDX-License-Identifier: MIT</meta>
+    <meta name="ms" value="98"/>
+    <meta name="revision" value="27abe8b"/>
+    <meta name="time" value="2025-04-17T09:32:04.455112Z"/>
+    <meta name="version" value="0.56.0"/>
+    <meta name="home" value="https://github.com/objectionary/eo"/>
+  </metas>
+</program>


### PR DESCRIPTION
Covers #698 
As a starting point i have managed to puzzle `Main.java` class with static methods to handle a single file and directory.

`mvn jmh:benchmark` gave me this result:

<img width="574" height="192" alt="image" src="https://github.com/user-attachments/assets/f8b91268-d191-401b-b01f-a0de6555f24d" />

my computer with ubuntu pop_os!:

<img width="582" height="56" alt="image" src="https://github.com/user-attachments/assets/c6afd5c0-dacc-48ef-9504-e60c7c7f74c0" />

`mvn clean install -Pqulice` gave me this result:

<img width="412" height="94" alt="image" src="https://github.com/user-attachments/assets/dd60f669-f7c0-4968-b08e-1579c3c500d7" />

After obtaining `lints-1.0-SNAPSHOT-jar-with-dependencies.jar` executable binary, i was trying to execute `test.xmir` file containing:

```
<?xml version="1.0"?>
<program xmlns="https://www.eolang.org/xmir">
  <objects>
    <o name="app" line="2" pos="0">
      <o name="foo" line="3" pos="2">
        <o base="∅" line="3" name="x" pos="3"/>
        <o base=".stdout" line="4" name="@" pos="9">
          <o base=".io" line="4" pos="6">
            <o base="QQ" line="4" pos="4"/>
          </o>
          <o base=".sprintf" line="5" pos="12">
            <o base=".txt" line="5" pos="8">
              <o base="QQ" line="5" pos="6"/>
            </o>
            <!-- Для строковых данных используем base="bytes" -->
            <o base="bytes" line="6" pos="8">
              <o>48-65-6C-6C-6F-2C-20-25-73-0A</o> <!-- "Hello, %s\n" в hex -->
            </o>
            <o base="x" line="7" pos="10"/>
          </o>
        </o>
      </o>
      <o base="foo" line="8" name="@" pos="2">
        <o base="bytes" line="9" pos="4">
          <o>77-6F-72-6C-64-21</o> <!-- "world!" в hex -->
        </o>
      </o>
    </o>
  </objects>
  <listing># App with proper aliases and data
+home https://github.com/objectionary/eo
+alias stdout org.eolang.io.stdout
+alias txt org.eolang.txt

[] &gt; app
  [x] &gt; foo
    stdout &gt; @
      txt.sprintf
        "Hello, %s\n"
        x
  foo &gt; @
    "world!"</listing>
  <metas>
    <meta name="dob" value="2024-12-27T11:00:08"/>
    <meta name="spdx">SPDX-License-Identifier: MIT</meta>
    <meta name="ms" value="98"/>
    <meta name="revision" value="27abe8b"/>
    <meta name="time" value="2025-04-17T09:32:04.455112Z"/>
    <meta name="version" value="0.56.0"/>
    <meta name="home" value="https://github.com/objectionary/eo"/>
  </metas>
</program>
```
and constantly encounter these warnings:
```
Exception in thread "main" java.lang.IllegalStateException: XMIR should have '/object/o/@name' attribute
```
need some clarification - is it the wrong `Main.java` file or the wrong `test.xmir` file?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a command-line tool for analyzing `.xmir` files and reporting defects, supporting both individual files and directories.
  * Added a sample `.xmir` file for testing and demonstration purposes.

* **Chores**
  * Updated build configuration to create an executable JAR and refined code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->