### PR TITLE
build(#906): update jcabi-xml to 0.36.0 and cactoos to 0.61.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-xml</artifactId>
-      <version>0.35.0</version>
+      <version>0.36.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.secretx33</groupId>
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
-      <version>0.59.0</version>
+      <version>0.61.0</version>
     </dependency>
     <dependency>
       <groupId>net.sf.saxon</groupId>


### PR DESCRIPTION
Bumps `jcabi-xml` to `0.36.0` and `cactoos` to `0.61.0` to resolve `RequireUpperBoundDeps` enforcer failure caused by transitive dependency version conflicts.

Fixes #906