### PR TITLE
fix(#886): scope reserved and deep profiles to run only tagged tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -485,7 +485,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <version>3.5.5</version>
             <configuration>
-              <excludedGroups>benchmark,reserved</excludedGroups>
+              <groups>deep</groups>
               <excludes>
                 <exclude>
                   generated/**

--- a/pom.xml
+++ b/pom.xml
@@ -733,7 +733,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <version>3.5.5</version>
             <configuration>
-              <excludedGroups>benchmark</excludedGroups>
+              <groups>reserved</groups>
               <excludes>
                 <exclude>
                   generated/**

--- a/pom.xml
+++ b/pom.xml
@@ -486,6 +486,7 @@
             <version>3.5.5</version>
             <configuration>
               <groups>deep</groups>
+              <excludedGroups>benchmark,reserved</excludedGroups>
               <excludes>
                 <exclude>
                   generated/**
@@ -734,6 +735,7 @@
             <version>3.5.5</version>
             <configuration>
               <groups>reserved</groups>
+              <excludedGroups>benchmark,deep</excludedGroups>
               <excludes>
                 <exclude>
                   generated/**


### PR DESCRIPTION
Fix `reserved` and `deep` profiles to run only their tagged tests instead of the full test suite.

Fixes #886