### PR TITLE
fix(#892): upgrade maybeslow to 0.1.0 to fix IllegalThreadStateException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
     <dependency>
       <groupId>com.yegor256</groupId>
       <artifactId>maybeslow</artifactId>
-      <version>0.0.4</version>
+      <version>0.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Bumps `maybeslow` dependency from `0.0.4` to `0.1.0` to fix `IllegalThreadStateException` caused by shared `Thread` instance in `MayBeSlow` during parallel test execution.

Fixes #892