### PR TITLE
fix(#952): skip `unit-test-missing` for concrete non-abstraction objects

### DIFF
--- a/src/main/resources/org/eolang/lints/tests/unit-test-missing.xsl
+++ b/src/main/resources/org/eolang/lints/tests/unit-test-missing.xsl
@@ -11,7 +11,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:if test="count(//o[starts-with(@name, '+')]) = 0">
+      <xsl:if test="count(//o[starts-with(@name, '+')]) = 0 and not(/object/o/@base)">
         <xsl:element name="defect">
           <xsl:attribute name="line">
             <xsl:value-of select="0"/>

--- a/src/test/resources/org/eolang/lints/packs/single/unit-test-missing/allows-concrete-object-without-tests-xmir.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unit-test-missing/allows-concrete-object-without-tests-xmir.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/unit-test-missing.xsl
+asserts:
+  - /defects[count(defect)=0]
+document: |
+  <object author="tests">
+    <o base="Φ.number" name="nan">7F-F8-00-00-00-00-00-00</o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/unit-test-missing/allows-concrete-object-without-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unit-test-missing/allows-concrete-object-without-tests.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/unit-test-missing.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # The not a number object.
+  number 7F-F8-00-00-00-00-00-00 > nan


### PR DESCRIPTION
Fixes false positive in `unit-test-missing` lint for concrete (non-abstraction) objects that have no unit tests to write.

Fixes #952