### PR TITLE
feat(#999): add unsorted-void-attributes lint

### DIFF
--- a/src/main/resources/org/eolang/lints/errors/unsorted-void-attributes.xsl
+++ b/src/main/resources/org/eolang/lints/errors/unsorted-void-attributes.xsl
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="unsorted-void-attributes" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[@name and @base='∅' and count(o)=0]">
+        <xsl:variable name="previous" select="preceding-sibling::o[@name and @base='∅' and count(o)=0][1]"/>
+        <xsl:if test="$previous and @name &lt; $previous/@name">
+          <xsl:element name="defect">
+            <xsl:variable name="line" select="eo:lineno(@line)"/>
+            <xsl:attribute name="line">
+              <xsl:value-of select="$line"/>
+            </xsl:attribute>
+            <xsl:if test="$line = '0'">
+              <xsl:attribute name="context">
+                <xsl:value-of select="eo:defect-context(.)"/>
+              </xsl:attribute>
+            </xsl:if>
+            <xsl:attribute name="severity">
+              <xsl:text>warning</xsl:text>
+            </xsl:attribute>
+            <xsl:text>The void attribute </xsl:text>
+            <xsl:value-of select="eo:escape(@name)"/>
+            <xsl:text> is out of order, void attributes must be sorted alphabetically</xsl:text>
+          </xsl:element>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/errors/unsorted-void-attributes.md
+++ b/src/main/resources/org/eolang/motives/errors/unsorted-void-attributes.md
@@ -1,0 +1,25 @@
+# Unsorted void attributes
+
+Void attributes (free parameters) of a formation must be listed in
+alphabetical order. A consistent order makes the signature of an object
+easier to read and avoids arbitrary, meaningless differences between
+formations.
+
+Incorrect:
+
+```eo
+# No comments.
+[b a c] > foo
+  something > @
+```
+
+Correct:
+
+```eo
+# No comments.
+[a b c] > foo
+  something > @
+```
+
+Only the void attributes of a single formation are compared with each
+other. The bound attributes in the body are not affected.

--- a/src/test/resources/org/eolang/lints/packs/single/unsorted-void-attributes/allows-absence-of-void-attributes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unsorted-void-attributes/allows-absence-of-void-attributes.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/errors/unsorted-void-attributes.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # No comments.
+  [] > foo
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/unsorted-void-attributes/allows-single-void-attribute.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unsorted-void-attributes/allows-single-void-attribute.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/errors/unsorted-void-attributes.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # No comments.
+  [x] > foo
+    something > @

--- a/src/test/resources/org/eolang/lints/packs/single/unsorted-void-attributes/allows-sorted-void-attributes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unsorted-void-attributes/allows-sorted-void-attributes.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/errors/unsorted-void-attributes.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # No comments.
+  [a b c] > foo
+    something > @

--- a/src/test/resources/org/eolang/lints/packs/single/unsorted-void-attributes/catches-reversed-void-attributes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unsorted-void-attributes/catches-reversed-void-attributes.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/errors/unsorted-void-attributes.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=2]
+input: |
+  # No comments.
+  [c b a] > foo
+    something > @

--- a/src/test/resources/org/eolang/lints/packs/single/unsorted-void-attributes/catches-swapped-void-attributes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unsorted-void-attributes/catches-swapped-void-attributes.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/errors/unsorted-void-attributes.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+input: |
+  # No comments.
+  [b a c] > foo
+    something > @

--- a/src/test/resources/org/eolang/lints/packs/single/unsorted-void-attributes/catches-unsorted-in-the-middle.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unsorted-void-attributes/catches-unsorted-in-the-middle.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/errors/unsorted-void-attributes.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+input: |
+  # No comments.
+  [a c b] > foo
+    something > @

--- a/src/test/resources/org/eolang/lints/packs/single/unsorted-void-attributes/prints-context-when-lines-empty.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unsorted-void-attributes/prints-context-when-lines-empty.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/errors/unsorted-void-attributes.xsl
+asserts:
+  - /defects[count(defect[@context and @severity='warning'])=1]
+document: |
+  <object author="tests">
+    <o name="foo">
+       <o base="∅" name="b"/>
+       <o base="∅" name="a"/>
+       <o base="Φ.boom" name="φ"/>
+    </o>
+  </object>


### PR DESCRIPTION
Closes #999.

## What

Adds a new XSL-based lint `unsorted-void-attributes` that reports a
**warning** when the void attributes (free parameters) of a formation
are not listed in alphabetical order. As proposed in #999, a consistent
order makes an object's signature easier to read and removes arbitrary
differences between formations — the same principle already enforced by
`unsorted-metas`.

Incorrect:

```eo
# No comments.
[b a c] > foo
  something > @
```

Correct:

```eo
# No comments.
[a b c] > foo
  something > @
```

## How

Following the `unsorted-metas` approach, each void attribute is compared
with the **immediately preceding** void attribute of the same formation;
if its name is smaller, it is reported as out of order. This way every
out-of-order attribute is flagged individually (e.g. `[c b a]` yields two
warnings).

Only void attributes are considered — `o[@name and @base='∅' and
count(o)=0]`. Bound attributes in the body are ignored, and the
comparison is scoped per formation (siblings only), so nested formations
are checked independently.

## Tests

YAML packs under `packs/single/unsorted-void-attributes/`:

* `allows-sorted-void-attributes`, `allows-single-void-attribute`,
  `allows-absence-of-void-attributes` — silent on well-ordered, single
  and empty parameter lists;
* `catches-swapped-void-attributes` (`[b a c]`) and
  `catches-unsorted-in-the-middle` (`[a c b]`) — one warning each;
* `catches-reversed-void-attributes` (`[c b a]`) — two warnings;
* `prints-context-when-lines-empty` — exercises the `@context` branch
  when source lines are absent.

The full `LtByXslTest` suite (which runs every pack and also verifies
each lint has a matching motive, a matching `@id`, a valid pack location
and schema-valid `document` packs) passes locally: 359 run, 0 failures,
0 errors.