### PR TITLE
#155: add too-deep-object lint

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/too-deep-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/too-deep-object.xsl
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:eo="https://www.eolang.org" id="too-deep-object" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:import href="/org/eolang/funcs/special-name.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <!--
+    Catch deeply nested EO objects (depth > 12).
+    Deep nesting makes code hard to read and reason about.
+    Use the `[] > app` syntax or inline definitions instead.
+  -->
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[not(eo:special(@name)) and count(ancestor::o) &gt; 12]">
+        <xsl:element name="defect">
+          <xsl:variable name="line" select="eo:lineno(@line)"/>
+          <xsl:attribute name="line">
+            <xsl:value-of select="$line"/>
+          </xsl:attribute>
+          <xsl:if test="$line = '0'">
+            <xsl:attribute name="context">
+              <xsl:value-of select="eo:defect-context(.)"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:attribute name="severity">warning</xsl:attribute>
+          <xsl:text>Object </xsl:text>
+          <xsl:choose>
+            <xsl:when test="@name">
+              <xsl:value-of select="eo:escape(@name)"/>
+            </xsl:when>
+            <xsl:otherwise>anonymous</xsl:otherwise>
+          </xsl:choose>
+          <xsl:text> is too deeply nested (depth </xsl:text>
+          <xsl:value-of select="count(ancestor::o)"/>
+          <xsl:text>). Consider refactoring with [] or inline definitions.</xsl:text>
+        </xsl:element>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/misc/too-deep-object.md
+++ b/src/main/resources/org/eolang/motives/misc/too-deep-object.md
@@ -1,0 +1,23 @@
+# Too deep object
+
+Objects nested more than 12 levels deep are hard to read and maintain.
+Flatten the hierarchy or extract inner objects into separate files.
+
+Incorrect:
+
+```eo
+[] > outer
+  [] > inner1
+    [] > inner2
+      ...
+        [] > inner12
+```
+
+Correct:
+
+```eo
+[] > outer
+  inner1 > @
+[] > inner1
+  inner2 > @
+```

--- a/src/test/resources/org/eolang/lints/packs/single/too-deep-object/allows-shallow-nesting.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/too-deep-object/allows-shallow-nesting.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/too-deep-object.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+document: |
+  <object author="tests">
+    <o name="outer" line="1">
+      <o name="i1" line="2">
+        <o name="i2" line="3">
+          <o name="i3" line="4">
+            <o name="i4" line="5">
+              <o name="i5" line="6">
+                <o name="i6" line="7">
+                  <o name="i7" line="8">
+                    <o name="i8" line="9">
+                      <o name="ok" line="10"/>
+                    </o>
+                  </o>
+                </o>
+              </o>
+            </o>
+          </o>
+        </o>
+      </o>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/too-deep-object/catches-deep-nesting.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/too-deep-object/catches-deep-nesting.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/too-deep-object.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+document: |
+  <object author="tests">
+    <o name="outer" line="1">
+      <o name="i1" line="2">
+        <o name="i2" line="3">
+          <o name="i3" line="4">
+            <o name="i4" line="5">
+              <o name="i5" line="6">
+                <o name="i6" line="7">
+                  <o name="i7" line="8">
+                    <o name="i8" line="9">
+                      <o name="i9" line="10">
+                        <o name="i10" line="11">
+                          <o name="i11" line="12">
+                            <o name="i12" line="13">
+                              <o name="too-deep" line="14"/>
+                            </o>
+                          </o>
+                        </o>
+                      </o>
+                    </o>
+                  </o>
+                </o>
+              </o>
+            </o>
+          </o>
+        </o>
+      </o>
+    </o>
+  </object>


### PR DESCRIPTION
New XSL lint that warns when objects are nested more than 12
levels deep.

Includes motive documentation and two YAML test cases
(shallow nesting allowed, deep nesting caught).