### PR TITLE
perf(#872): enable parallel test execution and cache EO parsing

### DIFF
--- a/src/test/java/fixtures/EoProgram.java
+++ b/src/test/java/fixtures/EoProgram.java
@@ -11,6 +11,7 @@ import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
+import org.cactoos.Input;
 import org.cactoos.io.ResourceOf;
 import org.eolang.parser.EoSyntax;
 
@@ -33,16 +34,31 @@ public final class EoProgram {
         .build();
 
     /**
+     * Program name for caching.
+     */
+    private final String name;
+
+    /**
      * Resource path.
      */
-    private final String resource;
+    private final Input resource;
 
     /**
      * Constructor.
      * @param res Classpath resource path to the EO source file
      */
     public EoProgram(final String res) {
-        this.resource = res;
+        this(res, new ResourceOf(res));
+    }
+
+    /**
+     * Constructor.
+     * @param nme Cache key and log label for this program
+     * @param input EO source input
+     */
+    public EoProgram(final String nme, final Input input) {
+        this.name = nme;
+        this.resource = input;
     }
 
     /**
@@ -51,11 +67,7 @@ public final class EoProgram {
      */
     public XML parse() {
         try {
-            return new XMLDocument(
-                EoProgram.CACHE.get(
-                    this.resource, () -> EoProgram.doParse(this.resource)
-                ).deepCopy()
-            );
+            return new XMLDocument(EoProgram.CACHE.get(this.name, this::doParse).deepCopy());
         } catch (final ExecutionException ex) {
             throw new IllegalStateException(
                 String.format("Failed to parse EO resource '%s'", this.resource),
@@ -66,18 +78,17 @@ public final class EoProgram {
 
     /**
      * Perform the actual parse and log timing.
-     * @param res Resource path to parse
      * @return Parsed XMIR document
      * @throws IOException If parsing fails
      */
     @SuppressWarnings("PMD.UnnecessaryLocalRule")
-    private static XML doParse(final String res) throws IOException {
+    private XML doParse() throws IOException {
         final long start = System.currentTimeMillis();
-        final XML xmir = new EoSyntax(new ResourceOf(res)).parsed();
+        final XML xmir = new EoSyntax(this.resource).parsed();
         Logger.info(
             EoProgram.class,
             "Parsed '%s': %dms",
-            res,
+            this.name,
             System.currentTimeMillis() - start
         );
         return xmir;

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import matchers.DefectsMatcher;
+import org.cactoos.io.InputOf;
 import org.cactoos.io.ReaderOf;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
@@ -41,6 +42,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.xembly.Directives;
 import org.xembly.ImpossibleModificationException;
@@ -74,6 +77,7 @@ final class LtByXslTest {
     }
 
     @SuppressWarnings("JTCOP.RuleNotContainsTestWord")
+    @Execution(ExecutionMode.CONCURRENT)
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/lints/packs/single/", glob = "**.yaml")
     void testsAllLintsByEo(final String yaml) {
@@ -82,7 +86,7 @@ final class LtByXslTest {
             new XtSticky(
                 new XtYaml(
                     yaml,
-                    eo -> new EoSyntax(eo).parsed()
+                    eo -> new EoProgram(String.valueOf(eo.hashCode()), new InputOf(eo)).parse()
                 )
             ),
             new XtoryMatcher(new DefectsMatcher())

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -29,7 +29,6 @@ import org.cactoos.map.MapOf;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 import org.eolang.jucs.ClasspathSource;
-import org.eolang.parser.EoSyntax;
 import org.eolang.parser.StrictXmir;
 import org.eolang.xax.XtSticky;
 import org.eolang.xax.XtYaml;
@@ -320,21 +319,10 @@ final class LtByXslTest {
     }
 
     private static boolean eoErrorFree(final Map<Path, Map<String, Object>> pack) {
-        try {
-            return new Xnav(
-                new EoSyntax(
-                    (String) pack.values().stream().findFirst().get().get("input")
-                ).parsed().inner()
-            ).path("/object[errors]").findAny().isEmpty();
-        } catch (final IOException exception) {
-            throw new IllegalStateException(
-                String.format(
-                    "Failed to parse EO snippet from '%s' pack",
-                    pack.keySet().iterator().next()
-                ),
-                exception
-            );
-        }
+        final String src = (String) pack.values().stream().findFirst().get().get("input");
+        return new Xnav(
+            new EoProgram(src, new InputOf(src)).parse().inner()
+        ).path("/object[errors]").findAny().isEmpty();
     }
 
     /**

--- a/src/test/java/org/eolang/lints/LtIncorrectUnlintTest.java
+++ b/src/test/java/org/eolang/lints/LtIncorrectUnlintTest.java
@@ -8,8 +8,8 @@ import fixtures.EoProgram;
 import java.io.IOException;
 import java.util.List;
 import matchers.DefectMatcher;
+import org.cactoos.io.InputOf;
 import org.cactoos.list.ListOf;
-import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -36,10 +36,11 @@ final class LtIncorrectUnlintTest {
 
     @Test
     void allowsCorrectUnlints() throws IOException {
+        final String src = "+unlint ascii-only";
         MatcherAssert.assertThat(
             "Defects are not empty, but they shouldn't be",
             new LtIncorrectUnlint(List.of("ascii-only")).defects(
-                new EoSyntax("+unlint ascii-only").parsed()
+                new EoProgram(src, new InputOf(src)).parse()
             ),
             Matchers.emptyIterable()
         );

--- a/src/test/java/org/eolang/lints/LtReservedNameTest.java
+++ b/src/test/java/org/eolang/lints/LtReservedNameTest.java
@@ -7,10 +7,10 @@ package org.eolang.lints;
 import fixtures.EoProgram;
 import java.io.IOException;
 import java.util.Collection;
+import org.cactoos.io.InputOf;
 import org.cactoos.list.ListOf;
 import org.cactoos.map.MapEntry;
 import org.cactoos.map.MapOf;
-import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
@@ -141,9 +141,12 @@ final class LtReservedNameTest {
 
     @Test
     void allowsAllUnique() throws IOException {
+        final String src = "[] > qux";
         MatcherAssert.assertThat(
             "Object names should not be reported, since they all unique",
-            new LtReservedName(new MapOf<>()).defects(new EoSyntax("[] > qux").parsed()),
+            new LtReservedName(new MapOf<>()).defects(
+                new EoProgram(src, new InputOf(src)).parse()
+            ),
             Matchers.emptyIterable()
         );
     }

--- a/src/test/java/org/eolang/lints/LtTestNotVerbTest.java
+++ b/src/test/java/org/eolang/lints/LtTestNotVerbTest.java
@@ -9,8 +9,8 @@ import com.yegor256.Together;
 import fixtures.EoProgram;
 import java.io.IOException;
 import matchers.DefectMatcher;
+import org.cactoos.io.InputOf;
 import org.cactoos.set.SetOf;
-import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.RepeatedTest;
@@ -23,6 +23,13 @@ import org.junit.jupiter.params.provider.ValueSource;
 /**
  * Tests for {@link LtTestNotVerb}.
  * @since 0.0.22
+ * @todo #872:60min Extract name-validation logic from LtTestNotVerb into a testable component.
+ *  Currently {@link LtTestNotVerbTest} parses many EO programs that differ only in the
+ *  object name being tested, making the tests slow and hard to maintain. The name-validation
+ *  predicate (verb vs. non-verb check) should be extracted into its own class so it can be
+ *  tested directly with plain strings — no EO parsing required. Once extracted, reduce
+ *  {@link LtTestNotVerbTest} to a few representative end-to-end cases and add a dedicated
+ *  unit test class for the new component.
  */
 final class LtTestNotVerbTest {
 
@@ -72,19 +79,22 @@ final class LtTestNotVerbTest {
             "hope-it-works"
         }
     )
-    void catchesBadName(final String name) throws Exception {
+    void catchesBadName(final String name) throws IOException {
         MatcherAssert.assertThat(
             "Defects size doesn't match with expected",
             new LtTestNotVerb().defects(
-                new EoSyntax(
-                    String.join(
-                        System.lineSeparator(),
-                        "# Foo",
-                        "[] > foo",
-                        String.format("  [] +> %s", name),
-                        "    42 > @"
+                new EoProgram(
+                    name,
+                    new InputOf(
+                        String.join(
+                            System.lineSeparator(),
+                            "# Foo",
+                            "[] > foo",
+                            String.format("  [] +> %s", name),
+                            "    42 > @"
+                        )
                     )
-                ).parsed()
+                ).parse()
             ),
             Matchers.allOf(
                 Matchers.<Defect>iterableWithSize(1),
@@ -122,19 +132,22 @@ final class LtTestNotVerbTest {
             "is-almost-correct"
         }
     )
-    void allowsGoodNames(final String name) throws Exception {
+    void allowsGoodNames(final String name) throws IOException {
         MatcherAssert.assertThat(
             "Defects are not empty, but they shouldn't be",
             new LtTestNotVerb().defects(
-                new EoSyntax(
-                    String.join(
-                        System.lineSeparator(),
-                        "# Foo",
-                        "[] > foo",
-                        String.format("  [] +> %s", name),
-                        "    42 > @"
+                new EoProgram(
+                    name,
+                    new InputOf(
+                        String.join(
+                            System.lineSeparator(),
+                            "# Foo",
+                            "[] > foo",
+                            String.format("  [] +> %s", name),
+                            "    42 > @"
+                        )
                     )
-                ).parsed()
+                ).parse()
             ),
             Matchers.hasSize(0)
         );

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -34,6 +34,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.bytes.UncheckedBytes;
+import org.cactoos.io.InputOf;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.iterable.Sticky;
 import org.cactoos.iterable.Synced;
@@ -41,7 +42,6 @@ import org.cactoos.list.ListOf;
 import org.cactoos.map.MapOf;
 import org.cactoos.scalar.Unchecked;
 import org.cactoos.set.SetOf;
-import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -250,19 +250,22 @@ final class SourceTest {
     @ValueSource(
         strings = {"mandatory-home", "mandatory-home:0"}
     )
-    void catchesBrokenUnlintAfterLintWasRemoved(final String lid) throws IOException {
+    void catchesBrokenUnlintAfterLintWasRemoved(final String lid) {
         MatcherAssert.assertThat(
             "Found defect does not match with expected",
             new Source(
-                new EoSyntax(
-                    String.join(
-                        System.lineSeparator(),
-                        String.format("+unlint %s", lid),
-                        "",
-                        "# Foo.",
-                        "[] > foo"
+                new EoProgram(
+                    lid,
+                    new InputOf(
+                        String.join(
+                            System.lineSeparator(),
+                            String.format("+unlint %s", lid),
+                            "",
+                            "# Foo.",
+                            "[] > foo"
+                        )
                     )
-                ).parsed()
+                ).parse()
             ).without(
                 "mandatory-home",
                 "mandatory-version",

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -5,3 +5,4 @@
 #  Currently, it fails with the 3s timeout on windows platform. Let's try to configure
 #  test default timeout exclusively for windows, and keep 3s for other platforms.
 junit.jupiter.execution.timeout.test.method.default = 45s
+junit.jupiter.execution.parallel.enabled = true


### PR DESCRIPTION
Enable parallel test execution and cache EO parsing results in `LtByXslTest` to reduce excessive test suite runtime.

Fixes #872