### PR TITLE
fix(#970): wrap `Sticky` with `Synced` in `LtByXsl` for thread safety

### DIFF
--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 import org.cactoos.Input;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Synced;
 import org.cactoos.scalar.Unchecked;
 import org.cactoos.text.FormattedText;
 import org.cactoos.text.IoCheckedText;
@@ -96,19 +97,24 @@ final class LtByXsl implements Lint {
      */
     private LtByXsl(final Unchecked<XML> xml, final Input motive, final Fix fix) {
         this.rule = new Unchecked<>(
-            new Sticky<>(
-                () -> new Xnav(xml.value().toString())
-                    .element("xsl:stylesheet")
-                    .attribute("id")
-                    .text()
-                    .orElseThrow()
+            new Synced<>(
+                new Sticky<>(
+                    () -> new Xnav(xml.value().toString())
+                        .element("xsl:stylesheet")
+                        .attribute("id")
+                        .text()
+                        .orElseThrow()
+                )
             )
         );
         this.sheet = new Unchecked<>(
-            new Sticky<>(
-                () -> new MeasuredXsl(
-                    this.rule.value(),
-                    new XSLDocument(xml.value(), this.rule.value()).with(new ClasspathSources())
+            new Synced<>(
+                new Sticky<>(
+                    () -> new MeasuredXsl(
+                        this.rule.value(),
+                        new XSLDocument(xml.value(), this.rule.value())
+                            .with(new ClasspathSources())
+                    )
                 )
             )
         );

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -8,6 +8,7 @@ import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.manifests.Manifests;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XMLDocument;
+import com.yegor256.Together;
 import fixtures.BytecodeClass;
 import fixtures.EoProgram;
 import fixtures.FixPack;
@@ -25,6 +26,7 @@ import org.cactoos.io.InputOf;
 import org.cactoos.io.ReaderOf;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.map.MapOf;
+import org.cactoos.set.SetOf;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 import org.eolang.jucs.ClasspathSource;
@@ -35,6 +37,7 @@ import org.eolang.xax.XtoryMatcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -80,6 +83,23 @@ final class LtByXslTest {
                 new EoProgram("org/eolang/lints/duplicate-names.eo").parse()
             ),
             Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
+
+    @Tag("deep")
+    @RepeatedTest(5)
+    void lintsInMultipleThreads() {
+        final LtByXsl lint = new LtByXsl("critical/duplicate-names");
+        MatcherAssert.assertThat(
+            "wrong number of defects found, in parallel",
+            new SetOf<>(
+                new Together<>(
+                    t -> lint.defects(
+                        new EoProgram("org/eolang/lints/duplicate-names.eo").parse()
+                    ).size()
+                ).asList()
+            ).size(),
+            Matchers.equalTo(1)
         );
     }
 

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -88,6 +88,7 @@ final class LtByXslTest {
 
     @Tag("deep")
     @RepeatedTest(5)
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void lintsInMultipleThreads() {
         final LtByXsl lint = new LtByXsl("critical/duplicate-names");
         MatcherAssert.assertThat(


### PR DESCRIPTION
Wraps `Sticky` scalars in `Synced` inside `LtByXsl` to fix a thread-safety race condition that caused `NullPointerException` during parallel linting, and adds a concurrent regression test to guard against recurrence.

Fixes #970