### PR TITLE
Fix NPE in DefectMissing for range +unlint of absent lint (#841)

### DIFF
--- a/src/main/java/org/eolang/lints/DefectMissing.java
+++ b/src/main/java/org/eolang/lints/DefectMissing.java
@@ -44,7 +44,11 @@ final class DefectMissing implements Function<String, Boolean> {
         final String name = split[0];
         final List<Integer> lines = this.defects.get(name);
         if (unlint.matches(String.format("%s:\\d+-\\d+", name))) {
-            missing = !lines.stream().allMatch(new UnlintInRange(unlint));
+            if (lines == null) {
+                missing = !this.excluded.contains(name);
+            } else {
+                missing = !lines.stream().allMatch(new UnlintInRange(unlint));
+            }
         } else {
             final Set<String> names;
             if (this.defects != null) {

--- a/src/test/java/org/eolang/lints/DefectMissingTest.java
+++ b/src/test/java/org/eolang/lints/DefectMissingTest.java
@@ -80,4 +80,23 @@ final class DefectMissingTest {
             Matchers.equalTo(true)
         );
     }
+
+    @Test
+    void returnsTrueWhenRangeReferencesAbsentLint() {
+        MatcherAssert.assertThat(
+            "Defect should be missing when referenced lint is absent from map",
+            new DefectMissing(new MapOf<>("other-lint", new ListOf<>(1, 2)), new ListOf<>())
+                .apply("ascii-only:1-5"),
+            Matchers.equalTo(true)
+        );
+    }
+
+    @Test
+    void returnsTrueWhenRangeReferencesLintInEmptyMap() {
+        MatcherAssert.assertThat(
+            "Defect should be missing when defects map is empty",
+            new DefectMissing(new MapOf<>(), new ListOf<>()).apply("ascii-only:1-5"),
+            Matchers.equalTo(true)
+        );
+    }
 }

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -222,4 +222,26 @@ final class LtUnlintNonExistingDefectTest {
             Matchers.iterableWithSize(1)
         );
     }
+
+    @Test
+    void catchesRangeUnlintOfAbsentLint() throws IOException {
+        MatcherAssert.assertThat(
+            "Range unlint referencing an absent lint should be reported, not throw NPE",
+            new LtUnlintNonExistingDefect(
+                new ListOf<>(new LtAsciiOnly()),
+                new ListOf<>()
+            ).defects(
+                new EoSyntax(
+                    String.join(
+                        "\n",
+                        "+unlint ascii-only:1-5",
+                        "",
+                        "# Hello.",
+                        "[] > main"
+                    )
+                ).parsed()
+            ),
+            Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
 }


### PR DESCRIPTION
Fixes #841.

When `+unlint name:line-line` (range form) references a lint name that did not fire, `DefectMissing.apply()` calls `this.defects.get(name)` which returns `null`, and then `lines.stream()` throws `NullPointerException`.

This PR:
- Adds two failing unit tests to `DefectMissingTest` covering the missing-key + range case (with and without other entries in the map).
- Adds an integration test `catchesRangeUnlintOfAbsentLint` to `LtUnlintNonExistingDefectTest` matching the reproducer in the issue.
- Fixes `DefectMissing.apply()` to treat a `null` lines list the same way the non-range branch does: the defect is reported as missing unless the lint name is in the `excluded` list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of unlint directives with line ranges that reference non-existent lint rules.

* **Tests**
  * Added test coverage for edge cases involving range-based unlint directives on absent lint types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->