### PR TITLE
fix(#909): update dependency com.jcabi:jcabi-xml to v0.37.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-xml</artifactId>
-      <version>0.36.0</version>
+      <version>0.37.0</version>
     </dependency>
     <dependency>
       <groupId>io.github.secretx33</groupId>


### PR DESCRIPTION
Bumps `com.jcabi:jcabi-xml` from `0.36.0` to `0.37.0`.

Fixes #909