### PR TITLE
#65: GHA workflow to embed lint list into README

### DIFF
--- a/.github/workflows/lints-readme.yml
+++ b/.github/workflows/lints-readme.yml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+name: Update Lints README
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Update Lints README
+        run: |
+          mvn -q -ntp -P!hone,qulice exec:java \
+            -Dexec.mainClass=org.eolang.lints.LintsReadmeGenerator \
+            -Dexec.args="./README.md"
+      - name: Commit README
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git diff --cached --quiet || git commit -m "chore: update lints README [skip ci]"
+          git push

--- a/src/main/java/org/eolang/lints/LintsReadmeGenerator.java
+++ b/src/main/java/org/eolang/lints/LintsReadmeGenerator.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
+
+/**
+ * Generates the lints list for README.
+ * Called via `mvn exec:java` on push to master.
+ * @since 0.0.1
+ */
+public final class LintsReadmeGenerator {
+
+    /**
+     * Main entry point.
+     * @param args Path to README.md
+     * @throws IOException If file I/O fails
+     */
+    public static void main(final String... args) throws IOException {
+        if (args.length < 1) {
+            System.err.println("Usage: LintsReadmeGenerator <path-to-README.md>");
+            System.exit(1);
+        }
+        final Path readme = Path.of(args[0]);
+        final MonoLints all = new MonoLints();
+        final String list = all.stream()
+            .map(lint -> String.format("  - `%s`", lint.name()))
+            .collect(Collectors.joining("\n"));
+        final String start = "<!-- LINTS_START -->";
+        final String end = "<!-- LINTS_END -->";
+        final String content = Files.readString(readme)
+            .replaceAll(
+                "(?s)(" + java.util.regex.Pattern.quote(start) + ").*(?:" + java.util.regex.Pattern.quote(end) + ")?",
+                start + "\n" + list + "\n" + end
+            );
+        Files.writeString(readme, content);
+        System.out.println("README updated with " + all.stream().count() + " lints");
+    }
+}


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs on push to master,
scans all XSL lint files, and updates the lint list section
in the README.

Includes a Java generator class that produces the markdown
table from the classpath resources.