### PR TITLE
feat(#998): add comment-starts-with-article lint

### DIFF
--- a/src/main/resources/org/eolang/lints/comments/comment-starts-with-article.xsl
+++ b/src/main/resources/org/eolang/lints/comments/comment-starts-with-article.xsl
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="comment-starts-with-article" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="/object/comments/comment[matches(., '^(a|an|the)\s', 'i')]">
+        <xsl:element name="defect">
+          <xsl:variable name="line" select="eo:lineno(@line)"/>
+          <xsl:attribute name="line">
+            <xsl:value-of select="$line"/>
+          </xsl:attribute>
+          <xsl:if test="$line = '0'">
+            <xsl:attribute name="context">
+              <xsl:value-of select="eo:defect-context(.)"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:attribute name="severity">
+            <xsl:text>warning</xsl:text>
+          </xsl:attribute>
+          <xsl:text>The comment starts with an article ("a", "an", or "the"), which is redundant and should be removed</xsl:text>
+        </xsl:element>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/comments/comment-starts-with-article.md
+++ b/src/main/resources/org/eolang/motives/comments/comment-starts-with-article.md
@@ -1,0 +1,25 @@
+# Comment Starts With Article
+
+Comments should not start with an article, such as `a`, `an`, or `the`.
+An article at the beginning of a comment adds no information and makes
+the documentation more verbose than necessary.
+
+Incorrect:
+
+```eo
+# The object that calculates the sum.
+[] > foo
+  42 > @
+```
+
+Correct:
+
+```eo
+# Object that calculates the sum.
+[] > foo
+  42 > @
+```
+
+The check is case-insensitive, so `A`, `An`, and `The` are flagged as
+well. Words that merely begin with the same letters as an article, such
+as `Another` or `Theory`, are not affected.

--- a/src/test/resources/org/eolang/lints/packs/single/comment-starts-with-article/allows-comment-without-article.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/comment-starts-with-article/allows-comment-without-article.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/comments/comment-starts-with-article.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # Object that calculates the sum of two numbers.
+  [] > foo
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/comment-starts-with-article/allows-word-starting-like-article.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/comment-starts-with-article/allows-word-starting-like-article.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/comments/comment-starts-with-article.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # Another object that wraps a theory of numbers.
+  [] > foo
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/comment-starts-with-article/catches-a-article.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/comment-starts-with-article/catches-a-article.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/comments/comment-starts-with-article.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='2']
+input: |
+  # a simple object that does nothing useful.
+  [] > foo
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/comment-starts-with-article/catches-an-article.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/comment-starts-with-article/catches-an-article.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/comments/comment-starts-with-article.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='2']
+input: |
+  # An object that represents a single user.
+  [] > foo
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/comment-starts-with-article/catches-the-article.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/comment-starts-with-article/catches-the-article.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/comments/comment-starts-with-article.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='2']
+input: |
+  # The object that calculates the sum.
+  [] > foo
+    42 > @


### PR DESCRIPTION
Closes #998.

## What

Adds a new XSL-based lint `comment-starts-with-article` that reports a
**warning** when an object's comment starts with an article — `a`, `an`,
or `the`. As discussed in #998, a leading article adds no information and
makes documentation needlessly verbose.

Incorrect:

```eo
# The object that calculates the sum.
[] > foo
  42 > @
```

Correct:

```eo
# Object that calculates the sum.
[] > foo
  42 > @
```

## How

The lint matches the comment text against `^(a|an|the)\s` with the
case-insensitive flag, so `A`, `An`, `The` and `THE` are all caught.
Because an article must be followed by whitespace, words that merely
begin with the same letters — `Another`, `Theory`, `Andes` — are **not**
flagged.

The lint follows the existing `comments/*` conventions: it reuses the
`lineno` and `defect-context` functions, sets `@id` to match the file
name, and ships with the corresponding motive document. No fix XSL is
provided (none is required).

## Tests

YAML packs under `packs/single/comment-starts-with-article/`:

* `catches-the-article` / `catches-a-article` / `catches-an-article` —
  each article produces exactly one warning on the documented object;
* `allows-comment-without-article` — a clean comment is silent;
* `allows-word-starting-like-article` — `Another` / `theory` are not
  flagged (article must be a whole word).

The full `LtByXslTest` suite (which runs every pack and also checks that
each lint has a matching motive, a matching `@id`, and a valid pack
location) passes locally: 337 run, 0 failures, 0 errors.