### PR TITLE
#560: route object names through eo:escape in defect messages

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/pos-without-line.xsl
+++ b/src/main/resources/org/eolang/lints/critical/pos-without-line.xsl
@@ -25,7 +25,7 @@
             <xsl:text>critical</xsl:text>
           </xsl:attribute>
           <xsl:text>Object </xsl:text>
-          <xsl:value-of select="@name"/>
+          <xsl:value-of select="eo:escape(@name)"/>
           <xsl:text> have the "@pos" attribute, but the "@line" attribute is absent</xsl:text>
         </xsl:element>
       </xsl:for-each>

--- a/src/main/resources/org/eolang/lints/misc/duplicate-names-in-diff-context.xsl
+++ b/src/main/resources/org/eolang/lints/misc/duplicate-names-in-diff-context.xsl
@@ -5,6 +5,7 @@
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="duplicate-names-in-diff-context">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:import href="/org/eolang/funcs/special-name.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
@@ -23,9 +24,9 @@
               </xsl:attribute>
             </xsl:if>
             <xsl:attribute name="severity">warning</xsl:attribute>
-            <xsl:text>Object "</xsl:text>
-            <xsl:value-of select="@name"/>
-            <xsl:text>" has the same name as </xsl:text>
+            <xsl:text>Object </xsl:text>
+            <xsl:value-of select="eo:escape(@name)"/>
+            <xsl:text> has the same name as </xsl:text>
             <xsl:variable name="lines" select="current-group()/@line[. and . != current()/@line]"/>
             <xsl:variable name="empty" select="count($lines) != count(current-group()) - 1"/>
             <xsl:if test="count($lines) &gt; 0">

--- a/src/test/resources/org/eolang/lints/packs/single/duplicate-names-in-diff-context/escapes-name-in-defect-message.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/duplicate-names-in-diff-context/escapes-name-in-defect-message.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/lints/misc/duplicate-names-in-diff-context.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[contains(normalize-space(), 'Object "foo\x22bar" has the same name as')]
+document: |
+  <object author="tests">
+    <o>
+      <o>
+        <o name='foo&quot;bar' line="3"/>
+      </o>
+      <o>
+        <o name='foo&quot;bar' line="6"/>
+      </o>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/pos-without-line/escapes-name-in-defect-message.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/pos-without-line/escapes-name-in-defect-message.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/lints/critical/pos-without-line.xsl
+asserts:
+  - /defects[count(defect[@severity='critical'])=1]
+  - /defects/defect[normalize-space()='Object "foo\x22bar" have the "@pos" attribute, but the "@line" attribute is absent']
+document: |
+  <object author="tests">
+    <o pos="3" name='foo&quot;bar'/>
+  </object>


### PR DESCRIPTION
yegor256, this PR fixes #560 - object names in defect messages now go through `eo:escape(...)`.

## What changed

Two single-source lints rendered object names directly from `@name` instead of going through `eo:escape(...)`:

* `src/main/resources/org/eolang/lints/critical/pos-without-line.xsl:28` — printed the bare `@name` with no quoting at all (`Object foo have the "@pos" attribute, ...`).
* `src/main/resources/org/eolang/lints/misc/duplicate-names-in-diff-context.xsl:27` — wrapped `@name` in literal `"` characters but did not call `eo:escape`, so spaces were not converted to `⌴` and embedded `"` characters were left unescaped.

This PR routes both through `eo:escape(@name)`. For names that are plain lowercase identifiers — every name produced by the EO parser today — the rendered text is byte-identical to before, so the existing single-pack assertions (`'Object "hello" has the same name as the objects on the lines 6, 8, 10'`, `'Object "s" has the same name as the objects on the lines 11'`, etc.) still hold. For a name with an embedded `"` the message now renders as `Object "foo\x22bar" ...` instead of being dropped on the floor.

## Tests

Two new YAML packs under `src/test/resources/org/eolang/lints/packs/single/...` exercise the escape path with XMIR documents that use the entity-encoded form `name='foo&quot;bar'`:

* `pos-without-line/escapes-name-in-defect-message.yaml`
* `duplicate-names-in-diff-context/escapes-name-in-defect-message.yaml`

Both fail on master (the rendered text contains the bare `foo"bar`, not the escaped `"foo\x22bar"`) and pass with the XSL change applied. They are picked up by the parameterized `LtByXslTest.testsAllLintsByEo`, which runs all 359 single-pack assertions; locally that test reports `Tests run: 359, Failures: 0, Errors: 0, Skipped: 1` after this change.

## CI status

The `mvn (×3 OS)`, `deep`, and `reserved` jobs fail on this branch. They are pre-existing failures that have been red on `master` since 2026-04-25 (commit `820cb36b`, the qulice 0.27.1 bump): `master`'s `mvn install` times out in `PkByXslTest.doesNotDuplicateDefectsWhenMultipleDefectsOnTheSameLine` after 45s. I reproduced the same failure by running `mvn clean install -ntp -PskipITs --errors --batch-mode` against `master` locally with no XSL changes — same timeout, same stack — so the redness is unrelated to this PR. Every fast check on this PR (`qulice`, `xcop`, `pdd`, `markdown-lint`, `yamllint`, `actionlint`, `bashate`, `shellcheck`, `vale`, `typos`, `reuse`, `ort`, `copyrights`, `labeler`) is green.
