### PR TITLE
refactor(#913): replace String.format with FormattedText in LtByXsl

### DIFF
--- a/src/main/java/org/eolang/lints/FxResource.java
+++ b/src/main/java/org/eolang/lints/FxResource.java
@@ -7,9 +7,11 @@ package org.eolang.lints;
 import com.jcabi.xml.XML;
 import java.io.IOException;
 import java.util.Collections;
+import org.cactoos.Text;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Synced;
 import org.cactoos.scalar.Unchecked;
+import org.cactoos.text.TextOf;
 
 /**
  * Fix loaded from a classpath resource.
@@ -27,11 +29,19 @@ public final class FxResource implements Fix {
      * Ctor.
      * @param path Classpath path to the XSL fix stylesheet
      */
-    public FxResource(final String path) {
+    FxResource(final String path) {
+        this(new TextOf(path));
+    }
+
+    /**
+     * Ctor.
+     * @param path Classpath path to the XSL fix stylesheet
+     */
+    FxResource(final Text path) {
         this.delegate = new Unchecked<>(
             new Synced<>(
                 new Sticky<>(
-                    () -> FxResource.load(path)
+                    () -> FxResource.load(path.asString())
                 )
             )
         );

--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -53,12 +53,6 @@ final class LtByXsl implements Lint {
     /**
      * Ctor.
      * @param xsl Relative path of XSL
-     * @todo #896:30min Replace String.format with FormattedText in this constructor.
-     *  FxResource currently accepts a String, so String.format is used here,
-     *  triggering ConstructorsCodeFreeCheck. Change FxResource to accept a Text
-     *  object and pass new FormattedText("org/eolang/fixes/%s.xsl", xsl) instead,
-     *  consistent with how ResourceOf is used for the lint and motive paths above.
-     * @checkstyle ConstructorsCodeFreeCheck (10 lines)
      */
     LtByXsl(final String xsl) {
         this(
@@ -68,7 +62,9 @@ final class LtByXsl implements Lint {
             new ResourceOf(
                 new FormattedText("org/eolang/motives/%s.md", xsl)
             ),
-            new FxResource(String.format("org/eolang/fixes/%s.xsl", xsl))
+            new FxResource(
+                new FormattedText("org/eolang/fixes/%s.xsl", xsl)
+            )
         );
     }
 


### PR DESCRIPTION
Replaces `String.format` in `LtByXsl` with `FormattedText` by updating `FxResource` to accept a `Text` object, resolving the `ConstructorsCodeFreeCheck` violation.

Fixes #913