### PR TITLE
#520: replace new ArrayList<>(0) with new ArrayList<>()

### DIFF
--- a/src/main/java/org/eolang/lints/LtAsciiOnly.java
+++ b/src/main/java/org/eolang/lints/LtAsciiOnly.java
@@ -20,17 +20,13 @@ import java.util.stream.Collectors;
  *  For now we just reusing object line number (via @line), which is not correct
  *  for specifying on which line of the program comment is located. This issue
  *  can be solved after <a href="https://github.com/objectionary/eo/issues/3536">this one</a>.
- * @todo #402:15min Replace the creation of new ArrayList<>(0) with the creation of
- *  ArrayList<>() without a constructor argument in whole project. Add ignore warning
- *  ConditionalRegexpMultilineCheck from Checkstyle (it doesn't seem to be possible at the moment
- *  <a href="https://github.com/yegor256/qulice/issues/1328">issue 1328</a>)
  * @checkstyle StringLiteralsConcatenationCheck (30 lines)
  */
 final class LtAsciiOnly implements Lint {
 
     @Override
     public Collection<Defect> defects(final XML xmir) throws IOException {
-        final Collection<Defect> defects = new ArrayList<>(0);
+        final Collection<Defect> defects = new ArrayList<>();
         final Xnav xml = new Xnav(xmir.inner());
         final List<Xnav> comments = xml.path("/object/comments/comment")
             .collect(Collectors.toList());

--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -111,7 +111,7 @@ final class LtByXsl implements Lint {
 
     @Override
     public Collection<Defect> defects(final XML xmir) {
-        final Collection<Defect> defects = new ArrayList<>(0);
+        final Collection<Defect> defects = new ArrayList<>();
         for (final XML defect : LtByXsl.findDefects(this.sheet.value().transform(xmir))) {
             final Xnav xml = new Xnav(defect.inner());
             final Optional<String> sever = xml.attribute("severity").text();

--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -46,7 +46,7 @@ final class LtUnlint implements Lint {
 
     @Override
     public Collection<Defect> defects(final XML xmir) throws IOException {
-        final Collection<Defect> defects = new ArrayList<>(0);
+        final Collection<Defect> defects = new ArrayList<>();
         final String lname = this.origin.name();
         final Collection<Defect> found = this.origin.defects(xmir);
         final List<Integer> problematic = found.stream()

--- a/src/main/java/org/eolang/lints/Source.java
+++ b/src/main/java/org/eolang/lints/Source.java
@@ -89,7 +89,7 @@ public final class Source {
      */
     public Collection<Defect> defects() {
         try {
-            final Collection<Defect> messages = new ArrayList<>(0);
+            final Collection<Defect> messages = new ArrayList<>();
             for (final Lint lint : this.lints) {
                 messages.addAll(new ScopedDefects(lint.defects(this.xmir), "S"));
             }

--- a/src/test/java/matchers/DefectMatcher.java
+++ b/src/test/java/matchers/DefectMatcher.java
@@ -21,7 +21,7 @@ public final class DefectMatcher extends BaseMatcher<Defect> {
     /**
      * Synthetic matcher that is built when input arrives.
      */
-    private final List<Matcher<?>> matchers = new ArrayList<>(0);
+    private final List<Matcher<?>> matchers = new ArrayList<>();
 
     @Override
     public boolean matches(final Object input) {

--- a/src/test/java/matchers/DefectsMatcher.java
+++ b/src/test/java/matchers/DefectsMatcher.java
@@ -27,7 +27,7 @@ public final class DefectsMatcher extends BaseMatcher<XML> {
 
     @Override
     public boolean matches(final Object xml) {
-        final Collection<Defect> defects = new ArrayList<>(0);
+        final Collection<Defect> defects = new ArrayList<>();
         for (final XML defect : ((XML) xml).nodes("/defects/defect")) {
             defects.add(
                 new Defect.Default(

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -518,7 +518,7 @@ final class SourceTest {
      * @return Benchmark results
      */
     private static Map<Map<SourceSize, Collection<Defect>>, String> benchmarkResults() {
-        final List<Map<SourceSize, Collection<Defect>>> results = new ArrayList<>(0);
+        final List<Map<SourceSize, Collection<Defect>>> results = new ArrayList<>();
         final StringBuilder sum = new StringBuilder();
         for (final SourceSize source : SourceSize.values()) {
             final long before = System.currentTimeMillis();
@@ -617,7 +617,7 @@ final class SourceTest {
          */
         Collection<Defect> defects() {
             try {
-                final Collection<Defect> messages = new ArrayList<>(0);
+                final Collection<Defect> messages = new ArrayList<>();
                 for (final Lint lint : this.lints) {
                     messages.addAll(this.timed(lint));
                 }


### PR DESCRIPTION
Closes #520

Replace `new ArrayList<>(0)` with `new ArrayList<>()` across 7 files. The initial capacity argument `0` is redundant — `ArrayList` defaults to an empty backing array and grows on first element addition either way.
