### PR TITLE
fix(#892): avoid MayBeSlow parallel test race

### DIFF
--- a/src/test/java/org/eolang/lints/LtTestNotVerbTest.java
+++ b/src/test/java/org/eolang/lints/LtTestNotVerbTest.java
@@ -16,7 +16,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,8 +28,13 @@ import org.junit.jupiter.params.provider.ValueSource;
  */
 final class LtTestNotVerbTest {
 
-    @ExtendWith(MayBeSlow.class)
-    @Execution(ExecutionMode.SAME_THREAD)
+    /**
+     * Slow-test watcher.
+     */
+    @RegisterExtension
+    private final MayBeSlow slow = new MayBeSlow();
+
+    @Execution(ExecutionMode.CONCURRENT)
     @ParameterizedTest
     @ValueSource(strings = {"it-works", "should-not-pass", "testing"})
     void catchesBadName(final String name) throws IOException {
@@ -56,8 +61,7 @@ final class LtTestNotVerbTest {
         );
     }
 
-    @ExtendWith(MayBeSlow.class)
-    @Execution(ExecutionMode.SAME_THREAD)
+    @Execution(ExecutionMode.CONCURRENT)
     @ParameterizedTest
     @ValueSource(strings = {"generates-report", "runs", "parses-dom"})
     void allowsGoodNames(final String name) throws IOException {
@@ -83,7 +87,6 @@ final class LtTestNotVerbTest {
 
     @SuppressWarnings("JTCOP.RuleNotContainsTestWord")
     @Test
-    @ExtendWith(MayBeSlow.class)
     void lintsRegexTests() throws IOException {
         MatcherAssert.assertThat(
             "Defects size doesn't match with expected",
@@ -107,6 +110,26 @@ final class LtTestNotVerbTest {
                 ).asList()
             ).size(),
             Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void registersSlowWatcherPerCase() {
+        MatcherAssert.assertThat(
+            "slow-test watcher should be available for each case",
+            this.slow,
+            Matchers.notNullValue()
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"catchesBadName", "allowsGoodNames"})
+    void keepsParameterizedCasesParallel(final String method) throws NoSuchMethodException {
+        MatcherAssert.assertThat(
+            String.format("method '%s' should stay concurrent", method),
+            LtTestNotVerbTest.class.getDeclaredMethod(method, String.class)
+                .getAnnotation(Execution.class).value(),
+            Matchers.equalTo(ExecutionMode.CONCURRENT)
         );
     }
 }

--- a/src/test/java/org/eolang/lints/LtTestNotVerbTest.java
+++ b/src/test/java/org/eolang/lints/LtTestNotVerbTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 final class LtTestNotVerbTest {
 
     @ExtendWith(MayBeSlow.class)
-    @Execution(ExecutionMode.CONCURRENT)
+    @Execution(ExecutionMode.SAME_THREAD)
     @ParameterizedTest
     @ValueSource(strings = {"it-works", "should-not-pass", "testing"})
     void catchesBadName(final String name) throws IOException {
@@ -57,7 +57,7 @@ final class LtTestNotVerbTest {
     }
 
     @ExtendWith(MayBeSlow.class)
-    @Execution(ExecutionMode.CONCURRENT)
+    @Execution(ExecutionMode.SAME_THREAD)
     @ParameterizedTest
     @ValueSource(strings = {"generates-report", "runs", "parses-dom"})
     void allowsGoodNames(final String name) throws IOException {


### PR DESCRIPTION
Fixes #892.

This changes only the two parameterized `LtTestNotVerbTest` methods that use `MayBeSlow` and were explicitly running their invocations concurrently. `MayBeSlow` 0.0.4 keeps its watcher thread in an extension instance field, so concurrent invocations can race and attempt to start the same `Thread` twice. Running these two MayBeSlow-decorated parameterized methods in `SAME_THREAD` keeps the rest of the test suite parallel while avoiding that extension-level race.

Validation:
- `mvn -DskipITs -Dtest=LtTestNotVerbTest#catchesBadName test -DtrimStackTrace=false` passed on Java 21 before the patch, so the exact Java 23 CI failure was not locally reproduced.
- `mvn -DskipITs -Dtest=LtTestNotVerbTest test -DtrimStackTrace=false` passed: 7 tests, 0 failures, 0 errors.
- `mvn -DskipITs test -DtrimStackTrace=false` passed: 527 tests, 0 failures, 0 errors, 2 skipped.
- `mvn -DskipITs -DskipTests -Pqulice qulice:check -DtrimStackTrace=false` completed with `BUILD SUCCESS`.
- `git diff --check` passed.
- `gitleaks git --no-banner --redact --staged=false --log-level error` passed.

Limitation:
- Full `mvn -DskipITs -DskipTests -Pqulice verify` could not complete locally because the available Android Studio JBR has no `jmods/java.base.jmod`, which ProGuard requires during packaging.