### PR TITLE
bug(#744): optimized `redundant-object` lint

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
@@ -9,28 +9,25 @@
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
+    <xsl:variable name="eligible" select="//o[@name and @name!='φ' and @base and @base!='∅' and not(@base='ξ' and @name='xi🌵')]"/>
+    <xsl:variable name="ref-groups" as="element(group)*">
+      <xsl:for-each-group select="//o[matches(@base, '^ξ(?:\.ρ)*\.')]" group-by="replace(@base, '^ξ(?:\.ρ)*\.([^.\s]+).*', '$1')">
+        <group name="{current-grouping-key()}" count="{count(current-group())}"/>
+      </xsl:for-each-group>
+    </xsl:variable>
     <defects>
       <xsl:variable name="top" select="/object/o/generate-id()"/>
-      <xsl:for-each select="//o[generate-id() != $top and @name and @name != 'φ' and @base and @base != '∅' and not(@base='ξ' and @name='xi🌵')]">
-        <xsl:variable name="usage" select="concat('^ξ(?:\.ρ)*\.', @name, '(?:\.[\w-]+)*$')"/>
-        <xsl:if test="count(//o[matches(@base, $usage)])&lt;=1 and not(@name and o[1]/@base = 'Φ.org.eolang.dataized')">
-          <xsl:element name="defect">
-            <xsl:variable name="line" select="eo:lineno(@line)"/>
-            <xsl:attribute name="line">
-              <xsl:value-of select="$line"/>
-            </xsl:attribute>
-            <xsl:if test="$line = '0'">
-              <xsl:attribute name="context">
-                <xsl:value-of select="eo:defect-context(.)"/>
-              </xsl:attribute>
+      <xsl:for-each select="$eligible[generate-id() != $top]">
+        <xsl:variable name="refs" select="number(($ref-groups[@name = current()/@name]/@count, 0)[1])"/>
+        <xsl:if test="$refs &lt;= 1 and not(@name and o[1]/@base = 'Φ.org.eolang.dataized')">
+          <defect line="{eo:lineno(@line)}" severity="warning">
+            <xsl:if test="eo:lineno(@line) = '0'">
+              <xsl:attribute name="context" select="eo:defect-context(.)"/>
             </xsl:if>
-            <xsl:attribute name="severity">
-              <xsl:text>warning</xsl:text>
-            </xsl:attribute>
             <xsl:text>The object </xsl:text>
             <xsl:value-of select="eo:escape(@name)"/>
             <xsl:text> is redundant and may be inlined</xsl:text>
-          </xsl:element>
+          </defect>
         </xsl:if>
       </xsl:for-each>
     </defects>

--- a/src/test/java/benchmarks/SourceBench.java
+++ b/src/test/java/benchmarks/SourceBench.java
@@ -45,14 +45,10 @@ public class SourceBench {
      * @todo #555:35min Enable `duplicate-names-in-diff-context` benchmark.
      *  Currently, its slow, especially for `L` and `XL`-sized sources. Let's optimize it,
      *  in order to enable this benchmark.
-     * @todo #376:60min Enable redundant object in the single XMIR scope benchmarks.
-     *  As for now, the lint is too slow, especially on L, XL and XXL-sized XMIRs.
-     *  This happens mostly because of multiple XPath `//o` selects in the XSL. Once,
-     *  the lint will be optimized, we can enable the lint in the benchmarks.
      */
     @Benchmark
     public final void scansXmir(final BenchmarkState state) {
-        new Source(state.xmir).without("redundant-object", "duplicate-names-in-diff-context")
+        new Source(state.xmir).without("duplicate-names-in-diff-context")
             .defects();
     }
 


### PR DESCRIPTION
In this PR I've optimized `redundant-object` lint from `O(n^2)` to `O(n + G)` execution time, where `n` - the number of `objects`, and `G` - one-time grouping pass.

## Evaluation

To evaluate results, I used the following script

```bash
mvn clean test -Dtest=SourceTest#lintsBenchmarkSourcesFromJava -Pbenchmark
cat target/timings.csv | sort -t, -k2 -n -r | grep "redundant-object"
```

Before:

```text
"redundant-object (XXL)","403"
"redundant-object (XL)","56"
"redundant-object (S)","114"
"redundant-object (M)","36"
"redundant-object (L)","42"
```

After:

```text
"redundant-object (XXL)","56"
"redundant-object (XL)","22"
"redundant-object (S)","104"
"redundant-object (M)","20"
"redundant-object (L)","22"
```

see #744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Refined “redundant-object” lint detection for more precise reporting, which may change the number of flagged cases.
  - Standardized lint output: severity reported as “warning” and context included only when the line number is unknown.

- Tests
  - Benchmark configuration updated to include “redundant-object” in scans, expanding the measured defect set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->