### PR TITLE
feat(#574): allow suppressing unused-void-attr with "unused" prefix

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/unused-void-attr.xsl
+++ b/src/main/resources/org/eolang/lints/misc/unused-void-attr.xsl
@@ -14,7 +14,7 @@
       <xsl:for-each select="//o[@base='∅']">
         <xsl:variable name="attr" select="@name"/>
         <xsl:variable name="formation" select=".."/>
-        <xsl:if test="not($attr='φ') and not(eo:atom($formation)) and not($formation//o[contains(@base, concat('ξ.', $attr))]/ancestor::o[eo:abstract(.)][1][generate-id()=$formation/generate-id()]) and not($formation//o[eo:atom(.)])">
+        <xsl:if test="not($attr='φ') and not(starts-with($attr, 'unused')) and not(eo:atom($formation)) and not($formation//o[contains(@base, concat('ξ.', $attr))]/ancestor::o[eo:abstract(.)][1][generate-id()=$formation/generate-id()]) and not($formation//o[eo:atom(.)])">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">
@@ -40,6 +40,7 @@
                 <xsl:text>anonymous object</xsl:text>
               </xsl:otherwise>
             </xsl:choose>
+            <xsl:text> (rename it with "unused" prefix to suppress)</xsl:text>
           </xsl:element>
         </xsl:if>
       </xsl:for-each>

--- a/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/allows-all-void-attrs-with-unused-prefix.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/allows-all-void-attrs-with-unused-prefix.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/unused-void-attr.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # Foo.
+  [unused unuseda unusedb] > foo
+    42 > bar

--- a/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/allows-mixed-attrs-with-unused-prefix.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/allows-mixed-attrs-with-unused-prefix.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/lints/misc/unused-void-attr.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # Foo.
+  [a unusedany b unusedany2] > foo
+    a.plus b > @

--- a/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/allows-void-attr-with-unused-prefix.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/allows-void-attr-with-unused-prefix.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/unused-void-attr.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # Foo.
+  [unusedi] > foo
+    42 > bar

--- a/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/catches-regular-attr-alongside-unused-prefix.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/catches-regular-attr-alongside-unused-prefix.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/lints/misc/unused-void-attr.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[1][contains(normalize-space(), 'The void attribute "b" is not used in the object "foo"')]
+input: |
+  # Foo.
+  [a unusedany b unusedany2] > foo
+    a.plus 1 > @

--- a/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/catches-unused-void-attr.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/catches-unused-void-attr.yaml
@@ -7,7 +7,7 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
   - /defects/defect[@line='2']
-  - /defects/defect[1][normalize-space()='The void attribute "x" is not used in the object "foo"']
+  - /defects/defect[1][contains(normalize-space(), 'The void attribute "x" is not used in the object "foo"')]
 input: |
   # Foo
   [x] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/catches-unused-void-attribute-horizontally-with-same-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/catches-unused-void-attribute-horizontally-with-same-name.yaml
@@ -7,7 +7,7 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
   - /defects/defect[@line='2']
-  - /defects/defect[1][normalize-space()='The void attribute "x" is not used in the object "foo"']
+  - /defects/defect[1][contains(normalize-space(), 'The void attribute "x" is not used in the object "foo"')]
 input: |
   # Foo.
   [x] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/catches-unused-void-attribute-with-same-named-formation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/catches-unused-void-attribute-with-same-named-formation.yaml
@@ -7,7 +7,7 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
   - /defects/defect[@line='2']
-  - /defects/defect[1][normalize-space()='The void attribute "x" is not used in the object "foo"']
+  - /defects/defect[1][contains(normalize-space(), 'The void attribute "x" is not used in the object "foo"')]
 input: |
   # No comments.
   [x] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/catches-void-with-same-name-in-canonical.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unused-void-attr/catches-void-with-same-name-in-canonical.yaml
@@ -7,7 +7,7 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
   - /defects/defect[@line='2']
-  - /defects/defect[1][normalize-space()='The void attribute "x" is not used in the object "foo"']
+  - /defects/defect[1][contains(normalize-space(), 'The void attribute "x" is not used in the object "foo"')]
 input: |
   # Foo.
   [x] > foo


### PR DESCRIPTION
Adds `unused` prefix suppression to `unused-void-attr` lint, allowing developers to silence false-positive warnings by renaming void attributes with the `unused` prefix.

Related to #574