### PR TITLE
Fix #637: recognise rho-walking references as void-attr usages

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/unused-void-attr.xsl
+++ b/src/main/resources/org/eolang/lints/misc/unused-void-attr.xsl
@@ -3,7 +3,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
  * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="unused-void-attr" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="unused-void-attr" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
@@ -14,7 +14,18 @@
       <xsl:for-each select="//o[@base='∅']">
         <xsl:variable name="attr" select="@name"/>
         <xsl:variable name="formation" select=".."/>
-        <xsl:if test="not($attr='φ') and not(eo:atom($formation)) and not($formation//o[contains(@base, concat('ξ.', $attr))]/ancestor::o[eo:abstract(.)][1][generate-id()=$formation/generate-id()]) and not($formation//o[eo:atom(.)])">
+        <xsl:variable name="pattern" select="concat('^ξ(\.ρ)*\.', $attr, '(\..*)?$')"/>
+        <xsl:variable name="usages" as="element()*">
+          <xsl:for-each select="$formation//o[matches(@base, $pattern)]">
+            <xsl:variable name="rhos" select="replace(@base, concat('^ξ((\.ρ)*)\.', $attr, '.*$'), '$1')"/>
+            <xsl:variable name="hops" select="string-length($rhos) - string-length(translate($rhos, 'ρ', ''))" as="xs:integer"/>
+            <xsl:variable name="anchor" select="ancestor::o[eo:abstract(.)][position() = $hops + 1]"/>
+            <xsl:if test="exists($anchor) and generate-id($anchor) = generate-id($formation)">
+              <xsl:sequence select="."/>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:variable>
+        <xsl:if test="not($attr='φ') and not(eo:atom($formation)) and empty($usages) and not($formation//o[eo:atom(.)])">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/allows-usage-as-nested-rho-ref.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/allows-usage-as-nested-rho-ref.yaml
@@ -4,8 +4,7 @@
 sheets:
   - /org/eolang/lints/misc/unused-void-attr.xsl
 asserts:
-  - /defects[count(defect[@severity='warning'])=1]
-  - /defects/defect[@line='2']
+  - /defects[count(defect[@severity='warning'])=0]
 input: |
   # Foo
   [x] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/allows-void-attr-used-in-nested-formation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/allows-void-attr-used-in-nested-formation.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Regression test for objectionary/lints#637.
+# The void attribute "widths" of "tabular" is referenced from inside the
+# nested "[i] > inner" formation as "widths.at i", which the parser turns
+# into "ξ.ρ.widths.at". The lint must recognise this rho-walking reference
+# as a real usage and not flag "widths" as unused.
+sheets:
+  - /org/eolang/lints/misc/unused-void-attr.xsl
+asserts:
+  - /defects[count(defect[contains(., '"widths"')])=0]
+input: |
+  # Foo.
+  [widths] > tabular
+    [i] > inner
+      widths.at i > @


### PR DESCRIPTION
@yegor256

Closes #637.

## Why

The `unused-void-attr` lint flagged a void attribute as unused even when it was clearly referenced from inside a nested formation. For example:

```eo
# Foo.
[widths] > tabular
  [i] > inner
    widths.at i > @
```

It warned that `widths` is unused, but `widths.at i` inside the inner `[i]` formation _is_ a usage — it just walks back through one `ρ` hop to reach `tabular`.

The XSL only checked for the literal substring `ξ.<attr>` in `@base`, so any reference parsed as `ξ.ρ.<attr>`, `ξ.ρ.ρ.<attr>`, etc. slipped past it.

## How

* `src/main/resources/org/eolang/lints/misc/unused-void-attr.xsl` — match `^ξ(.ρ)*.<attr>(...)?$`, count the `ρ` hops, and confirm that the formation declaring the attribute is exactly that many enclosing abstract scopes above the usage. References that walk past the formation, or that resolve into a different scope, still leave the attribute flagged as unused.
* `src/test/resources/.../allows-void-attr-used-in-nested-formation.yaml` — new regression test covering the bug from the issue (`widths.at i` from inside a nested formation).
* `src/test/resources/.../allows-usage-as-nested-rho-ref.yaml` — the previously-named `catches-usage-as-nested-rho-ref` pack was locking in the buggy behaviour, so it is renamed and its assertion flipped: `^.x` from a nested formation _is_ a real usage of the outer `x`.

All the existing shadowing tests (`catches-unused-void-attribute-with-same-named-formation`, `catches-unused-void-attribute-horizontally-with-same-name`, `catches-void-with-same-name-in-canonical`, `catches-unused-void-attr`) keep passing, because rho-walking is structural rather than name-based: an inner formation that declares its own `x` as void does not absorb the outer scope’s `ξ.ρ.ρ.x`.

## How verified

* `mvn -B test -Dtest=LtByXslTest#testsAllLintsByEo` — 345 packs pass, 1 skipped (unchanged).
* Manual run of `Source(...).defects(...)` on the snippet from #637: no `unused-void-attr` warning is emitted any more.

## Note about CI

The `mvn (ubuntu/macos/windows)`, `deep`, and `reserved` jobs are red on this PR, but they have been red on every `master` commit since 2026-04-26 (last green run #2202 on 2026-04-24). I confirmed locally that the same two tests time out on plain master too: `MonoLintsTest.lintsProgramCorrectly` and `PkByXslTest.doesNotDuplicateDefectsWhenMultipleDefectsOnTheSameLine`. Those failures are not introduced by this change.