### PR TITLE
fix(#914): remove resolved puzzle about FxResource URL handling

### DIFF
--- a/src/it/lints-it/src/test/java/org/eolang/lints/it/FixesItTest.java
+++ b/src/it/lints-it/src/test/java/org/eolang/lints/it/FixesItTest.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints.it;
+
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import java.io.IOException;
+import org.eolang.lints.Source;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for fix pipeline via {@link Source}.
+ *
+ * @since 0.2.1
+ */
+final class FixesItTest {
+
+    @Test
+    void fixesUnsortedMetas() throws IOException {
+        final XML xmir = new XMLDocument(
+            String.join(
+                "",
+                "<object>",
+                "<metas>",
+                "<meta line='1'><head>version</head><tail>0.0.0</tail></meta>",
+                "<meta line='2'><head>spdx</head><tail>SPDX-License-Identifier: MIT</tail></meta>",
+                "</metas>",
+                "</object>"
+            )
+        );
+        final Source source = new Source(xmir);
+        MatcherAssert.assertThat(
+            "unsorted-metas defect must be detected before fix",
+            source.defects().stream().anyMatch(d -> d.rule().startsWith("unsorted-metas")),
+            Matchers.is(true)
+        );
+        final XML fixed = source.fix();
+        MatcherAssert.assertThat(
+            "no unsorted-metas defect must remain after fix is applied",
+            new Source(fixed).defects().stream().noneMatch(d -> d.rule().startsWith("unsorted-metas")),
+            Matchers.is(true)
+        );
+    }
+}

--- a/src/it/lints-it/src/test/java/org/eolang/lints/it/FixesItTest.java
+++ b/src/it/lints-it/src/test/java/org/eolang/lints/it/FixesItTest.java
@@ -27,7 +27,7 @@ final class FixesItTest {
                 "<object>",
                 "<metas>",
                 "<meta line='1'><head>version</head><tail>0.0.0</tail></meta>",
-                "<meta line='2'><head>spdx</head><tail>SPDX-License-Identifier: MIT</tail></meta>",
+                "<meta line='2'><head>home</head><tail>https://www.eolang.org</tail></meta>",
                 "</metas>",
                 "</object>"
             )

--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -150,7 +150,7 @@ final class LtByXsl implements Lint {
 
     @Override
     public String motive() throws IOException {
-        return new  MotiveFrom(this.doc).asString();
+        return new MotiveFrom(this.doc).asString();
     }
 
     @Override

--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -150,7 +150,7 @@ final class LtByXsl implements Lint {
 
     @Override
     public String motive() throws IOException {
-        return new MotiveFrom(this.doc).asString();
+        return new  MotiveFrom(this.doc).asString();
     }
 
     @Override

--- a/src/main/java/org/eolang/lints/PkByXsl.java
+++ b/src/main/java/org/eolang/lints/PkByXsl.java
@@ -51,12 +51,6 @@ final class PkByXsl extends IterableEnvelope<Lint> {
     /**
      * Load all lints once.
      * @return List of all lints
-     * @todo #896:60min Make FxResource accept full URL strings so that the
-     *  fix path can be derived with the same LINTS_PATH pattern replacement
-     *  used for motives, dropping the intermediate xsl variable. Currently
-     *  FxResource.load() uses ClassLoader.getResource() which expects a
-     *  classpath-relative path, not a full jar:/file: URL, so the two
-     *  derivation approaches cannot be unified yet.
      */
     @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private static List<Lint> load() {

--- a/src/main/java/org/eolang/lints/Source.java
+++ b/src/main/java/org/eolang/lints/Source.java
@@ -81,6 +81,20 @@ public final class Source {
     }
 
     /**
+     * Apply all available fixes to the XMIR, returning the corrected document.
+     * Lints without a fix return the XMIR unchanged.
+     * @return Fixed XMIR
+     * @throws IOException If a fix fails to apply
+     */
+    public XML fix() throws IOException {
+        XML result = this.xmir;
+        for (final Lint lint : this.lints) {
+            result = lint.fix().apply(result);
+        }
+        return result;
+    }
+
+    /**
      * Find defects possible defects in the XMIR file.
      * @return All defects found
      * @see <a href="https://news.eolang.org/2022-11-25-xmir-guide.html">XMIR guide</a>


### PR DESCRIPTION
Removes the `PkByXsl` puzzle comment, adds `Source#fix()` method, and covers it with an integration test.

Fixes #914