### PR TITLE
fix(#963): suppress sparse-decoration false positive when `@` uses `^`

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/sparse-decoration.xsl
+++ b/src/main/resources/org/eolang/lints/misc/sparse-decoration.xsl
@@ -3,14 +3,18 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
  * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="sparse-decoration" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:eo="https://www.eolang.org" id="sparse-decoration" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:function name="eo:has-rho-ref" as="xs:boolean">
+    <xsl:param name="node" as="element()"/>
+    <xsl:sequence select="boolean($node/descendant-or-self::o[@base and matches(@base, '(^|\.)ρ(\.|$)')])"/>
+  </xsl:function>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[eo:abstract(.) and not(starts-with(@name, '+')) and count(o[not(@base='ξ' and @name='xi🌵')])=1 and o[not(@base='ξ' and @name='xi🌵')][1][@name='φ']]">
+      <xsl:for-each select="//o[eo:abstract(.) and not(starts-with(@name, '+')) and count(o[not(@base='ξ' and @name='xi🌵')])=1 and o[not(@base='ξ' and @name='xi🌵')][1][@name='φ'] and not(eo:has-rho-ref(o[not(@base='ξ' and @name='xi🌵')][1]))]">
         <xsl:element name="defect">
           <xsl:variable name="line" select="eo:lineno(@line)"/>
           <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/single/sparse-decoration/no-sparse-because-rho-application.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sparse-decoration/no-sparse-because-rho-application.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/sparse-decoration.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # No comments.
+  [] > tests
+    [foo] > return
+    # No comments.
+    [] > a
+      ^.return > @
+        plus.
+          42
+          1

--- a/src/test/resources/org/eolang/lints/packs/single/sparse-decoration/no-sparse-because-rho-nested-application.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sparse-decoration/no-sparse-because-rho-nested-application.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/sparse-decoration.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # No comments.
+  [] > func
+    ^.m.put (^.m.as-number.plus 1) > @

--- a/src/test/resources/org/eolang/lints/packs/single/sparse-decoration/no-sparse-because-rho.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sparse-decoration/no-sparse-because-rho.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/sparse-decoration.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # No comments.
+  [x] > a
+    # No comments.
+    [] > @
+      ^.x > @


### PR DESCRIPTION
Fixes false positive in `sparse-decoration` lint when the `@` attribute contains a `^` (rho) reference, which makes the wrapping semantically necessary.

Fixes #963