### PR TITLE
#566: add invalid-name-notation lint

### DIFF
--- a/src/main/resources/org/eolang/lints/names/invalid-name-notation.xsl
+++ b/src/main/resources/org/eolang/lints/names/invalid-name-notation.xsl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  * SPDX-License-Identifier: MIT
+  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:eo="https://www.eolang.org" id="invalid-name-notation" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:import href="/org/eolang/funcs/special-name.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <!--
+    Object names should follow kebab-case convention:
+    - Only lowercase letters, digits, and hyphens
+    - Must start with a lowercase letter
+    - No digits at the start
+    Examples: valid: "my-object", invalid: "MyObject", "my_object", "my123"
+  -->
+  <xsl:function name="eo:kebab-case" as="xs:boolean">
+    <xsl:param name="name"/>
+    <xsl:sequence select="matches($name, '^[a-z][a-z0-9]*(-[a-z0-9]+)*$')"/>
+  </xsl:function>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[@name and not(eo:special(@name)) and not(@name='ξ') and not(eo:kebab-case(@name))]">
+        <defect>
+          <xsl:variable name="line" select="eo:lineno(@line)"/>
+          <xsl:attribute name="line">
+            <xsl:value-of select="$line"/>
+          </xsl:attribute>
+          <xsl:if test="$line = '0'">
+            <xsl:attribute name="context">
+              <xsl:value-of select="eo:defect-context(.)"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:attribute name="severity">warning</xsl:attribute>
+          <xsl:text>Object name </xsl:text>
+          <xsl:value-of select="eo:escape(@name)"/>
+          <xsl:text> does not follow kebab-case convention. Use lowercase letters and hyphens only.</xsl:text>
+        </defect>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/names/invalid-name-notation.md
+++ b/src/main/resources/org/eolang/motives/names/invalid-name-notation.md
@@ -1,0 +1,26 @@
+# Invalid Name Notation
+
+**Lint ID:** `invalid-name-notation`
+
+**Rule:** All object names should follow kebab-case convention.
+
+## What
+
+Names like `my-object` are valid. Names like `MyObject`, `my_object`, or `123test` are not.
+
+## Why
+
+Consistent naming conventions reduce cognitive load when reading EO code. Kebab-case is the [official EO naming convention](https://www.eolang.org/convention.html).
+
+## Examples
+
+```eo
+[] > my-object    ✓ valid
+[] > MyObject     ✗ invalid (camelCase)
+[] > my_object    ✗ invalid (snake_case)
+[] > 123test      ✗ invalid (starts with digit)
+```
+
+## Fix
+
+Rename the object to follow kebab-case: use only lowercase letters, digits, and hyphens, starting with a letter.

--- a/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/allows-valid-names.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/allows-valid-names.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/invalid-name-notation.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+document: |
+  <object author="tests">
+    <o name="my-object" line="1"/>
+    <o name="valid-name" line="2"/>
+    <o name="a" line="3"/>
+    <o name="kebab-case-123" line="4"/>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/catches-camelcase.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/catches-camelcase.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/invalid-name-notation.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='1']
+document: |
+  <object author="tests">
+    <o name="MyObject" line="1"/>
+    <o name="valid-name" line="2"/>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/catches-snake-case.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/catches-snake-case.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/invalid-name-notation.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='1']
+document: |
+  <object author="tests">
+    <o name="my_object" line="1"/>
+    <o name="valid-name" line="2"/>
+  </object>


### PR DESCRIPTION
New XSL lint that checks @name attributes follow kebab-case
convention. Rejects camelCase and snake_case names.

Includes motive documentation and three YAML test cases
(valid names, catches camelCase, catches snake_case).