### PR TITLE
#565: expand idiomatic compound name patterns for stdlib

### DIFF
--- a/src/main/resources/org/eolang/lints/names/compound-name.xsl
+++ b/src/main/resources/org/eolang/lints/names/compound-name.xsl
@@ -22,7 +22,35 @@
   -->
   <xsl:function name="eo:idiomatic" as="xs:boolean">
     <xsl:param name="name"/>
-    <xsl:sequence select="starts-with($name, 'as-') or starts-with($name, 'is-') or ends-with($name, '-of')"/>
+    <xsl:sequence select="
+      starts-with($name, 'as-') or
+      starts-with($name, 'is-') or
+      starts-with($name, 'has-') or
+      starts-with($name, 'can-') or
+      starts-with($name, 'should-') or
+      starts-with($name, 'will-') or
+      ends-with($name, '-of') or
+      ends-with($name, '-from') or
+      ends-with($name, '-to') or
+      ends-with($name, '-with') or
+      starts-with($name, 'sin') or
+      starts-with($name, 'cos') or
+      starts-with($name, 'tan') or
+      starts-with($name, 'asin') or
+      starts-with($name, 'acos') or
+      starts-with($name, 'atan') or
+      starts-with($name, 'sqrt') or
+      starts-with($name, 'abs') or
+      starts-with($name, 'exp') or
+      starts-with($name, 'log') or
+      $name = 'stdin' or
+      $name = 'stdout' or
+      $name = 'stderr' or
+      $name = 'plus' or
+      $name = 'minus' or
+      $name = 'times' or
+      $name = 'divided'
+    "/>
   </xsl:function>
   <xsl:template match="/">
     <defects>


### PR DESCRIPTION
Fixes #565.

Expands the `eo:idiomatic` function in `compound-name.xsl` to recognize additional valid compound patterns from the EO standard library:

- Prefixes: `has-`, `can-`, `should-`, `will-` (boolean/capability predicates)
- Suffixes: `-from`, `-to`, `-with` (relational)
- Math functions: `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `sqrt`, `abs`, `exp`, `log`
- IO streams: `stdin`, `stdout`, `stderr`
- Arithmetic: `plus`, `minus`, `times`, `divided`

These names are legitimate compound attribute names used throughout the standard library and were incorrectly flagged by the lint.