### PR TITLE
Fix #639: don't flag self-aliases used in nested formations

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
@@ -13,7 +13,8 @@
       <xsl:variable name="top" select="/object/o/generate-id()"/>
       <xsl:for-each select="//o[generate-id() != $top and @name and @name != 'φ' and @base and @base != '∅' and not(@base='ξ' and @name='xi🌵')]">
         <xsl:variable name="usage" select="concat('^ξ(?:\.ρ)*\.', @name, '(?:\.[\w-]+)*$')"/>
-        <xsl:if test="count(//o[matches(@base, $usage)])&lt;=1 and not(@name and o[1]/@base = 'Φ.dataized')">
+        <xsl:variable name="nested-usage" select="concat('^ξ\.ρ(?:\.ρ)*\.', @name, '(?:\.[\w-]+)*$')"/>
+        <xsl:if test="count(//o[matches(@base, $usage)])&lt;=1 and not(@base='ξ' and count(//o[matches(@base, $nested-usage)])&gt;=1) and not(@name and o[1]/@base = 'Φ.dataized')">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-self-reused-in-nested-formation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-self-reused-in-nested-formation.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/redundant-object.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # Foo.
+  [] > jeff
+    $ > self
+    [] > say-hello
+      stdout self > @


### PR DESCRIPTION
@yegor256 this PR fixes #639. Here's what changed and why:

## The bug

The example from the issue:

```eo
[] > jeff
  $ > self
  [] > say-hello
    stdout self > @
```

raised `The object "self" is redundant and may be inlined`. You confirmed it was a false positive.

## Root cause

`redundant-object.xsl` flags any named, non-`φ` object whose `@base` reference appears at most once in the program. The parser emits the only reference to `self` from inside `say-hello` as `<o base="ξ.ρ.self"/>`, so the count is `1` and the lint fires.

The match itself is fine — the suggested *remediation* (inlining) is what would be unsafe. `self`'s body is `$` (`@base="ξ"`), and inlining `$` into a nested formation changes its meaning, since `ξ` inside `say-hello` refers to `say-hello`, not to `jeff`. The fix has to suppress the warning specifically for that shape.

## Fix

`src/main/resources/org/eolang/lints/misc/redundant-object.xsl`: add a second regex that captures only references reached through a parent hop (`^ξ\.ρ(?:\.ρ)*\.<name>(?:\.[\w-]+)*$`), and skip the warning when the candidate's `@base="ξ"` **and** at least one of its usages matches that nested-reference regex. Same-level usages of a `$`-alias remain flagged because they can be safely inlined.

## Test

Added pack `redundant-object/allows-self-reused-in-nested-formation.yaml` with the exact snippet from the issue, asserting zero defects. It fails on the pre-fix XSL and passes after.

## CI

Lint-only checks (`qulice`, `pdd`, `ort`, `xcop`, `yamllint`, `markdown-lint`, `vale`, `actionlint`, `shellcheck`, `reuse`, `copyrights`, `bashate`, `typos`, `labeler`) all pass.

The `mvn` matrix, `deep`, and `reserved` jobs are red, but they are red on `master` too — every push since 2026-04-25 has failed them (run 24960783274 on master, your most recent push, fails the same way). The failures are timeouts in `MonoLintsTest.lintsProgramCorrectly` and `PkByXslTest.doesNotDuplicateDefectsWhenMultipleDefectsOnTheSameLine` after 45s, which I reproduced locally on a clean checkout of `master` before applying my fix. Happy to open a separate ticket for the timeouts if useful.

## Test plan

- [x] New pack `allows-self-reused-in-nested-formation.yaml` reproduces the issue and passes after the fix.
- [x] All other `redundant-object` packs still pass (8 allow + 7 catch).
- [x] Full `LtByXslTest` passes locally (357 tests, 1 skipped).

Ready for merge.