### PR TITLE
bug(#738): `unused-void-attr` allows Phi void attribute unused

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/unused-void-attr.xsl
+++ b/src/main/resources/org/eolang/lints/misc/unused-void-attr.xsl
@@ -14,7 +14,7 @@
       <xsl:for-each select="//o[@base='∅']">
         <xsl:variable name="attr" select="@name"/>
         <xsl:variable name="formation" select=".."/>
-        <xsl:if test="not(eo:atom($formation)) and not($formation//o[contains(@base, concat('ξ.', $attr))]/ancestor::o[eo:abstract(.)][1][generate-id()=$formation/generate-id()]) and not($formation//o[eo:atom(.)])">
+        <xsl:if test="not($attr='φ') and not(eo:atom($formation)) and not($formation//o[contains(@base, concat('ξ.', $attr))]/ancestor::o[eo:abstract(.)][1][generate-id()=$formation/generate-id()]) and not($formation//o[eo:atom(.)])">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/allows-unused-phi.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/allows-unused-phi.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/unused-void-attr.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  [] > main
+    [@] > foo
+      42 > x1
+      52 > x2
+      x2.plus x1 > i


### PR DESCRIPTION
see #738

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a false positive in the unused-void-attribute check: attributes named “φ” are no longer incorrectly reported as defects.
* **Tests**
  * Added a test case to ensure “φ” attributes are allowed and produce zero defects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->