### PR TITLE
Reset xml.totalEntitySizeLimit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -769,7 +769,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <!-- version from the parent pom -->
         <configuration>
-          <argLine>${argLine} -Djdk.xml.totalEntitySizeLimit=0</argLine>
+          <argLine>@{argLine} -Djdk.xml.totalEntitySizeLimit=0</argLine>
           <skipTests>${skipUTs}</skipTests>
           <excludedGroups>benchmark,deep,reserved</excludedGroups>
           <excludes>
@@ -837,6 +837,8 @@
         <!-- version from the parent pom -->
         <executions>
           <execution>
+            <id>unpack-hadoop-fsnamesystem</id>
+            <phase>process-classes</phase>
             <goals>
               <goal>unpack</goal>
             </goals>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted test environment to set XML parsing limits during test runs and added a configurable test JVM property for passing extra JVM arguments.
  * Added a build execution that unpacks a specific Hadoop component during the build process to ensure required runtime artifacts are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->