### PR TITLE
refactor(#873): remove duplicate `first-foo.eo` fixture file

### DIFF
--- a/src/test/java/org/eolang/lints/LtAlwaysTest.java
+++ b/src/test/java/org/eolang/lints/LtAlwaysTest.java
@@ -19,7 +19,7 @@ final class LtAlwaysTest {
     void complainsAlways() {
         MatcherAssert.assertThat(
             "didn't return one defect",
-            new LtAlways().defects(new EoProgram("org/eolang/lints/first-foo.eo").parse()),
+            new LtAlways().defects(new EoProgram("org/eolang/lints/foo-without-dot.eo").parse()),
             Matchers.hasSize(1)
         );
     }

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -57,13 +57,6 @@ import org.yaml.snakeyaml.Yaml;
  *  classpath-scanning suites), and consider splitting heavy tests into a separate
  *  integration-test profile, parallelising test execution, or caching parsed XMIR
  *  across test cases where it is safe to do so.
- * @todo #870:60min Deduplicate EO resource files under src/test/resources/org/eolang/lints/.
- *  We now have 46 small {@code .eo} fixture files added during the extraction of inline
- *  EO programs. Some of these files may contain identical or semantically equivalent
- *  programs (e.g. {@code foo-without-dot.eo}, {@code first-foo.eo}, {@code simple.eo}).
- *  Audit all fixture files for content duplicates and consolidate where possible, updating
- *  test references to point to the surviving canonical file. This reduces maintenance
- *  burden and avoids subtle divergence between "the same" EO program defined twice.
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
 @SuppressWarnings("PMD.TooManyMethods")

--- a/src/test/java/org/eolang/lints/LtUnlintTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintTest.java
@@ -24,7 +24,7 @@ final class LtUnlintTest {
         MatcherAssert.assertThat(
             "failed to return one error",
             new LtUnlint(new LtAlways()).defects(
-                new EoProgram("org/eolang/lints/first-foo.eo").parse()
+                new EoProgram("org/eolang/lints/foo-without-dot.eo").parse()
             ),
             Matchers.hasSize(1)
         );

--- a/src/test/resources/org/eolang/lints/first-foo.eo
+++ b/src/test/resources/org/eolang/lints/first-foo.eo
@@ -1,5 +1,0 @@
-+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
-
-# first
-[] > foo


### PR DESCRIPTION
Removes duplicate `first-foo.eo` fixture, consolidating tests to use `foo-without-dot.eo` as the canonical resource.

Fixes #873