### PR TITLE
fix(#805): skip capitalization check for `@todo`/`@fixme` markers

### DIFF
--- a/.pdd
+++ b/.pdd
@@ -3,6 +3,9 @@
 --exclude target/**/*
 --exclude coverage/**/*
 --exclude node_modules/**/*
+--exclude src/main/resources/org/eolang/motives/comments/comment-not-capitalized.md
+--exclude src/test/resources/org/eolang/lints/packs/single/comment-not-capitalized/allows-todo-marker-comment.yaml
+--exclude src/test/resources/org/eolang/lints/packs/single/comment-not-capitalized/allows-fixme-marker-comment.yaml
 --rule min-words:20
 --rule min-estimate:15
 --rule max-estimate:90

--- a/src/main/resources/org/eolang/lints/comments/comment-not-capitalized.xsl
+++ b/src/main/resources/org/eolang/lints/comments/comment-not-capitalized.xsl
@@ -10,7 +10,7 @@
   <xsl:template match="/">
     <xsl:variable name="min" select="32"/>
     <defects>
-      <xsl:for-each select="/object/comments/comment[not(matches(., '^[A-Z]'))]">
+      <xsl:for-each select="/object/comments/comment[not(matches(., '^[A-Z]')) and not(matches(., '^@\S+'))]">
         <xsl:element name="defect">
           <xsl:variable name="line" select="eo:lineno(@line)"/>
           <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/motives/comments/comment-not-capitalized.md
+++ b/src/main/resources/org/eolang/motives/comments/comment-not-capitalized.md
@@ -17,3 +17,12 @@ Correct:
 [] > foo
   42 > @
 ```
+
+Comments starting with an `@`-marker, such as `@todo` or `@fixme`, are
+exempt from this check:
+
+```eo
+# @todo #123:30min Implement this feature.
+[] > foo
+  42 > @
+```

--- a/src/main/resources/org/eolang/motives/comments/comment-not-capitalized.md
+++ b/src/main/resources/org/eolang/motives/comments/comment-not-capitalized.md
@@ -22,7 +22,7 @@ Comments starting with an `@`-marker, such as `@todo` or `@fixme`, are
 exempt from this check:
 
 ```eo
-# @todo #123:30min Implement this feature.
+# @todo implement this feature.
 [] > foo
   42 > @
 ```

--- a/src/main/resources/org/eolang/motives/comments/comment-not-capitalized.md
+++ b/src/main/resources/org/eolang/motives/comments/comment-not-capitalized.md
@@ -18,7 +18,7 @@ Correct:
   42 > @
 ```
 
-Comments starting with an `@`-marker, such as `@todo` or `@fixme`, are
+Comments starting with an `@`-marker, such as @todo or @fixme, are
 exempt from this check:
 
 ```eo

--- a/src/test/resources/org/eolang/lints/packs/single/comment-not-capitalized/allows-fixme-marker-comment.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/comment-not-capitalized/allows-fixme-marker-comment.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/comments/comment-not-capitalized.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # @fixme this code is broken after the refactoring.
+  [] > foo
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/comment-not-capitalized/allows-todo-marker-comment.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/comment-not-capitalized/allows-todo-marker-comment.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/comments/comment-not-capitalized.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # @todo #4475:35min Enable this feature after resize is implemented.
+  [] > foo
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/comment-not-capitalized/allows-todo-marker-comment.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/comment-not-capitalized/allows-todo-marker-comment.yaml
@@ -6,6 +6,6 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='warning'])=0]
 input: |
-  # @todo #4475:35min Enable this feature after resize is implemented.
+  # @todo this comment starts with a lowercase marker.
   [] > foo
     42 > @


### PR DESCRIPTION
The `comment-not-capitalized` lint now skips comments that begin with an `@`-marker (e.g., `@todo`, `@fixme`).

Fixes #805