### PR TITLE
Fix #640: recognize chained-dot usage of $-aliased attributes

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
@@ -13,7 +13,8 @@
       <xsl:variable name="top" select="/object/o/generate-id()"/>
       <xsl:for-each select="//o[generate-id() != $top and @name and @name != 'φ' and @base and @base != '∅' and not(@base='ξ' and @name='xi🌵')]">
         <xsl:variable name="usage" select="concat('^ξ(?:\.ρ)*\.', @name, '(?:\.[\w-]+)*$')"/>
-        <xsl:if test="count(//o[matches(@base, $usage)])&lt;=1 and not(@name and o[1]/@base = 'Φ.dataized')">
+        <xsl:variable name="chained-usage" select="concat('^\.', @name, '(?:\.[\w-]+)*$')"/>
+        <xsl:if test="count(//o[matches(@base, $usage)])&lt;=1 and not(@base='ξ' and count(//o[matches(@base, $chained-usage)])&gt;=1) and not(@name and o[1]/@base = 'Φ.dataized')">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-self-used-via-chained-dot.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-self-used-via-chained-dot.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/redundant-object.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # Bytes as input.
+  [bts] > bytes-as-input
+    # Read 'size' amount of bytes from 'bts'.
+    [size] > read
+      ((input-block bts --).read size).self > @
+      # Bytes-as-input block.
+      [data buffer] > input-block
+        buffer > @
+        $ > self


### PR DESCRIPTION
Fixes #640.

## The bug

`redundant-object` flags `self` as redundant for the snippet from the issue:

```eo
[bts] > bytes-as-input
  [size] > read
    ((input-block bts --).read size).self > @
    [data buffer] > input-block
      buffer > @
      $ > self
```

The XMIR shows the only reference to `self` as `<o base=".self"/>` (a chained method call on the result of `(input-block bts --).read size`), but the existing usage XPath only matches `@base` values starting with `ξ`:

```
^ξ(?:\.ρ)*\.self(?:\.[\w-]+)*$
```

So the count of usages stays at 0, the `<= 1` condition fires, and the lint emits *"The object self is redundant and may be inlined"* — but inlining is impossible here, since `self` aliases `$` and `(...).$` is not valid EO.

## Fix

`src/main/resources/org/eolang/lints/misc/redundant-object.xsl`: add a second regex matching the chained-dot usage form (`^\.<name>(?:\.[\w-]+)*$`), and skip the warning when the candidate's `@base='ξ'` **and** at least one chained-dot usage exists. Same-level redundant aliases stay flagged because their usages still appear under the `ξ.<name>` shape, so all existing `catches-*` packs continue to fire.

## Test

New pack `allows-self-used-via-chained-dot.yaml` reproduces the issue example and asserts zero defects. Without the XSL change it fails with the *"self is redundant"* warning; with the change it passes. The full `LtByXslTest#testsAllLintsByEo` parameterized suite (346 packs) is green.