### PR TITLE
fix(#927): exclude newlines from ascii-only lint control char filter

### DIFF
--- a/src/main/java/org/eolang/lints/LtAsciiOnly.java
+++ b/src/main/java/org/eolang/lints/LtAsciiOnly.java
@@ -36,7 +36,7 @@ final class LtAsciiOnly implements Lint {
             .collect(Collectors.toList());
         for (final Xnav comment : comments) {
             final Optional<Character> abusive = comment.text().get().chars()
-                .filter(chr -> (chr < 32 && chr != '\n') || chr > 127)
+                .filter(chr -> chr < 32 && chr != '\n' || chr > 127)
                 .mapToObj(chr -> (char) chr)
                 .findFirst();
             if (!abusive.isPresent()) {

--- a/src/main/java/org/eolang/lints/LtAsciiOnly.java
+++ b/src/main/java/org/eolang/lints/LtAsciiOnly.java
@@ -36,7 +36,7 @@ final class LtAsciiOnly implements Lint {
             .collect(Collectors.toList());
         for (final Xnav comment : comments) {
             final Optional<Character> abusive = comment.text().get().chars()
-                .filter(chr -> chr < 32 || chr > 127)
+                .filter(chr -> (chr < 32 && chr != '\n') || chr > 127)
                 .mapToObj(chr -> (char) chr)
                 .findFirst();
             if (!abusive.isPresent()) {

--- a/src/main/java/org/eolang/lints/LtAsciiOnly.java
+++ b/src/main/java/org/eolang/lints/LtAsciiOnly.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
  *  ConditionalRegexpMultilineCheck from Checkstyle (it doesn't seem to be possible at the moment
  *  <a href="https://github.com/yegor256/qulice/issues/1328">issue 1328</a>)
  * @checkstyle StringLiteralsConcatenationCheck (30 lines)
+ * @checkstyle UnnecessaryParenthesesCheck (30 lines)
  */
 final class LtAsciiOnly implements Lint {
 
@@ -36,7 +37,7 @@ final class LtAsciiOnly implements Lint {
             .collect(Collectors.toList());
         for (final Xnav comment : comments) {
             final Optional<Character> abusive = comment.text().get().chars()
-                .filter(chr -> chr < 32 && chr != '\n' || chr > 127)
+                .filter(chr -> (chr < 32 && chr != '\n') || chr > 127)
                 .mapToObj(chr -> (char) chr)
                 .findFirst();
             if (!abusive.isPresent()) {

--- a/src/test/java/org/eolang/lints/LtAsciiOnlyTest.java
+++ b/src/test/java/org/eolang/lints/LtAsciiOnlyTest.java
@@ -76,4 +76,15 @@ final class LtAsciiOnlyTest {
             Matchers.equalTo(Severity.WARNING)
         );
     }
+
+    @Test
+    void doesNotFlagNewlinesInMultilineComment() throws IOException {
+        MatcherAssert.assertThat(
+            "Multi-line ASCII comment must not trigger ascii-only false positive",
+            new LtAsciiOnly().defects(
+                new EoProgram("org/eolang/lints/ascii-multiline-comment.eo").parse()
+            ),
+            Matchers.emptyIterable()
+        );
+    }
 }

--- a/src/test/resources/org/eolang/lints/ascii-multiline-comment.eo
+++ b/src/test/resources/org/eolang/lints/ascii-multiline-comment.eo
@@ -1,0 +1,7 @@
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# This is a multi-line comment
+# that spans several lines
+# all characters are valid ASCII
+[] > foo


### PR DESCRIPTION
Fix false positive in `ascii-only` lint for newlines in multi-line comments.

Fixes #927