### PR TITLE
bug(#632): `wrong-test-order` lint

### DIFF
--- a/.github/workflows/deep.yml
+++ b/.github/workflows/deep.yml
@@ -12,7 +12,7 @@ name: deep
       - master
 jobs:
   deep:
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/hone.yml
+++ b/.github/workflows/hone.yml
@@ -10,6 +10,8 @@ name: hone
   pull_request:
     branches:
       - master
+env:
+  RUN_WORKFLOW: false
 jobs:
   hone:
     timeout-minutes: 45
@@ -19,7 +21,7 @@ jobs:
     #  this issue: https://github.com/objectionary/hone-maven-plugin/issues/297. Also, the plugin run
     #  is time-consuming, we should enable it only after the plugin will have stable execution time,
     #  in order to not disturb the development in this repository.
-    if: false
+    if: env.RUN_WORKFLOW == 'true'
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5

--- a/.github/workflows/hone.yml
+++ b/.github/workflows/hone.yml
@@ -21,7 +21,7 @@ jobs:
     #  this issue: https://github.com/objectionary/hone-maven-plugin/issues/297. Also, the plugin run
     #  is time-consuming, we should enable it only after the plugin will have stable execution time,
     #  in order to not disturb the development in this repository.
-    if: env.RUN_WORKFLOW == 'true'
+    if: ${{ env.RUN_WORKFLOW == 'true' }}
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5

--- a/.github/workflows/hone.yml
+++ b/.github/workflows/hone.yml
@@ -21,7 +21,7 @@ jobs:
     #  this issue: https://github.com/objectionary/hone-maven-plugin/issues/297. Also, the plugin run
     #  is time-consuming, we should enable it only after the plugin will have stable execution time,
     #  in order to not disturb the development in this repository.
-    if: ${{ env.RUN_WORKFLOW == 'true' }}
+    if: ${{ vars.RUN_WORKFLOW == 'true' }}
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5

--- a/.github/workflows/jmh.yml
+++ b/.github/workflows/jmh.yml
@@ -13,7 +13,7 @@ jobs:
   jmh:
     timeout-minutes: 45
     runs-on: ubuntu-24.04
-    if: env.RUN_WORKFLOW == 'true'
+    if: ${{ env.RUN_WORKFLOW == 'true' }}
     steps:
       - name: Run JMH Benchmark Action
         uses: volodya-lombrozo/jmh-benchmark-action@v1

--- a/.github/workflows/jmh.yml
+++ b/.github/workflows/jmh.yml
@@ -7,11 +7,13 @@ name: jmh
   pull_request:
     branches:
       - master
+env:
+  RUN_WORKFLOW: false
 jobs:
   jmh:
     timeout-minutes: 45
     runs-on: ubuntu-24.04
-    if: false
+    if: env.RUN_WORKFLOW == 'true'
     steps:
       - name: Run JMH Benchmark Action
         uses: volodya-lombrozo/jmh-benchmark-action@v1

--- a/.github/workflows/jmh.yml
+++ b/.github/workflows/jmh.yml
@@ -13,7 +13,7 @@ jobs:
   jmh:
     timeout-minutes: 45
     runs-on: ubuntu-24.04
-    if: ${{ env.RUN_WORKFLOW == 'true' }}
+    if: ${{ vars.RUN_WORKFLOW == 'true' }}
     steps:
       - name: Run JMH Benchmark Action
         uses: volodya-lombrozo/jmh-benchmark-action@v1

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -34,5 +34,8 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
+      - uses: JesseTG/rm@v1.0.3
+        with:
+          path: ~/.m2/repository/org/eolang
       - run: mvn clean install -PskipITs --errors --batch-mode
       - run: mvn test --errors --batch-mode

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [ 17, 23 ]
+        java: [17, 23]
         exclude:
           - os: windows-2022
             java: 17

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -16,7 +16,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [11, 21]
+        java: [ 17, 23 ]
+        exclude:
+          - os: windows-2022
+            java: 17
+          - os: macos-15
+            java: 17
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5

--- a/src/main/resources/org/eolang/lints/tests/wrong-test-order.xsl
+++ b/src/main/resources/org/eolang/lints/tests/wrong-test-order.xsl
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="wrong-test-order" version="2.0">
+  <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="/object//o[starts-with(@name, '+')]">
+        <xsl:variable name="next" select="following-sibling::*[1]"/>
+        <xsl:if test="$next[self::o] and not(starts-with($next/@name, '+'))">
+          <xsl:element name="defect">
+            <xsl:variable name="line" select="eo:lineno(@line)"/>
+            <xsl:attribute name="line">
+              <xsl:value-of select="$line"/>
+            </xsl:attribute>
+            <xsl:if test="$line = '0'">
+              <xsl:attribute name="context">
+                <xsl:value-of select="eo:defect-context(.)"/>
+              </xsl:attribute>
+            </xsl:if>
+            <xsl:attribute name="severity">
+              <xsl:text>warning</xsl:text>
+            </xsl:attribute>
+            <xsl:text>The unit test wrongly ordered: </xsl:text>
+            <xsl:value-of select="eo:escape(eo:escape-plus(@name))"/>
+          </xsl:element>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/tests/wrong-test-order.md
+++ b/src/main/resources/org/eolang/motives/tests/wrong-test-order.md
@@ -1,0 +1,19 @@
+# Wrong test order
+
+Unit tests must be located after live objects:
+
+Incorrect:
+
+```eo
+[] > foo
+  [] +> runs-something
+  [] > bar
+```
+
+Correct:
+
+```eo
+[] > foo
+  [] > bar
+  [] +> runs-something
+```

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/allows-correct-order.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/allows-correct-order.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/wrong-test-order.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='3']
+input: |
+  [] > foo
+    [] > bar
+    [] +> runs-program
+    [] > boom

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/allows-no-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/allows-no-tests.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/wrong-test-order.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [] > foo
+    [] > a
+    [] > x
+    [] > y

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/allows-single-test.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/allows-single-test.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/wrong-test-order.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [] > main
+    [] +> testing

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/allows-tests-only.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/allows-tests-only.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/wrong-test-order.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [] > at
+    [] +> test
+    [] +> another-test

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/catches-mixed.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/catches-mixed.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/wrong-test-order.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='2']
+input: |
+  [] > app
+    [] +> runs
+    [] > x
+    [] +> something

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/catches-test-first.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/catches-test-first.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/wrong-test-order.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='2']
+input: |
+  [] > x
+    [] +> runs-x
+    [] > bool
+    [] > t

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/catches-wrong-order.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/catches-wrong-order.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/wrong-test-order.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [] > main
+    [] > bar
+    [] > boom
+    [] > test


### PR DESCRIPTION
In this pull I've implemented new lint: `wrong-test-order`, that issues defect with `warning` severity if test attributes are wrongly ordered.

see #632

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lint that warns when unit tests are placed before live objects (reports warning with contextual info).

* **Documentation**
  * Added guidance illustrating correct vs incorrect test ordering with examples.

* **Tests**
  * Added multiple test cases covering correct order, no tests, single/multiple tests, mixed orders, and wrong-order detection.

* **Chores**
  * CI: gated optional jobs via RUN_WORKFLOW, updated Java matrix, added cleanup step, increased job timeout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->