### PR TITLE
feat(#902): replace partial meta comparison with full XMIR match

### DIFF
--- a/src/main/java/org/eolang/lints/FxByXsl.java
+++ b/src/main/java/org/eolang/lints/FxByXsl.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import com.jcabi.xml.ClasspathSources;
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XSL;
+import com.jcabi.xml.XSLDocument;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.text.IoCheckedText;
+import org.cactoos.text.TextOf;
+
+/**
+ * Fix implemented by a sequence of XSL stylesheets.
+ * @since 0.2.1
+ */
+public final class FxByXsl implements Fix {
+
+    /**
+     * XSL stylesheets to apply in order.
+     */
+    private final List<XSL> sheets;
+
+    /**
+     * Constructor.
+     * @param paths Classpath resource paths to XSL stylesheets (leading slash optional)
+     * @checkstyle ConstructorsCodeFreeCheck (5 lines)
+     */
+    public FxByXsl(final List<String> paths) {
+        this.sheets = FxByXsl.load(paths);
+    }
+
+    @Override
+    public XML apply(final XML xmir) throws IOException {
+        XML result = xmir;
+        for (final XSL sheet : this.sheets) {
+            result = sheet.transform(result);
+        }
+        return result;
+    }
+
+    private static List<XSL> load(final List<String> paths) {
+        final List<XSL> result = new ArrayList<>(paths.size());
+        for (final String path : paths) {
+            try {
+                result.add(
+                    new XSLDocument(
+                        new IoCheckedText(
+                            new TextOf(new ResourceOf(path.replaceFirst("^/", "")))
+                        ).asString()
+                    ).with(new ClasspathSources())
+                );
+            } catch (final IOException ex) {
+                throw new UncheckedIOException(
+                    String.format("Failed to load XSL stylesheet: %s", path),
+                    ex
+                );
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/eolang/lints/FxUnsortedMetas.java
+++ b/src/main/java/org/eolang/lints/FxUnsortedMetas.java
@@ -4,16 +4,9 @@
  */
 package org.eolang.lints;
 
-import com.jcabi.xml.ClasspathSources;
 import com.jcabi.xml.XML;
-import com.jcabi.xml.XSL;
-import com.jcabi.xml.XSLDocument;
 import java.io.IOException;
-import org.cactoos.io.ResourceOf;
-import org.cactoos.scalar.Sticky;
-import org.cactoos.scalar.Unchecked;
-import org.cactoos.text.IoCheckedText;
-import org.cactoos.text.TextOf;
+import java.util.List;
 
 /**
  * Fix for the {@code unsorted-metas} lint.
@@ -24,29 +17,20 @@ import org.cactoos.text.TextOf;
 public final class FxUnsortedMetas implements Fix {
 
     /**
-     * The XSL stylesheet.
+     * Delegate fix.
      */
-    private final Unchecked<XSL> sheet;
+    private final Fix delegate;
 
     /**
      * Ctor.
+     * @checkstyle ConstructorsCodeFreeCheck (5 lines)
      */
     public FxUnsortedMetas() {
-        this.sheet = new Unchecked<>(
-            new Sticky<>(
-                () -> new XSLDocument(
-                    new IoCheckedText(
-                        new TextOf(
-                            new ResourceOf("org/eolang/fixes/metas/unsorted-metas.xsl")
-                        )
-                    ).asString()
-                ).with(new ClasspathSources())
-            )
-        );
+        this.delegate = new FxByXsl(List.of("org/eolang/fixes/metas/unsorted-metas.xsl"));
     }
 
     @Override
     public XML apply(final XML xmir) throws IOException {
-        return this.sheet.value().transform(xmir);
+        return this.delegate.apply(xmir);
     }
 }

--- a/src/test/java/fixtures/FixPack.java
+++ b/src/test/java/fixtures/FixPack.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package fixtures;
+
+import com.jcabi.xml.XML;
+import java.util.Map;
+import org.cactoos.io.InputOf;
+import org.eolang.lints.Fix;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * A YAML test pack for a {@link Fix}, exposing the normalized fixed and
+ * expected XMIR for comparison in tests.
+ * @since 0.2.1
+ */
+public final class FixPack {
+
+    /**
+     * Parsed YAML pack with 'input' and 'output' EO programs.
+     */
+    private final Map<String, Object> pack;
+
+    /**
+     * The fix to apply to the input.
+     */
+    private final Fix fix;
+
+    /**
+     * Constructor.
+     * @param yaml Raw YAML string containing 'input' and 'output' fields
+     * @param fix The fix to apply
+     */
+    public FixPack(final String yaml, final Fix fix) {
+        this((Map<String, Object>) new Yaml().load(yaml), fix);
+    }
+
+    /**
+     * Constructor.
+     * @param pack Parsed YAML map containing 'input' and 'output' fields
+     * @param fix The fix to apply
+     */
+    private FixPack(final Map<String, Object> pack, final Fix fix) {
+        this.pack = pack;
+        this.fix = fix;
+    }
+
+    /**
+     * Returns normalized XMIR after applying the fix to the input program.
+     * @return Normalized XMIR string
+     * @throws Exception If parsing or fix application fails
+     */
+    public String fixed() throws Exception {
+        return FixPack.normalize(
+            this.fix.apply(
+                new EoProgram(
+                    String.valueOf(this.pack.get("input").hashCode()),
+                    new InputOf(this.pack.get("input").toString())
+                ).parse()
+            )
+        );
+    }
+
+    /**
+     * Returns normalized XMIR of the expected output program.
+     * @return Normalized XMIR string
+     */
+    public String expected() {
+        return FixPack.normalize(
+            new EoProgram(
+                String.valueOf(this.pack.get("output").hashCode()),
+                new InputOf(this.pack.get("output").toString())
+            ).parse()
+        );
+    }
+
+    private static String normalize(final XML xmir) {
+        return xmir.toString()
+            .replaceAll("(?s)<!--.*?-->", "")
+            .replaceAll("(?s)<listing>.*?</listing>", "<listing/>")
+            .replaceAll(" time=\"[^\"]*\"", "")
+            .replaceAll(" ms=\"[^\"]*\"", "")
+            .replaceAll(" line=\"\\d+\"", "");
+    }
+}

--- a/src/test/java/fixtures/FixPack.java
+++ b/src/test/java/fixtures/FixPack.java
@@ -5,45 +5,41 @@
 package fixtures;
 
 import com.jcabi.xml.XML;
+import java.util.List;
 import java.util.Map;
 import org.cactoos.io.InputOf;
 import org.eolang.lints.Fix;
+import org.eolang.lints.FxByXsl;
 import org.yaml.snakeyaml.Yaml;
 
 /**
- * A YAML test pack for a {@link Fix}, exposing the normalized fixed and
+ * A YAML test pack for a fix, exposing the normalized fixed and
  * expected XMIR for comparison in tests.
  * @since 0.2.1
  */
 public final class FixPack {
 
     /**
-     * Parsed YAML pack with 'input' and 'output' EO programs.
+     * Parsed YAML pack with 'sheets', 'input' and 'output' fields.
      */
     private final Map<String, Object> pack;
 
     /**
-     * The fix to apply to the input.
-     */
-    private final Fix fix;
-
-    /**
      * Constructor.
-     * @param yaml Raw YAML string containing 'input' and 'output' fields
-     * @param fix The fix to apply
+     * @param yaml Raw YAML string containing 'sheets', 'input' and 'output' fields
+     * @checkstyle ConstructorsCodeFreeCheck (5 lines)
      */
-    public FixPack(final String yaml, final Fix fix) {
-        this((Map<String, Object>) new Yaml().load(yaml), fix);
+    @SuppressWarnings("unchecked")
+    public FixPack(final String yaml) {
+        this((Map<String, Object>) new Yaml().load(yaml));
     }
 
     /**
      * Constructor.
-     * @param pack Parsed YAML map containing 'input' and 'output' fields
-     * @param fix The fix to apply
+     * @param pack Parsed YAML map
      */
-    private FixPack(final Map<String, Object> pack, final Fix fix) {
+    private FixPack(final Map<String, Object> pack) {
         this.pack = pack;
-        this.fix = fix;
     }
 
     /**
@@ -53,7 +49,7 @@ public final class FixPack {
      */
     public String fixed() throws Exception {
         return FixPack.normalize(
-            this.fix.apply(
+            this.fix().apply(
                 new EoProgram(
                     String.valueOf(this.pack.get("input").hashCode()),
                     new InputOf(this.pack.get("input").toString())
@@ -73,6 +69,10 @@ public final class FixPack {
                 new InputOf(this.pack.get("output").toString())
             ).parse()
         );
+    }
+
+    private Fix fix() {
+        return new FxByXsl((List<String>) this.pack.get("sheets"));
     }
 
     private static String normalize(final XML xmir) {

--- a/src/test/java/org/eolang/lints/FxUnsortedMetasTest.java
+++ b/src/test/java/org/eolang/lints/FxUnsortedMetasTest.java
@@ -19,7 +19,7 @@ final class FxUnsortedMetasTest {
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/lints/fixes/unsorted-metas/", glob = "**.yaml")
     void fixesUnsortedMetas(final String yaml) throws Exception {
-        final FixPack pack = new FixPack(yaml, new FxUnsortedMetas());
+        final FixPack pack = new FixPack(yaml);
         MatcherAssert.assertThat(
             "Full XMIR after fix must exactly match the expected XMIR",
             pack.fixed(),

--- a/src/test/java/org/eolang/lints/FxUnsortedMetasTest.java
+++ b/src/test/java/org/eolang/lints/FxUnsortedMetasTest.java
@@ -4,15 +4,11 @@
  */
 package org.eolang.lints;
 
-import com.jcabi.xml.XML;
-import fixtures.EoProgram;
-import java.util.Map;
-import org.cactoos.io.InputOf;
+import fixtures.FixPack;
 import org.eolang.jucs.ClasspathSource;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.yaml.snakeyaml.Yaml;
 
 /**
  * Tests for {@link FxUnsortedMetas}.
@@ -23,30 +19,11 @@ final class FxUnsortedMetasTest {
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/lints/fixes/unsorted-metas/", glob = "**.yaml")
     void fixesUnsortedMetas(final String yaml) throws Exception {
-        final Map<String, Object> pack = new Yaml().load(yaml);
-        final XML fixed = new FxUnsortedMetas().apply(
-            new EoProgram(
-                String.valueOf(pack.get("input").hashCode()),
-                new InputOf(pack.get("input").toString())
-            ).parse()
-        );
-        final XML expected = new EoProgram(
-            String.valueOf(pack.get("output").hashCode()),
-            new InputOf(pack.get("output").toString())
-        ).parse();
+        final FixPack pack = new FixPack(yaml, new FxUnsortedMetas());
         MatcherAssert.assertThat(
             "Full XMIR after fix must exactly match the expected XMIR",
-            FxUnsortedMetasTest.normalize(fixed),
-            Matchers.equalTo(FxUnsortedMetasTest.normalize(expected))
+            pack.fixed(),
+            Matchers.equalTo(pack.expected())
         );
-    }
-
-    private static String normalize(final XML xmir) {
-        return xmir.toString()
-            .replaceAll("(?s)<!--.*?-->", "")
-            .replaceAll("(?s)<listing>.*?</listing>", "<listing/>")
-            .replaceAll(" time=\"[^\"]*\"", "")
-            .replaceAll(" ms=\"[^\"]*\"", "")
-            .replaceAll(" line=\"\\d+\"", "");
     }
 }

--- a/src/test/java/org/eolang/lints/FxUnsortedMetasTest.java
+++ b/src/test/java/org/eolang/lints/FxUnsortedMetasTest.java
@@ -4,9 +4,9 @@
  */
 package org.eolang.lints;
 
+import com.jcabi.xml.XML;
 import fixtures.EoProgram;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.cactoos.io.InputOf;
 import org.eolang.jucs.ClasspathSource;
 import org.hamcrest.MatcherAssert;
@@ -17,12 +17,6 @@ import org.yaml.snakeyaml.Yaml;
 /**
  * Tests for {@link FxUnsortedMetas}.
  * @since 0.2.1
- * @todo #896:60min Replace partial meta comparison with exact XMIR match.
- *  Currently the test only compares the ordered sequence of "head tail"
- *  strings extracted from the metas section. Since we have a clear 'input'
- *  and 'output' EO program in each YAML pack, we should compare the full
- *  XMIR structure of the fixed result against the expected XMIR, ignoring
- *  only volatile attributes such as @line numbers.
  */
 final class FxUnsortedMetasTest {
 
@@ -30,34 +24,29 @@ final class FxUnsortedMetasTest {
     @ClasspathSource(value = "org/eolang/lints/fixes/unsorted-metas/", glob = "**.yaml")
     void fixesUnsortedMetas(final String yaml) throws Exception {
         final Map<String, Object> pack = new Yaml().load(yaml);
-        final Object input = pack.get("input");
-        final Object output = pack.get("output");
-        MatcherAssert.assertThat(
-            "Metas after fix must match the expected order",
-            new FxUnsortedMetas().apply(
-                new EoProgram(
-                    String.valueOf(input.hashCode()),
-                    new InputOf(input.toString())
-                ).parse()
-            ).nodes("/object/metas/meta").stream().map(
-                m -> String.format(
-                    "%s %s",
-                    m.xpath("head/text()").get(0),
-                    m.xpath("tail/text()").get(0)
-                )
-            ).collect(Collectors.toList()),
-            Matchers.equalTo(
-                new EoProgram(
-                    String.valueOf(output.hashCode()),
-                    new InputOf(output.toString())
-                ).parse().nodes("/object/metas/meta").stream().map(
-                    m -> String.format(
-                        "%s %s",
-                        m.xpath("head/text()").get(0),
-                        m.xpath("tail/text()").get(0)
-                    )
-                ).collect(Collectors.toList())
-            )
+        final XML fixed = new FxUnsortedMetas().apply(
+            new EoProgram(
+                String.valueOf(pack.get("input").hashCode()),
+                new InputOf(pack.get("input").toString())
+            ).parse()
         );
+        final XML expected = new EoProgram(
+            String.valueOf(pack.get("output").hashCode()),
+            new InputOf(pack.get("output").toString())
+        ).parse();
+        MatcherAssert.assertThat(
+            "Full XMIR after fix must exactly match the expected XMIR",
+            FxUnsortedMetasTest.normalize(fixed),
+            Matchers.equalTo(FxUnsortedMetasTest.normalize(expected))
+        );
+    }
+
+    private static String normalize(final XML xmir) {
+        return xmir.toString()
+            .replaceAll("(?s)<!--.*?-->", "")
+            .replaceAll("(?s)<listing>.*?</listing>", "<listing/>")
+            .replaceAll(" time=\"[^\"]*\"", "")
+            .replaceAll(" ms=\"[^\"]*\"", "")
+            .replaceAll(" line=\"\\d+\"", "");
     }
 }


### PR DESCRIPTION
Replaces partial meta comparison in `FxUnsortedMetasTest` with full XMIR structure matching, and extracts `FxByXsl` and `FixPack` to support reusable XSL-based fix testing.

Fixes #902