### PR TITLE
docs(#849): update version to 0.2.1 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ We use this package as a dependency in the
 <dependency>
   <groupId>org.eolang</groupId>
   <artifactId>lints</artifactId>
-  <version>0.1.0</version>
+  <version>0.2.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Updates the version reference in `README.md` from `0.1.0` to `0.2.1`.

Fixes #849