### PR TITLE
perf(#975): use xsl:key to fix O(n²) complexity in redundant-object lint

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
@@ -8,12 +8,12 @@
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:key name="referenced-by-name" match="o[@base]" use="if (matches(@base, '^ξ(?:\.ρ)*\.')) then tokenize(replace(@base, '^ξ(?:\.ρ)*\.', ''), '\.')[1] else ''"/>
   <xsl:template match="/">
     <defects>
       <xsl:variable name="top" select="/object/o/generate-id()"/>
       <xsl:for-each select="//o[generate-id() != $top and @name and @name != 'φ' and @base and @base != '∅' and not(@base='ξ' and @name='xi🌵')]">
-        <xsl:variable name="usage" select="concat('^ξ(?:\.ρ)*\.', @name, '(?:\.[\w-]+)*$')"/>
-        <xsl:if test="count(//o[matches(@base, $usage)])&lt;=1 and not(@name and o[1]/@base = 'Φ.dataized')">
+        <xsl:if test="count(key('referenced-by-name', @name))&lt;=1 and not(@name and o[1]/@base = 'Φ.dataized')">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -243,6 +243,27 @@ final class LtByXslTest {
     }
 
     @Test
+    @Timeout(10L)
+    void checksRedundantObjectLintOnLargeXmirInReasonableTime() {
+        final int count = 2000;
+        final Directives dirs = new Directives()
+            .add("object")
+            .add("o").attr("name", "root");
+        for (int idx = 0; idx < count; idx += 1) {
+            dirs.add("o")
+                .attr("name", String.format("obj%d", idx))
+                .attr("base", String.format("ξ.obj%d", (idx + 1) % count))
+                .up();
+        }
+        Assertions.assertDoesNotThrow(
+            () -> new LtByXsl("misc/redundant-object").defects(
+                new XMLDocument(new Xembler(dirs).xml())
+            ),
+            "Large XMIR with many objects must not time out for redundant-object lint"
+        );
+    }
+
+    @Test
     void returnsNonExperimentalWhenXslStaysQuiet() {
         MatcherAssert.assertThat(
             "Experimental flag should be set to false",


### PR DESCRIPTION
Optimizes `redundant-object` lint by replacing O(n²) per-node regex traversal with an `xsl:key`-based lookup, and adds a timeout test to guard against regressions on large XMIR files.

Fixes #975