### PR TITLE
refactor(#874): introduce `EoProgram` helper to simplify test parsing

### DIFF
--- a/src/test/java/fixtures/EoProgram.java
+++ b/src/test/java/fixtures/EoProgram.java
@@ -8,6 +8,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import org.cactoos.io.ResourceOf;
@@ -50,7 +51,11 @@ public final class EoProgram {
      */
     public XML parse() {
         try {
-            return EoProgram.CACHE.get(this.resource, () -> EoProgram.doParse(this.resource));
+            return new XMLDocument(
+                EoProgram.CACHE.get(
+                    this.resource, () -> EoProgram.doParse(this.resource)
+                ).deepCopy()
+            );
         } catch (final ExecutionException ex) {
             throw new IllegalStateException(
                 String.format("Failed to parse EO resource '%s'", this.resource),

--- a/src/test/java/fixtures/EoProgram.java
+++ b/src/test/java/fixtures/EoProgram.java
@@ -65,6 +65,7 @@ public final class EoProgram {
      * @return Parsed XMIR document
      * @throws IOException If parsing fails
      */
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private static XML doParse(final String res) throws IOException {
         final long start = System.currentTimeMillis();
         final XML xmir = new EoSyntax(new ResourceOf(res)).parsed();

--- a/src/test/java/fixtures/EoProgram.java
+++ b/src/test/java/fixtures/EoProgram.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package fixtures;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.jcabi.log.Logger;
+import com.jcabi.xml.XML;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import org.cactoos.io.ResourceOf;
+import org.eolang.parser.EoSyntax;
+
+/**
+ * Parsed EO program from a classpath resource, with bounded in-memory caching.
+ * @since 0.2.0
+ */
+public final class EoProgram {
+
+    /**
+     * Maximum number of cached entries.
+     */
+    private static final int MAX = 1000;
+
+    /**
+     * Cache of parsed XMIR documents, keyed by resource path.
+     */
+    private static final Cache<String, XML> CACHE = CacheBuilder.newBuilder()
+        .maximumSize(EoProgram.MAX)
+        .build();
+
+    /**
+     * Resource path.
+     */
+    private final String resource;
+
+    /**
+     * Constructor.
+     * @param res Classpath resource path to the EO source file
+     */
+    public EoProgram(final String res) {
+        this.resource = res;
+    }
+
+    /**
+     * Parse the EO resource into XMIR, using the cache when available.
+     * @return Parsed XMIR document
+     */
+    public XML parse() {
+        try {
+            return EoProgram.CACHE.get(this.resource, () -> EoProgram.doParse(this.resource));
+        } catch (final ExecutionException ex) {
+            throw new IllegalStateException(
+                String.format("Failed to parse EO resource '%s'", this.resource),
+                ex
+            );
+        }
+    }
+
+    /**
+     * Perform the actual parse and log timing.
+     * @param res Resource path to parse
+     * @return Parsed XMIR document
+     * @throws IOException If parsing fails
+     */
+    private static XML doParse(final String res) throws IOException {
+        final long start = System.currentTimeMillis();
+        final XML xmir = new EoSyntax(new ResourceOf(res)).parsed();
+        Logger.info(
+            EoProgram.class,
+            "Parsed '%s': %dms",
+            res,
+            System.currentTimeMillis() - start
+        );
+        return xmir;
+    }
+}

--- a/src/test/java/org/eolang/lints/LtAlwaysTest.java
+++ b/src/test/java/org/eolang/lints/LtAlwaysTest.java
@@ -4,9 +4,7 @@
  */
 package org.eolang.lints;
 
-import java.io.IOException;
-import org.cactoos.io.ResourceOf;
-import org.eolang.parser.EoSyntax;
+import fixtures.EoProgram;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -18,14 +16,10 @@ import org.junit.jupiter.api.Test;
 final class LtAlwaysTest {
 
     @Test
-    void complainsAlways() throws IOException {
+    void complainsAlways() {
         MatcherAssert.assertThat(
             "didn't return one defect",
-            new LtAlways().defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/first-foo.eo")
-                ).parsed()
-            ),
+            new LtAlways().defects(new EoProgram("org/eolang/lints/first-foo.eo").parse()),
             Matchers.hasSize(1)
         );
     }

--- a/src/test/java/org/eolang/lints/LtAsciiOnlyTest.java
+++ b/src/test/java/org/eolang/lints/LtAsciiOnlyTest.java
@@ -4,11 +4,11 @@
  */
 package org.eolang.lints;
 
+import fixtures.EoProgram;
 import java.io.IOException;
 import matchers.DefectMatcher;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
-import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
@@ -25,9 +25,7 @@ final class LtAsciiOnlyTest {
         MatcherAssert.assertThat(
             "non-ascii comment is not welcome",
             new LtAsciiOnly().defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/non-ascii-cyrillic.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/non-ascii-cyrillic.eo").parse()
             ),
             Matchers.allOf(
                 Matchers.<Defect>iterableWithSize(Matchers.greaterThan(0)),
@@ -42,9 +40,7 @@ final class LtAsciiOnlyTest {
             "non-ascii comment error should contain abusive character",
             new ListOf<>(
                 new LtAsciiOnly().defects(
-                    new EoSyntax(
-                        new ResourceOf("org/eolang/lints/non-ascii-cyrillic.eo")
-                    ).parsed()
+                    new EoProgram("org/eolang/lints/non-ascii-cyrillic.eo").parse()
                 )
             ).get(0).text(),
             Matchers.containsString("Only ASCII characters are allowed in comments")
@@ -52,7 +48,7 @@ final class LtAsciiOnlyTest {
     }
 
     @Test
-    void explainsMotive() throws Exception {
+    void explainsMotive() throws IOException {
         MatcherAssert.assertThat(
             "The motive doesn't contain expected string",
             new LtAsciiOnly().motive().contains("# ASCII-Only Characters in Comments"),
@@ -61,13 +57,11 @@ final class LtAsciiOnlyTest {
     }
 
     @Test
-    void setsRuleCorrectly() throws Exception {
+    void setsRuleCorrectly() throws IOException {
         MatcherAssert.assertThat(
             "The rule name is set right",
             new LtAsciiOnly().defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/non-ascii-tuk-tuk.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/non-ascii-tuk-tuk.eo").parse()
             ).iterator().next().rule(),
             Matchers.equalTo("ascii-only")
         );
@@ -78,9 +72,7 @@ final class LtAsciiOnlyTest {
         MatcherAssert.assertThat(
             "The lint should complain as warning",
             new LtAsciiOnly().defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/non-ascii-chinese.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/non-ascii-chinese.eo").parse()
             ).iterator().next().severity(),
             Matchers.equalTo(Severity.WARNING)
         );

--- a/src/test/java/org/eolang/lints/LtAsciiOnlyTest.java
+++ b/src/test/java/org/eolang/lints/LtAsciiOnlyTest.java
@@ -7,7 +7,6 @@ package org.eolang.lints;
 import fixtures.EoProgram;
 import java.io.IOException;
 import matchers.DefectMatcher;
-import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -64,6 +64,7 @@ import org.yaml.snakeyaml.Yaml;
  *  Audit all fixture files for content duplicates and consolidate where possible, updating
  *  test references to point to the surviving canonical file. This reduces maintenance
  *  burden and avoids subtle divergence between "the same" EO program defined twice.
+ * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
 @SuppressWarnings("PMD.TooManyMethods")
 final class LtByXslTest {

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -10,6 +10,7 @@ import com.jcabi.manifests.Manifests;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XMLDocument;
 import fixtures.BytecodeClass;
+import fixtures.EoProgram;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -68,13 +69,11 @@ import org.yaml.snakeyaml.Yaml;
 final class LtByXslTest {
 
     @Test
-    void lintsOneFile() throws IOException {
+    void lintsOneFile() {
         MatcherAssert.assertThat(
             "No defects found, while a few of them expected",
             new LtByXsl("critical/duplicate-names").defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/duplicate-names.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/duplicate-names.eo").parse()
             ),
             Matchers.hasSize(Matchers.greaterThan(0))
         );
@@ -214,14 +213,12 @@ final class LtByXslTest {
     }
 
     @Test
-    void returnsNonExperimentalWhenXslStaysQuiet() throws IOException {
+    void returnsNonExperimentalWhenXslStaysQuiet() {
         MatcherAssert.assertThat(
             "Experimental flag should be set to false",
             new ListOf<>(
                 new LtByXsl("comments/comment-without-dot").defects(
-                    new EoSyntax(
-                        new ResourceOf("org/eolang/lints/foo-without-dot.eo")
-                    ).parsed()
+                    new EoProgram("org/eolang/lints/foo-without-dot.eo").parse()
                 )
             ).get(0).experimental(),
             Matchers.equalTo(false)
@@ -264,11 +261,9 @@ final class LtByXslTest {
     }
 
     @Test
-    void doesNotDuplicateDefectsWhenMultipleDefectsOnTheSameLine() throws Exception {
+    void doesNotDuplicateDefectsWhenMultipleDefectsOnTheSameLine() {
         final Collection<Defect> defects = new LtByXsl("misc/unused-void-attr").defects(
-            new EoSyntax(
-                new ResourceOf("org/eolang/lints/unused-voids.eo")
-            ).parsed()
+            new EoProgram("org/eolang/lints/unused-voids.eo").parse()
         );
         MatcherAssert.assertThat(
             Logger.format(

--- a/src/test/java/org/eolang/lints/LtIncorrectUnlintTest.java
+++ b/src/test/java/org/eolang/lints/LtIncorrectUnlintTest.java
@@ -4,10 +4,10 @@
  */
 package org.eolang.lints;
 
+import fixtures.EoProgram;
 import java.io.IOException;
 import java.util.List;
 import matchers.DefectMatcher;
-import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
@@ -21,13 +21,11 @@ import org.junit.jupiter.api.Test;
 final class LtIncorrectUnlintTest {
 
     @Test
-    void catchesIncorrectUnlints() throws Exception {
+    void catchesIncorrectUnlints() throws IOException {
         MatcherAssert.assertThat(
             "unlint must point to existing lint",
             new LtIncorrectUnlint(List.of("hello")).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/incorrect-unlints.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/incorrect-unlints.eo").parse()
             ),
             Matchers.allOf(
                 Matchers.<Defect>iterableWithSize(2),
@@ -37,13 +35,11 @@ final class LtIncorrectUnlintTest {
     }
 
     @Test
-    void allowsCorrectUnlints() throws Exception {
+    void allowsCorrectUnlints() throws IOException {
         MatcherAssert.assertThat(
             "Defects are not empty, but they shouldn't be",
             new LtIncorrectUnlint(List.of("ascii-only")).defects(
-                new EoSyntax(
-                    "+unlint ascii-only"
-                ).parsed()
+                new EoSyntax("+unlint ascii-only").parsed()
             ),
             Matchers.emptyIterable()
         );
@@ -55,9 +51,7 @@ final class LtIncorrectUnlintTest {
             "Lint text doesn't contain clear message to the reader",
             new ListOf<>(
                 new LtIncorrectUnlint(List.of("hello")).defects(
-                    new EoSyntax(
-                        new ResourceOf("org/eolang/lints/unlint-boom.eo")
-                    ).parsed()
+                    new EoProgram("org/eolang/lints/unlint-boom.eo").parse()
                 )
             ).get(0).text(),
             Matchers.containsString("Suppressing \"boom\" does not make sense")
@@ -69,9 +63,7 @@ final class LtIncorrectUnlintTest {
         MatcherAssert.assertThat(
             "Unlints with line number should be supported",
             new LtIncorrectUnlint(new ListOf<>("comment-not-capitalized")).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-with-line-number.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/unlint-with-line-number.eo").parse()
             ),
             Matchers.emptyIterable()
         );
@@ -82,9 +74,7 @@ final class LtIncorrectUnlintTest {
         MatcherAssert.assertThat(
             "Non existing unlint with line number should be caught",
             new LtIncorrectUnlint(new ListOf<>("a")).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-non-existing-with-line.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/unlint-non-existing-with-line.eo").parse()
             ),
             Matchers.hasSize(Matchers.greaterThan(0))
         );

--- a/src/test/java/org/eolang/lints/LtReservedNameTest.java
+++ b/src/test/java/org/eolang/lints/LtReservedNameTest.java
@@ -4,9 +4,9 @@
  */
 package org.eolang.lints;
 
+import fixtures.EoProgram;
 import java.io.IOException;
 import java.util.Collection;
-import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
 import org.cactoos.map.MapEntry;
 import org.cactoos.map.MapOf;
@@ -27,9 +27,7 @@ final class LtReservedNameTest {
         MatcherAssert.assertThat(
             "It is expected to catch only one defect here",
             new LtReservedName(new MapOf<>("true", "true.eo")).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/reserved-qqq.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/reserved-qqq.eo").parse()
             ),
             Matchers.hasSize(1)
         );
@@ -40,9 +38,7 @@ final class LtReservedNameTest {
         MatcherAssert.assertThat(
             "Defects are not empty, but they should",
             new LtReservedName(new MapOf<>("true", "true.eo")).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/non-reserved-x.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/non-reserved-x.eo").parse()
             ),
             Matchers.emptyIterable()
         );
@@ -53,9 +49,7 @@ final class LtReservedNameTest {
         MatcherAssert.assertThat(
             "Defects are not empty, but they should",
             new LtReservedName(new MapOf<>("f", "f.eo")).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/non-reserved-top.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/non-reserved-top.eo").parse()
             ),
             Matchers.emptyIterable()
         );
@@ -65,11 +59,7 @@ final class LtReservedNameTest {
     void catchesReservedNameWithPackage() throws IOException {
         final Collection<Defect> found = new LtReservedName(
             new MapOf<>("stdout", "stdout.eo")
-        ).defects(
-            new EoSyntax(
-                new ResourceOf("org/eolang/lints/reserved-with-package.eo")
-            ).parsed()
-        );
+        ).defects(new EoProgram("org/eolang/lints/reserved-with-package.eo").parse());
         final int expected = 1;
         MatcherAssert.assertThat(
             String.format(
@@ -90,11 +80,7 @@ final class LtReservedNameTest {
                     new MapEntry<>("ja", "ja.eo"),
                     new MapEntry<>("spb", "spb.eo")
                 )
-            ).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/reserved-ja-spb.eo")
-                ).parsed()
-            ),
+            ).defects(new EoProgram("org/eolang/lints/reserved-ja-spb.eo").parse()),
             Matchers.hasSize(2)
         );
     }
@@ -105,11 +91,7 @@ final class LtReservedNameTest {
             "Defects size does not match with expected",
             new LtReservedName(
                 new MapOf<>("foo", "foo.eo")
-            ).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/reserved-foo-spb.eo")
-                ).parsed()
-            ),
+            ).defects(new EoProgram("org/eolang/lints/reserved-foo-spb.eo").parse()),
             Matchers.hasSize(1)
         );
     }
@@ -121,11 +103,7 @@ final class LtReservedNameTest {
             new ListOf<>(
                 new LtReservedName(
                     new MapOf<>("foo", "foo.eo")
-                ).defects(
-                    new EoSyntax(
-                        new ResourceOf("org/eolang/lints/reserved-foo-spb.eo")
-                    ).parsed()
-                )
+                ).defects(new EoProgram("org/eolang/lints/reserved-foo-spb.eo").parse())
             ).get(0).text(),
             Matchers.equalTo(
                 "Object name \"foo\" is already reserved by object in the \"foo.eo\""
@@ -139,9 +117,7 @@ final class LtReservedNameTest {
         MatcherAssert.assertThat(
             "Defects size does not match with expected",
             new LtReservedName().defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/reserved-bar-stdout.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/reserved-bar-stdout.eo").parse()
             ),
             Matchers.hasSize(1)
         );
@@ -154,9 +130,7 @@ final class LtReservedNameTest {
             "Defect message does not match with expected",
             new ListOf<>(
                 new LtReservedName().defects(
-                    new EoSyntax(
-                        new ResourceOf("org/eolang/lints/reserved-baz-stdout.eo")
-                    ).parsed()
+                    new EoProgram("org/eolang/lints/reserved-baz-stdout.eo").parse()
                 )
             ).get(0).text(),
             Matchers.equalTo(

--- a/src/test/java/org/eolang/lints/LtTestNotVerbTest.java
+++ b/src/test/java/org/eolang/lints/LtTestNotVerbTest.java
@@ -6,8 +6,9 @@ package org.eolang.lints;
 
 import com.yegor256.MayBeSlow;
 import com.yegor256.Together;
+import fixtures.EoProgram;
+import java.io.IOException;
 import matchers.DefectMatcher;
-import org.cactoos.io.ResourceOf;
 import org.cactoos.set.SetOf;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
@@ -142,13 +143,11 @@ final class LtTestNotVerbTest {
     @SuppressWarnings("JTCOP.RuleNotContainsTestWord")
     @Test
     @ExtendWith(MayBeSlow.class)
-    void lintsRegexTests() throws Exception {
+    void lintsRegexTests() throws IOException {
         MatcherAssert.assertThat(
             "Defects size doesn't match with expected",
             new LtTestNotVerb().defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/regex-test.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/regex-test.eo").parse()
             ),
             Matchers.hasSize(1)
         );
@@ -162,9 +161,7 @@ final class LtTestNotVerbTest {
             new SetOf<>(
                 new Together<>(
                     t -> new LtTestNotVerb().defects(
-                        new EoSyntax(
-                            new ResourceOf("org/eolang/lints/regex-match.eo")
-                        ).parsed()
+                        new EoProgram("org/eolang/lints/regex-match.eo").parse()
                     ).size()
                 ).asList()
             ).size(),

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -4,11 +4,10 @@
  */
 package org.eolang.lints;
 
+import fixtures.EoProgram;
 import java.io.IOException;
 import java.util.stream.Collectors;
-import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
-import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -27,9 +26,7 @@ final class LtUnlintNonExistingDefectTest {
                 new ListOf<>(new LtAsciiOnly()),
                 new ListOf<>()
             ).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-ascii-only-no-defect.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/unlint-ascii-only-no-defect.eo").parse()
             ),
             Matchers.hasSize(Matchers.greaterThan(0))
         );
@@ -43,9 +40,7 @@ final class LtUnlintNonExistingDefectTest {
                 new ListOf<>(new LtAsciiOnly()),
                 new ListOf<>()
             ).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-ascii-only-duplicate.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/unlint-ascii-only-duplicate.eo").parse()
             ).stream()
                 .map(Defect::line)
                 .collect(Collectors.toList()),
@@ -63,9 +58,7 @@ final class LtUnlintNonExistingDefectTest {
                 new ListOf<>(new LtAsciiOnly()),
                 new ListOf<>()
             ).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-ascii-only-chinese.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/unlint-ascii-only-chinese.eo").parse()
             ),
             Matchers.emptyIterable()
         );
@@ -79,9 +72,7 @@ final class LtUnlintNonExistingDefectTest {
                 new ListOf<>(new LtAsciiOnly()),
                 new ListOf<>()
             ).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/non-ascii-bar.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/non-ascii-bar.eo").parse()
             ),
             Matchers.emptyIterable()
         );
@@ -95,9 +86,7 @@ final class LtUnlintNonExistingDefectTest {
                 new ListOf<>(new LtAsciiOnly()),
                 new ListOf<>()
             ).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-ascii-only-line.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/unlint-ascii-only-line.eo").parse()
             ),
             Matchers.emptyIterable()
         );
@@ -111,9 +100,9 @@ final class LtUnlintNonExistingDefectTest {
                 new ListOf<>(new LtAsciiOnly()),
                 new ListOf<>()
             ).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-ascii-only-wrong-line.eo")
-                ).parsed()
+                new EoProgram(
+                    "org/eolang/lints/unlint-ascii-only-wrong-line.eo"
+                ).parse()
             ),
             Matchers.hasSize(Matchers.greaterThan(0))
         );
@@ -127,9 +116,9 @@ final class LtUnlintNonExistingDefectTest {
                 new ListOf<>(new LtAsciiOnly()),
                 new ListOf<>()
             ).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-ascii-only-range.eo")
-                ).parsed()
+                new EoProgram(
+                    "org/eolang/lints/unlint-ascii-only-range.eo"
+                ).parse()
             ),
             Matchers.emptyIterable()
         );
@@ -143,9 +132,9 @@ final class LtUnlintNonExistingDefectTest {
                 new ListOf<>(new LtAsciiOnly()),
                 new ListOf<>()
             ).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-ascii-only-out-range.eo")
-                ).parsed()
+                new EoProgram(
+                    "org/eolang/lints/unlint-ascii-only-out-range.eo"
+                ).parse()
             ),
             Matchers.iterableWithSize(1)
         );
@@ -159,9 +148,9 @@ final class LtUnlintNonExistingDefectTest {
                 new ListOf<>(new LtAsciiOnly()),
                 new ListOf<>()
             ).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-ascii-only-absent.eo")
-                ).parsed()
+                new EoProgram(
+                    "org/eolang/lints/unlint-ascii-only-absent.eo"
+                ).parse()
             ),
             Matchers.iterableWithSize(1)
         );

--- a/src/test/java/org/eolang/lints/LtUnlintTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintTest.java
@@ -5,11 +5,10 @@
 package org.eolang.lints;
 
 import com.jcabi.log.Logger;
+import fixtures.EoProgram;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
-import org.cactoos.io.ResourceOf;
-import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -25,9 +24,7 @@ final class LtUnlintTest {
         MatcherAssert.assertThat(
             "failed to return one error",
             new LtUnlint(new LtAlways()).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/first-foo.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/first-foo.eo").parse()
             ),
             Matchers.hasSize(1)
         );
@@ -38,9 +35,7 @@ final class LtUnlintTest {
         MatcherAssert.assertThat(
             "failed to return empty list",
             new LtUnlint(new LtAlways()).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-always.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/unlint-always.eo").parse()
             ),
             Matchers.emptyIterable()
         );
@@ -51,9 +46,7 @@ final class LtUnlintTest {
         MatcherAssert.assertThat(
             "Only one defect should be unlinted",
             new LtUnlint(new LtAsciiOnly()).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-ascii-only-grainy.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/unlint-ascii-only-grainy.eo").parse()
             ),
             Matchers.allOf(
                 Matchers.iterableWithSize(1),
@@ -74,9 +67,7 @@ final class LtUnlintTest {
         MatcherAssert.assertThat(
             "All defects should be unlinted",
             new LtUnlint(new LtAsciiOnly()).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-ascii-only-multiple.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/unlint-ascii-only-multiple.eo").parse()
             ),
             Matchers.emptyIterable()
         );
@@ -88,11 +79,7 @@ final class LtUnlintTest {
             "All defects should be unlinted",
             new LtUnlint(
                 new LtByXsl("comments/comment-without-dot")
-            ).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-comment-without-dot.eo")
-                ).parsed()
-            ),
+            ).defects(new EoProgram("org/eolang/lints/unlint-comment-without-dot.eo").parse()),
             Matchers.emptyIterable()
         );
     }
@@ -104,9 +91,7 @@ final class LtUnlintTest {
             new LtUnlint(
                 new LtByXsl("comments/comment-without-dot")
             ).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-comment-without-dot-line.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/unlint-comment-without-dot-line.eo").parse()
             ),
             Matchers.emptyIterable()
         );
@@ -116,11 +101,7 @@ final class LtUnlintTest {
     void doesNotDuplicateDefectsWhenMultipleDefectsOnTheSameLine() throws IOException {
         final Collection<Defect> defects = new LtUnlint(
             new LtByXsl("misc/unused-void-attr")
-        ).defects(
-            new EoSyntax(
-                new ResourceOf("org/eolang/lints/unused-voids.eo")
-            ).parsed()
-        );
+        ).defects(new EoProgram("org/eolang/lints/unused-voids.eo").parse());
         MatcherAssert.assertThat(
             Logger.format(
                 "Found defects (%[list]s) contain duplicates, but they should not",
@@ -136,9 +117,7 @@ final class LtUnlintTest {
         MatcherAssert.assertThat(
             "Defects are not empty, but they should",
             new LtUnlint(new LtByXsl("comments/comment-without-dot")).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-comment-without-dot-range.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/unlint-comment-without-dot-range.eo").parse()
             ),
             Matchers.emptyIterable()
         );
@@ -149,9 +128,9 @@ final class LtUnlintTest {
         MatcherAssert.assertThat(
             "Resulted defects do not match with expected",
             new LtUnlint(new LtByXsl("comments/comment-without-dot")).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-comment-without-dot-out-of-range.eo")
-                ).parsed()
+                new EoProgram(
+                    "org/eolang/lints/unlint-comment-without-dot-out-of-range.eo"
+                ).parse()
             ),
             Matchers.allOf(
                 Matchers.iterableWithSize(1),
@@ -172,9 +151,7 @@ final class LtUnlintTest {
         MatcherAssert.assertThat(
             "Size of defects does not match with expected",
             new LtUnlint(new LtAsciiOnly()).defects(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-ascii-only-out-of-range.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/unlint-ascii-only-out-of-range.eo").parse()
             ),
             Matchers.iterableWithSize(2)
         );

--- a/src/test/java/org/eolang/lints/MonoLintsTest.java
+++ b/src/test/java/org/eolang/lints/MonoLintsTest.java
@@ -9,13 +9,12 @@ import com.jcabi.xml.XML;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import fixtures.EoProgram;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.stream.Collectors;
-import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
-import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -67,26 +66,9 @@ final class MonoLintsTest {
     /**
      * Parse EO source into XMIR once.
      * @return Parsed XMIR
-     * @throws IOException If fails
-     * @todo #870:90min Introduce EoProgram helper class to wrap EO resource parsing.
-     *  In many test classes we repeat {@code new EoSyntax(new ResourceOf("...")).parsed()}.
-     *  Extract this into a dedicated {@code EoProgram(String resource)} class with a
-     *  {@code parse()} method that handles {@link java.io.IOException} gracefully,
-     *  logs parse timing, and provides a minimal in-memory cache so the same resource
-     *  is not re-parsed across multiple test methods.
      */
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
-    private static XML parse() throws IOException {
-        final long start = System.currentTimeMillis();
-        final XML xmir = new EoSyntax(
-            new ResourceOf("org/eolang/lints/simple.eo")
-        ).parsed();
-        Logger.info(
-            MonoLintsTest.class,
-            "Parsing: %dms",
-            System.currentTimeMillis() - start
-        );
-        return xmir;
+    private static XML parse() {
+        return new EoProgram("org/eolang/lints/simple.eo").parse();
     }
 
     /**

--- a/src/test/java/org/eolang/lints/PkByXslTest.java
+++ b/src/test/java/org/eolang/lints/PkByXslTest.java
@@ -102,7 +102,6 @@ final class PkByXslTest {
      * Parse EO source into XMIR once.
      * @return Parsed XMIR
      */
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private static XML parse() {
         return new EoProgram("org/eolang/lints/unused-voids.eo").parse();
     }

--- a/src/test/java/org/eolang/lints/PkByXslTest.java
+++ b/src/test/java/org/eolang/lints/PkByXslTest.java
@@ -7,6 +7,7 @@ package org.eolang.lints;
 import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
+import fixtures.EoProgram;
 import io.github.secretx33.resourceresolver.PathMatchingResourcePatternResolver;
 import io.github.secretx33.resourceresolver.Resource;
 import java.io.IOException;
@@ -15,11 +16,9 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.function.Predicate;
 import org.cactoos.io.InputOf;
-import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
-import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -67,7 +66,7 @@ final class PkByXslTest {
 
     @Test
     @SuppressWarnings("PMD.UnnecessaryLocalRule")
-    void doesNotDuplicateDefectsWhenMultipleDefectsOnTheSameLine() throws Exception {
+    void doesNotDuplicateDefectsWhenMultipleDefectsOnTheSameLine() {
         final XML xmir = PkByXslTest.parse();
         final Collection<Defect> aggregated = new ListOf<>();
         new PkByXsl().forEach(
@@ -102,20 +101,10 @@ final class PkByXslTest {
     /**
      * Parse EO source into XMIR once.
      * @return Parsed XMIR
-     * @throws IOException If fails
      */
     @SuppressWarnings("PMD.UnnecessaryLocalRule")
-    private static XML parse() throws IOException {
-        final long start = System.currentTimeMillis();
-        final XML xmir = new EoSyntax(
-            new ResourceOf("org/eolang/lints/unused-voids.eo")
-        ).parsed();
-        Logger.info(
-            PkByXslTest.class,
-            "Parsing: %dms",
-            System.currentTimeMillis() - start
-        );
-        return xmir;
+    private static XML parse() {
+        return new EoProgram("org/eolang/lints/unused-voids.eo").parse();
     }
 
     /**

--- a/src/test/java/org/eolang/lints/PkMonoTest.java
+++ b/src/test/java/org/eolang/lints/PkMonoTest.java
@@ -9,9 +9,9 @@ import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import com.yegor256.Together;
+import fixtures.EoProgram;
 import io.github.secretx33.resourceresolver.PathMatchingResourcePatternResolver;
 import io.github.secretx33.resourceresolver.Resource;
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
@@ -19,11 +19,9 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
 import org.cactoos.scalar.LengthOf;
 import org.cactoos.set.SetOf;
-import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
@@ -52,13 +50,13 @@ final class PkMonoTest {
     }
 
     @Test
-    void allowsUnlint() throws IOException {
+    void allowsUnlint() {
         MatcherAssert.assertThat(
             "Defects found, though they were unlinted",
             new Source(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-ascii-only.eo")
-                ).parsed(),
+                new EoProgram(
+                    "org/eolang/lints/unlint-ascii-only.eo"
+                ).parse(),
                 new PkMono()
             ).defects().stream().filter(
                 defect -> "ascii-only".equals(defect.rule())

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -16,6 +16,7 @@ import com.yegor256.tojos.TjCached;
 import com.yegor256.tojos.TjDefault;
 import com.yegor256.tojos.Tojos;
 import fixtures.BytecodeClass;
+import fixtures.EoProgram;
 import fixtures.SourceSize;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -77,9 +78,7 @@ final class SourceTest {
         MatcherAssert.assertThat(
             "defects found even though the code is clean",
             new Source(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/valid-source.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/valid-source.eo").parse()
             ).defects(),
             Matchers.emptyIterable()
         );
@@ -90,9 +89,7 @@ final class SourceTest {
         MatcherAssert.assertThat(
             "defect found even though lint is suppressed",
             new Source(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/suppress-all-lints.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/suppress-all-lints.eo").parse()
             ).defects(),
             Matchers.emptyIterable()
         );
@@ -103,9 +100,9 @@ final class SourceTest {
         final Path path = dir.resolve("foo.xmir");
         Files.write(
             path,
-            new EoSyntax(
-                new ResourceOf("org/eolang/lints/foo-without-dot.eo")
-            ).parsed().toString().getBytes(StandardCharsets.UTF_8)
+            new EoProgram("org/eolang/lints/foo-without-dot.eo").parse()
+                .toString()
+                .getBytes(StandardCharsets.UTF_8)
         );
         MatcherAssert.assertThat(
             "the defect is found",
@@ -124,9 +121,7 @@ final class SourceTest {
             new SetOf<>(
                 new Together<>(
                     t -> new Source(
-                        new EoSyntax(
-                            new ResourceOf("org/eolang/lints/foo-without-dot.eo")
-                        ).parsed(),
+                        new EoProgram("org/eolang/lints/foo-without-dot.eo").parse(),
                         new ListOf<>(new LtByXsl("comments/comment-without-dot"))
                     ).defects().size()
                 ).asList()
@@ -136,13 +131,11 @@ final class SourceTest {
     }
 
     @Test
-    void checksLargerBrokenSource() throws IOException {
+    void checksLargerBrokenSource() {
         MatcherAssert.assertThat(
             "checking passes",
             new Source(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/broken-source.eo")
-                ).parsed(),
+                new EoProgram("org/eolang/lints/broken-source.eo").parse(),
                 new ListOf<>(new LtByXsl("aliases/alias-too-long"))
             ).defects(),
             Matchers.allOf(
@@ -162,12 +155,10 @@ final class SourceTest {
 
     @Test
     @Timeout(60L)
-    void acceptsCanonicalCode() throws IOException {
-        final XML xmir = new EoSyntax(
-            new ResourceOf(
-                "org/eolang/lints/canonical.eo"
-            )
-        ).parsed();
+    void acceptsCanonicalCode() {
+        final XML xmir = new EoProgram(
+            "org/eolang/lints/canonical.eo"
+        ).parse();
         MatcherAssert.assertThat(
             String.format("no errors in canonical code in %s", xmir),
             new Source(xmir).defects(),
@@ -188,13 +179,11 @@ final class SourceTest {
     }
 
     @Test
-    void createsSourceWithoutOneLint() throws IOException {
+    void createsSourceWithoutOneLint() {
         MatcherAssert.assertThat(
             "Defects for disabled lint are not empty, but should be",
             new Source(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/non-ascii-cyrillic.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/non-ascii-cyrillic.eo").parse()
             ).without("ascii-only").defects().stream()
                 .filter(defect -> defect.rule().equals("ascii-only"))
                 .collect(Collectors.toList()),
@@ -203,62 +192,55 @@ final class SourceTest {
     }
 
     @Test
-    void createsSourceWithoutMultipleLints() throws IOException {
+    void createsSourceWithoutMultipleLints() {
         MatcherAssert.assertThat(
             "Defects for disabled lints are not empty, but should be",
-            new Source(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/non-ascii-cyrillic.eo")
-                ).parsed()
-            ).without(
-                "ascii-only",
-                "object-does-not-match-filename",
-                "comment-not-capitalized",
-                "empty-object",
-                "mandatory-home",
-                "mandatory-version",
-                "mandatory-package",
-                "comment-too-short",
-                "mandatory-spdx",
-                "no-attribute-formation",
-                "unit-test-missing"
-            ).defects(),
+            new Source(new EoProgram("org/eolang/lints/non-ascii-cyrillic.eo").parse())
+                .without(
+                    "ascii-only",
+                    "object-does-not-match-filename",
+                    "comment-not-capitalized",
+                    "empty-object",
+                    "mandatory-home",
+                    "mandatory-version",
+                    "mandatory-package",
+                    "comment-too-short",
+                    "mandatory-spdx",
+                    "no-attribute-formation",
+                    "unit-test-missing"
+                ).defects(),
             Matchers.emptyIterable()
         );
     }
 
     @Test
-    void returnsOnlyOneDefect() throws IOException {
+    void returnsOnlyOneDefect() {
         MatcherAssert.assertThat(
             "Only one defect should be found",
-            new Source(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/main-with-test.eo")
-                ).parsed()
-            ).without("mandatory-spdx").defects(),
+            new Source(new EoProgram("org/eolang/lints/main-with-test.eo").parse())
+                .without("mandatory-spdx")
+                .defects(),
             Matchers.hasSize(1)
         );
     }
 
     @Test
-    void disablesUnlintNonExistingDefectViaWithout() throws IOException {
+    void disablesUnlintNonExistingDefectViaWithout() {
         MatcherAssert.assertThat(
             "unlint-non-existing-defect should be silenced when disabled via without()",
             new Source(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/unlint-mandatory-home.eo")
-                ).parsed()
+                new EoProgram("org/eolang/lints/unlint-mandatory-home.eo").parse()
             ).without(
-                "unlint-non-existing-defect",
-                "mandatory-home",
-                "mandatory-version",
-                "empty-object",
-                "mandatory-package",
-                "mandatory-spdx",
-                "comment-too-short",
-                "no-attribute-formation",
-                "unit-test-missing"
-            ).defects().stream()
+                    "unlint-non-existing-defect",
+                    "mandatory-home",
+                    "mandatory-version",
+                    "empty-object",
+                    "mandatory-package",
+                    "mandatory-spdx",
+                    "comment-too-short",
+                    "no-attribute-formation",
+                    "unit-test-missing"
+                ).defects().stream()
                 .filter(defect -> defect.rule().startsWith("unlint-non-existing-defect"))
                 .collect(Collectors.toList()),
             Matchers.emptyIterable()
@@ -310,11 +292,9 @@ final class SourceTest {
     }
 
     @Test
-    void doesNotDuplicateDefectsWhenMultipleDefectsOnTheSameLine() throws IOException {
+    void doesNotDuplicateDefectsWhenMultipleDefectsOnTheSameLine() {
         final Collection<Defect> defects = new Source(
-            new EoSyntax(
-                new ResourceOf("org/eolang/lints/unused-voids.eo")
-            ).parsed(),
+            new EoProgram("org/eolang/lints/unused-voids.eo").parse(),
             new ListOf<>(new LtByXsl("misc/unused-void-attr"))
         ).defects();
         MatcherAssert.assertThat(
@@ -328,13 +308,11 @@ final class SourceTest {
     }
 
     @Test
-    void outputsInformationAboutSingleScope() throws IOException {
+    void outputsInformationAboutSingleScope() {
         MatcherAssert.assertThat(
             "Found defects don't contain information about Single scope, but they should",
             new Source(
-                new EoSyntax(
-                    new ResourceOf("org/eolang/lints/foo-without-dot.eo")
-                ).parsed(),
+                new EoProgram("org/eolang/lints/foo-without-dot.eo").parse(),
                 new ListOf<>(new LtByXsl("comments/comment-without-dot"))
             ).defects(),
             Matchers.hasItem(

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -195,20 +195,19 @@ final class SourceTest {
     void createsSourceWithoutMultipleLints() {
         MatcherAssert.assertThat(
             "Defects for disabled lints are not empty, but should be",
-            new Source(new EoProgram("org/eolang/lints/non-ascii-cyrillic.eo").parse())
-                .without(
-                    "ascii-only",
-                    "object-does-not-match-filename",
-                    "comment-not-capitalized",
-                    "empty-object",
-                    "mandatory-home",
-                    "mandatory-version",
-                    "mandatory-package",
-                    "comment-too-short",
-                    "mandatory-spdx",
-                    "no-attribute-formation",
-                    "unit-test-missing"
-                ).defects(),
+            new Source(new EoProgram("org/eolang/lints/non-ascii-cyrillic.eo").parse()).without(
+                "ascii-only",
+                "object-does-not-match-filename",
+                "comment-not-capitalized",
+                "empty-object",
+                "mandatory-home",
+                "mandatory-version",
+                "mandatory-package",
+                "comment-too-short",
+                "mandatory-spdx",
+                "no-attribute-formation",
+                "unit-test-missing"
+            ).defects(),
             Matchers.emptyIterable()
         );
     }
@@ -231,16 +230,16 @@ final class SourceTest {
             new Source(
                 new EoProgram("org/eolang/lints/unlint-mandatory-home.eo").parse()
             ).without(
-                    "unlint-non-existing-defect",
-                    "mandatory-home",
-                    "mandatory-version",
-                    "empty-object",
-                    "mandatory-package",
-                    "mandatory-spdx",
-                    "comment-too-short",
-                    "no-attribute-formation",
-                    "unit-test-missing"
-                ).defects().stream()
+                "unlint-non-existing-defect",
+                "mandatory-home",
+                "mandatory-version",
+                "empty-object",
+                "mandatory-package",
+                "mandatory-spdx",
+                "comment-too-short",
+                "no-attribute-formation",
+                "unit-test-missing"
+            ).defects().stream()
                 .filter(defect -> defect.rule().startsWith("unlint-non-existing-defect"))
                 .collect(Collectors.toList()),
             Matchers.emptyIterable()


### PR DESCRIPTION
Introduces `EoProgram` test fixture with bounded caching and migrates test classes away from inline `EoSyntax`/`ResourceOf` boilerplate to use it, resolving puzzle `870-3df121a4`.

Fixes #874