### PR TITLE
Fix #699: respect without("unlint-non-existing-defect")

### DIFF
--- a/src/main/java/org/eolang/lints/MonoWithout.java
+++ b/src/main/java/org/eolang/lints/MonoWithout.java
@@ -22,6 +22,11 @@ final class MonoWithout extends IterableEnvelope<Lint> {
      * @param names Lints to exclude
      */
     MonoWithout(final String... names) {
-        super(new PkMono(new WithoutLints(MonoWithout.LINTS, names)));
+        super(
+            new WithoutLints(
+                new PkMono(new WithoutLints(MonoWithout.LINTS, names)),
+                names
+            )
+        );
     }
 }

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -326,6 +326,37 @@ final class SourceTest {
         );
     }
 
+    @Test
+    void disablesUnlintNonExistingDefectViaWithout() throws IOException {
+        MatcherAssert.assertThat(
+            "unlint-non-existing-defect should be silenced when disabled via without()",
+            new Source(
+                new EoSyntax(
+                    String.join(
+                        System.lineSeparator(),
+                        "+unlint mandatory-home",
+                        "",
+                        "# Foo.",
+                        "[] > foo"
+                    )
+                ).parsed()
+            ).without(
+                "unlint-non-existing-defect",
+                "mandatory-home",
+                "mandatory-version",
+                "empty-object",
+                "mandatory-package",
+                "mandatory-spdx",
+                "comment-too-short",
+                "no-attribute-formation",
+                "unit-test-missing"
+            ).defects().stream()
+                .filter(defect -> defect.rule().startsWith("unlint-non-existing-defect"))
+                .collect(Collectors.toList()),
+            Matchers.emptyIterable()
+        );
+    }
+
     @ParameterizedTest
     @ValueSource(
         strings = {"mandatory-home", "mandatory-home:0"}


### PR DESCRIPTION
@yegor256 this fixes #699.

**Problem.** When a user excludes `unlint-non-existing-defect` via `Source.without(...)`, the warning is still emitted. The cause is in `PkMono`: it always appends a fresh `LtUnlintNonExistingDefect` lint to the joined list it returns. `MonoWithout` only filtered the input lints with `WithoutLints` *before* passing them into `PkMono`, so the lint that `PkMono` adds at the end never went through the exclusion filter and `without("unlint-non-existing-defect")` had no effect on it.

**Fix.** Wrap the `PkMono` result in a second `WithoutLints` so any lint whose name the caller asked to exclude is dropped, including ones added inside `PkMono`. The inner `WithoutLints` is preserved so `LtUnlintNonExistingDefect` is still constructed from the same filtered lint list it has always seen.

**Test.** `SourceTest#disablesUnlintNonExistingDefectViaWithout` reproduces the bug: it has `+unlint mandatory-home` in source and disables `mandatory-home` plus all the other lints that the snippet would otherwise trigger. `unlint-non-existing-defect` would normally fire because there is no `mandatory-home` defect for the `+unlint` to silence; the test asserts that `without("unlint-non-existing-defect")` suppresses it. The test fails on master and passes after the fix.

**CI.** The same five jobs that were failing on master at `820cb36b` (`mvn` on all three OSes, `deep`, `reserved`) also fail on this PR — they're pre-existing flaky 45 s test timeouts (e.g. `MonoLintsTest.lintsProgramCorrectly`, `PkByXslTest.doesNotDuplicateDefectsWhenMultipleDefectsOnTheSameLine`) and are unrelated to this change. Reproduced locally on master without my changes. The `@todo #767` puzzle in `SourceTest` already tracks the underlying lint-performance work.