### PR TITLE
perf(#994): fix duplicate-as-attribute XSL to use key-based lookup

### DIFF
--- a/src/main/resources/org/eolang/lints/names/duplicate-as-attribute.xsl
+++ b/src/main/resources/org/eolang/lints/names/duplicate-as-attribute.xsl
@@ -8,42 +8,41 @@
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:key name="as-key" match="o/@as" use="."/>
+  <xsl:key name="as-key" match="o/@as" use="concat(generate-id(../..),  '|', .)"/>
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="//o[o[@as]]">
+        <xsl:variable name="pid" select="generate-id()"/>
         <xsl:variable name="oname" select="@name"/>
         <xsl:variable name="line" select="eo:lineno(@line)"/>
         <xsl:variable name="context" select="eo:defect-context(.)"/>
-        <xsl:variable name="attributes" select="o/@as"/>
-        <xsl:for-each select="distinct-values($attributes)">
-          <xsl:variable name="current" select="."/>
-          <xsl:variable name="duplicates" select="count($attributes[.= $current])"/>
-          <xsl:if test="$duplicates &gt; 1">
-            <defect>
-              <xsl:attribute name="line">
-                <xsl:value-of select="$line"/>
+        <xsl:for-each select="o/@as[
+          count(key('as-key', concat($pid, '|', .))) &gt; 1
+          and generate-id(.) = generate-id(key('as-key', concat($pid, '|', .))[1])
+        ]">
+          <defect>
+            <xsl:attribute name="line">
+              <xsl:value-of select="$line"/>
+            </xsl:attribute>
+            <xsl:if test="$line = '0'">
+              <xsl:attribute name="context">
+                <xsl:value-of select="$context"/>
               </xsl:attribute>
-              <xsl:if test="$line = '0'">
-                <xsl:attribute name="context">
-                  <xsl:value-of select="$context"/>
-                </xsl:attribute>
-              </xsl:if>
-              <xsl:attribute name="severity">warning</xsl:attribute>
-              <xsl:text>The </xsl:text>
-              <xsl:choose>
-                <xsl:when test="$oname">
-                  <xsl:text>object </xsl:text>
-                  <xsl:value-of select="eo:escape($oname)"/>
-                </xsl:when>
-                <xsl:otherwise>
-                  <xsl:text>anonymous object</xsl:text>
-                </xsl:otherwise>
-              </xsl:choose>
-              <xsl:text> has duplicated @as attribute </xsl:text>
-              <xsl:value-of select="eo:escape($current)"/>
-            </defect>
-          </xsl:if>
+            </xsl:if>
+            <xsl:attribute name="severity">warning</xsl:attribute>
+            <xsl:text>The </xsl:text>
+            <xsl:choose>
+              <xsl:when test="$oname">
+                <xsl:text>object </xsl:text>
+                <xsl:value-of select="eo:escape($oname)"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:text>anonymous object</xsl:text>
+              </xsl:otherwise>
+            </xsl:choose>
+            <xsl:text> has duplicated @as attribute </xsl:text>
+            <xsl:value-of select="eo:escape(.)"/>
+          </defect>
         </xsl:for-each>
       </xsl:for-each>
     </defects>

--- a/src/main/resources/org/eolang/lints/names/duplicate-as-attribute.xsl
+++ b/src/main/resources/org/eolang/lints/names/duplicate-as-attribute.xsl
@@ -16,10 +16,7 @@
         <xsl:variable name="oname" select="@name"/>
         <xsl:variable name="line" select="eo:lineno(@line)"/>
         <xsl:variable name="context" select="eo:defect-context(.)"/>
-        <xsl:for-each select="o[@as][
-          count(key('as-key', concat($pid, '|', @as))) &gt; 1
-          and generate-id(.) = generate-id(key('as-key', concat($pid, '|', @as))[1])
-        ]">
+        <xsl:for-each select="o[@as][count(key('as-key', concat($pid, '|', @as))) &gt; 1 and generate-id(.) = generate-id(key('as-key', concat($pid, '|', @as))[1])]">
           <defect>
             <xsl:attribute name="line">
               <xsl:value-of select="$line"/>

--- a/src/main/resources/org/eolang/lints/names/duplicate-as-attribute.xsl
+++ b/src/main/resources/org/eolang/lints/names/duplicate-as-attribute.xsl
@@ -8,7 +8,7 @@
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:key name="as-key" match="o/@as" use="concat(generate-id(../..),  '|', .)"/>
+  <xsl:key name="as-key" match="o[@as]" use="concat(generate-id(..), '|', @as)"/>
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="//o[o[@as]]">
@@ -16,9 +16,9 @@
         <xsl:variable name="oname" select="@name"/>
         <xsl:variable name="line" select="eo:lineno(@line)"/>
         <xsl:variable name="context" select="eo:defect-context(.)"/>
-        <xsl:for-each select="o/@as[
-          count(key('as-key', concat($pid, '|', .))) &gt; 1
-          and generate-id(.) = generate-id(key('as-key', concat($pid, '|', .))[1])
+        <xsl:for-each select="o[@as][
+          count(key('as-key', concat($pid, '|', @as))) &gt; 1
+          and generate-id(.) = generate-id(key('as-key', concat($pid, '|', @as))[1])
         ]">
           <defect>
             <xsl:attribute name="line">
@@ -41,7 +41,7 @@
               </xsl:otherwise>
             </xsl:choose>
             <xsl:text> has duplicated @as attribute </xsl:text>
-            <xsl:value-of select="eo:escape(.)"/>
+            <xsl:value-of select="eo:escape(@as)"/>
           </defect>
         </xsl:for-each>
       </xsl:for-each>

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -264,6 +264,31 @@ final class LtByXslTest {
     }
 
     @Test
+    @Timeout(10L)
+    void checksDuplicateAsAttributeLintOnLargeXmirInReasonableTime()
+        throws ImpossibleModificationException {
+        final int parents = 500;
+        final int args = 500;
+        final Directives dirs = new Directives().add("object");
+        for (int parent = 0; parent < parents; parent += 1) {
+            dirs.add("o").attr("name", String.format("obj%d", parent));
+            for (int arg = 0; arg < args; arg += 1) {
+                dirs.add("o")
+                    .attr("base", String.format("Φ.f%d", arg))
+                    .attr("as", String.format("arg%d", arg))
+                    .up();
+            }
+            dirs.up();
+        }
+        Assertions.assertDoesNotThrow(
+            () -> new LtByXsl("names/duplicate-as-attribute").defects(
+                new XMLDocument(new Xembler(dirs).xml())
+            ),
+            "Large XMIR with many @as attributes must not time out for duplicate-as-attribute lint"
+        );
+    }
+
+    @Test
     void returnsNonExperimentalWhenXslStaysQuiet() {
         MatcherAssert.assertThat(
             "Experimental flag should be set to false",


### PR DESCRIPTION
Fixes performance issue in `duplicate-as-attribute` lint by leveraging `xsl:key` for O(1) duplicate lookups instead of O(k²) per-parent scans, and adds a timeout test to prevent regressions.

Fixes #994