### PR TITLE
bug(#767): add explicit timeouts to slow tests, puzzle for lint performance optimization

### DIFF
--- a/src/test/groovy/org/eolang/lints/HomeNamesTest.groovy
+++ b/src/test/groovy/org/eolang/lints/HomeNamesTest.groovy
@@ -7,6 +7,7 @@ package org.eolang.lints
 import com.yegor256.MayBeSlow
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.junit.jupiter.api.Tag
@@ -24,6 +25,7 @@ import org.junit.jupiter.api.io.TempDir
 @ExtendWith(MayBeSlow)
 final class HomeNamesTest {
 
+  @Timeout(unit = TimeUnit.MINUTES, value = 3L)
   @Test
   void placesHomeObjectsAsReserved(@TempDir final Path temp) {
     final String csv = temp.resolve("reserved.csv").toString()
@@ -35,6 +37,7 @@ final class HomeNamesTest {
     )
   }
 
+  @Timeout(unit = TimeUnit.MINUTES, value = 3L)
   @Test
   void placesHomeObjectsWithCorrectNames(@TempDir final Path temp) {
     final String csv = temp.resolve("reserved.csv").toString()

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -359,7 +360,7 @@ final class LtByXslTest {
 
     @SuppressWarnings("StreamResourceLeak")
     @Tag("deep")
-    @Timeout(180L)
+    @Timeout(unit = TimeUnit.MINUTES, value = 5L)
     @Test
     void validatesEoPacksForErrors() throws IOException {
         Files.walk(Paths.get("src/test/resources/org/eolang/lints/packs/single"))

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.cactoos.bytes.BytesOf;
@@ -61,12 +62,17 @@ import org.objectweb.asm.Opcodes;
  * Test for {@link Source}.
  *
  * @since 0.0.1
+ * @todo #767:60min Decrease timeouts for source linting.
+ *  As for now, most lints are too slow, we need to optimize them first, so they
+ *  run in milliseconds, not seconds/minutes. It should decrease our build time too.
+ *  After that, we need to decrease our test timeouts. Don't forget to remove this puzzle.
  * @checkstyle MethodBodyCommentsCheck (50 lines)
  */
 @SuppressWarnings("PMD.TooManyMethods")
 @ExtendWith(MktmpResolver.class)
 final class SourceTest {
 
+    @Timeout(unit = TimeUnit.SECONDS, value = 60L)
     @Test
     void returnsEmptyListOfDefects() throws IOException {
         MatcherAssert.assertThat(
@@ -144,7 +150,7 @@ final class SourceTest {
     }
 
     @Tag("deep")
-    @Timeout(60L)
+    @Timeout(unit = TimeUnit.MINUTES, value = 2L)
     @RepeatedTest(2)
     void lintsInMultipleThreads() {
         MatcherAssert.assertThat(


### PR DESCRIPTION
closes  #767

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Increased timeouts for several long-running tests to improve stability and reduce flakiness.
  - Standardized timeout units and added per-test timeouts where appropriate.
- Documentation
  - Added notes in test documentation regarding lint timeouts and performance considerations.

No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->