### PR TITLE
#861: exclude λ marker from not-empty-atom lint

### DIFF
--- a/src/main/resources/org/eolang/lints/atoms/not-empty-atom.xsl
+++ b/src/main/resources/org/eolang/lints/atoms/not-empty-atom.xsl
@@ -11,7 +11,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[eo:atom(.) and o[@base and @base!='∅' and not(@base='ξ' and @name='xi🌵')]]">
+      <xsl:for-each select="//o[eo:atom(.) and o[@base and @base!='∅' and not(@name='λ') and not(@base='ξ' and @name='xi🌵')]]">
         <xsl:element name="defect">
           <xsl:variable name="line" select="eo:lineno(@line)"/>
           <xsl:attribute name="line">
@@ -28,7 +28,7 @@
           <xsl:text>The atom </xsl:text>
           <xsl:value-of select="eo:escape(@name)"/>
           <xsl:text> may not have any attributes, which however exist: </xsl:text>
-          <xsl:for-each select="o[@base]">
+          <xsl:for-each select="o[@base and not(@name='λ')]">
             <xsl:if test="position() &gt; 1">
               <xsl:text>, </xsl:text>
             </xsl:if>

--- a/src/test/resources/org/eolang/lints/packs/single/not-empty-atom/allows-atom-with-typed-lambda.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/not-empty-atom/allows-atom-with-typed-lambda.yaml
@@ -4,12 +4,10 @@
 sheets:
   - /org/eolang/lints/atoms/not-empty-atom.xsl
 asserts:
-  - /defects[count(defect[@severity='error'])=1]
-  - /defects/defect[@line='1']
+  - /defects[count(defect)=0]
 document: |
   <object author="tests">
-    <o line="1" name="number">
-      <o base="∅" name="λ"/>
-      <o base="Φ.f" name="x"/>
+    <o name="times">
+      <o base="Φ.number" name="λ"/>
     </o>
   </object>

--- a/src/test/resources/org/eolang/lints/packs/single/not-empty-atom/prints-context-when-lines-empty.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/not-empty-atom/prints-context-when-lines-empty.yaml
@@ -8,6 +8,7 @@ asserts:
 document: |
   <object author="tests">
     <o name="number">
-      <o base="Φ.foo" name="λ"/>
+      <o base="∅" name="λ"/>
+      <o base="Φ.foo" name="x"/>
     </o>
   </object>


### PR DESCRIPTION
Closes #861.

The `not-empty-atom` lint (`src/main/resources/org/eolang/lints/atoms/not-empty-atom.xsl`) used to flag every atom whose `λ` marker carried a non-empty `@base`. After the restoration of the `/name` return-type syntax in `objectionary/eo` (objectionary/eo#4707), atoms like `[] > times /number` produce XMIR with `<o base="number" name="λ"/>`, which the previous XPath treated as a regular inner object. The fix adds `not(@name='λ')` to the predicate (mirroring the existing `@name='xi🌵'` exclusion) so that the λ marker is recognized as part of the atom syntax in both the outer match and the inner listing.

Tests:

- New `allows-atom-with-typed-lambda.yaml` — atom with `<o base="Φ.number" name="λ"/>` → 0 defects (regression for the bug).
- Updated `catches-empty-atom.yaml` and `prints-context-when-lines-empty.yaml` — they continue to assert that the lint fires when the atom has a real non-`λ` inner object alongside the (now valid) `λ` marker.

After this lint is released, `objectionary/eo` can bump the dependency in `eo-maven-plugin/pom.xml` and drop the `+unlint not-empty-atom` lines from the 22 affected `.eo` files in `eo-runtime` (puzzle `4707-ff431d75` / objectionary/eo#5091).
