### PR TITLE
bug(#728): EO 0.58.3 up, idempotent attributes, fixed XMIR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-parser</artifactId>
-      <version>0.58.2</version>
+      <version>0.58.3</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/src/main/resources/org/eolang/lints/atoms/not-empty-atom.xsl
+++ b/src/main/resources/org/eolang/lints/atoms/not-empty-atom.xsl
@@ -11,7 +11,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[eo:atom(.) and o[@base and @base!='∅']]">
+      <xsl:for-each select="//o[eo:atom(.) and o[@base and @base!='∅' and not(@base='ξ' and @name='xi🌵')]]">
         <xsl:element name="defect">
           <xsl:variable name="line" select="eo:lineno(@line)"/>
           <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/lints/critical/idempotent-attribute-is-not-first.xsl
+++ b/src/main/resources/org/eolang/lints/critical/idempotent-attribute-is-not-first.xsl
@@ -3,14 +3,15 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
  * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="phi-is-not-first">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="idempotent-attribute-is-not-first">
+  <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:apply-templates select="(//o[@name='φ'][preceding-sibling::o[not(@base='∅') and not(@base='ξ' and @name='xi🌵')]])[last()]" mode="unordered"/>
+      <xsl:apply-templates select="//o[eo:abstract(.) and not(o[1][@base='ξ' and @name='xi🌵'])]" mode="unordered"/>
     </defects>
   </xsl:template>
   <xsl:template match="o" mode="unordered">
@@ -24,8 +25,8 @@
           <xsl:value-of select="eo:defect-context(.)"/>
         </xsl:attribute>
       </xsl:if>
-      <xsl:attribute name="severity">warning</xsl:attribute>
-      <xsl:text>The "@" object must go first (except void attributes ordering)</xsl:text>
+      <xsl:attribute name="severity">critical</xsl:attribute>
+      <xsl:text>The idempotent object must go first inside formation</xsl:text>
     </defect>
   </xsl:template>
 </xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/critical/idempotent-attribute-is-not-first.xsl
+++ b/src/main/resources/org/eolang/lints/critical/idempotent-attribute-is-not-first.xsl
@@ -11,7 +11,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:apply-templates select="//o[eo:abstract(.) and not(o[1][@base='ξ' and @name='xi🌵'])]" mode="unordered"/>
+      <xsl:apply-templates select="//o[eo:abstract(.) and not(eo:has-data(.)) and not(o[1][@base='ξ' and @name='xi🌵'])]" mode="unordered"/>
     </defects>
   </xsl:template>
   <xsl:template match="o" mode="unordered">

--- a/src/main/resources/org/eolang/lints/critical/void-attributes-not-higher-than-other.xsl
+++ b/src/main/resources/org/eolang/lints/critical/void-attributes-not-higher-than-other.xsl
@@ -10,7 +10,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:apply-templates select="//o[@base='∅' and preceding-sibling::o[@base != '∅']]" mode="low-void"/>
+      <xsl:apply-templates select="//o[@base='∅' and preceding-sibling::o[@base != '∅' and not(@base='ξ' and @name='xi🌵')]]" mode="low-void"/>
     </defects>
   </xsl:template>
   <xsl:template match="o" mode="low-void">

--- a/src/main/resources/org/eolang/lints/errors/empty-object.xsl
+++ b/src/main/resources/org/eolang/lints/errors/empty-object.xsl
@@ -11,7 +11,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="/object//o[not(@base) and not(o) and not(eo:atom(.)) and not(eo:has-data(.) and parent::o[@base='Φ.org.eolang.bytes']) and not(parent::o[eo:atom(.)])]">
+      <xsl:for-each select="/object//o[not(@base) and not(o[not(@base='ξ' and @name='xi🌵')]) and not(eo:atom(.)) and not(eo:has-data(.) and parent::o[@base='Φ.org.eolang.bytes']) and not(parent::o[eo:atom(.)])]">
         <xsl:element name="defect">
           <xsl:variable name="line" select="eo:lineno(@line)"/>
           <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
@@ -11,7 +11,7 @@
   <xsl:template match="/">
     <defects>
       <xsl:variable name="top" select="/object/o/generate-id()"/>
-      <xsl:for-each select="//o[generate-id() != $top and @name and @name != 'φ' and @base and @base != '∅']">
+      <xsl:for-each select="//o[generate-id() != $top and @name and @name != 'φ' and @base and @base != '∅' and not(@base='ξ' and @name='xi🌵')]">
         <xsl:variable name="usage" select="concat('^ξ(?:\.ρ)*\.', @name, '(?:\.[\w-]+)*$')"/>
         <xsl:if test="count(//o[matches(@base, $usage)])&lt;=1 and not(@name and o[1]/@base = 'Φ.org.eolang.dataized')">
           <xsl:element name="defect">

--- a/src/main/resources/org/eolang/lints/misc/sparse-decoration.xsl
+++ b/src/main/resources/org/eolang/lints/misc/sparse-decoration.xsl
@@ -10,7 +10,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[eo:abstract(.) and not(starts-with(@name, '+')) and count(o)=1 and o[1][@name='φ']]">
+      <xsl:for-each select="//o[eo:abstract(.) and not(starts-with(@name, '+')) and count(o[not(@base='ξ' and @name='xi🌵')])=1 and o[not(@base='ξ' and @name='xi🌵')][1][@name='φ']]">
         <xsl:element name="defect">
           <xsl:variable name="line" select="eo:lineno(@line)"/>
           <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/motives/critical/idempotent-attribute-is-not-first.md
+++ b/src/main/resources/org/eolang/motives/critical/idempotent-attribute-is-not-first.md
@@ -1,0 +1,22 @@
+# Idempotent attribute is not first
+
+The idempotent attribute (object with `@name="ξ"` and `@name="xi🌵"`) must be
+declared first in the formation.
+
+Incorrect:
+
+```xml
+<o name="foo">
+  <o base="∅" name="x"/>
+  <o base="ξ" name="xi🌵"/>
+</o>
+```
+
+Correct:
+
+```xml
+<o name="foo">
+  <o base="ξ" name="xi🌵"/>
+  <o base="∅" name="x"/>
+</o>
+```

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-objects-inside-formation/allows-idempotent-in-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-objects-inside-formation/allows-idempotent-in-tests.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/errors/anonymous-objects-inside-formation.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  [] > foo
+    [] +> tests-slice-foreign-literals
+      eq. > @
+        "hello, 大家!".slice
+          7
+          1
+        "大"

--- a/src/test/resources/org/eolang/lints/packs/single/idempotent-attribute-is-not-first/allows-data-without-idempotent-attr.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/idempotent-attribute-is-not-first/allows-data-without-idempotent-attr.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/critical/idempotent-attribute-is-not-first.xsl
+asserts:
+  - /defects[count(defect)=0]
+document: |
+  <object author="tests">
+    <o name="b" base="Φ.org.eolang.bytes" line="9" pos="6">
+      <o as="α0" line="9" pos="6">48-65-6C-6C-6F-20-25-73</o>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/idempotent-attribute-is-not-first/allows-idempotent-first.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/idempotent-attribute-is-not-first/allows-idempotent-first.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/critical/idempotent-attribute-is-not-first.xsl
+asserts:
+  - /defects[count(defect)=0]
+document: |
+  <object author="tests">
+    <o name="foo">
+      <o base="ξ" name="xi🌵"/>
+      <o base="∅" name="x"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/idempotent-attribute-is-not-first/catches-idempotent-not-first.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/idempotent-attribute-is-not-first/catches-idempotent-not-first.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/critical/idempotent-attribute-is-not-first.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=1]
+document: |
+  <object author="tests">
+    <o name="foo">
+      <o base="∅" name="x"/>
+      <o base="ξ" name="xi🌵"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-redundant-phi-in-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-redundant-phi-in-tests.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/redundant-object.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  [] > real
+    [] +> tests-sqrt-check-nan-input
+      is-nan. +> @
+        sqrt.
+          real nan

--- a/src/test/resources/org/eolang/lints/packs/single/void-attributes-not-higher-than-other/allows-idempotent-first.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/void-attributes-not-higher-than-other/allows-idempotent-first.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/critical/void-attributes-not-higher-than-other.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=0]
+document: |
+  <object author="tests">
+    <o name="foo">
+      <o base="ξ" name="xi🌵"/>
+      <o base="∅" name="x"/>
+      <o base="∅" name="y"/>
+    </o>
+  </object>


### PR DESCRIPTION
In this PR I've upgraded EO-parser dependency to [0.58.3]() with fixed XMIR, updated lints to handle idempotent attributes, added new lint `idempotent-attribute-is-not-first`, that issues defect with `critical` severity if idempotency attribute is not placed first among the formation's attributes.

see #728
see #730