### PR TITLE
perf(#985): optimize many-void-attributes XSL to fix performance issue

### DIFF
--- a/src/main/resources/org/eolang/lints/errors/many-void-attributes.xsl
+++ b/src/main/resources/org/eolang/lints/errors/many-void-attributes.xsl
@@ -11,7 +11,7 @@
   <xsl:variable name="max" select="5"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[count(o[@name and @base='∅' and count(o)=0]) &gt; $max]">
+      <xsl:for-each select="//o[count(o[@name and @base='∅' and not(o)]) &gt; $max]">
         <xsl:element name="defect">
           <xsl:variable name="line" select="eo:lineno(@line)"/>
           <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/lints/errors/many-void-attributes.xsl
+++ b/src/main/resources/org/eolang/lints/errors/many-void-attributes.xsl
@@ -11,27 +11,31 @@
   <xsl:variable name="max" select="5"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[count(o[@name and @base='∅' and not(o)]) &gt; $max]">
-        <xsl:element name="defect">
-          <xsl:variable name="line" select="eo:lineno(@line)"/>
-          <xsl:attribute name="line">
-            <xsl:value-of select="$line"/>
-          </xsl:attribute>
-          <xsl:if test="$line = '0'">
-            <xsl:attribute name="context">
-              <xsl:value-of select="eo:defect-context(.)"/>
-            </xsl:attribute>
-          </xsl:if>
-          <xsl:attribute name="severity">
-            <xsl:text>warning</xsl:text>
-          </xsl:attribute>
-          <xsl:text>The object </xsl:text>
-          <xsl:value-of select="eo:escape(@name)"/>
-          <xsl:text> has more than </xsl:text>
-          <xsl:value-of select="$max"/>
-          <xsl:text> void attributes, it's too many</xsl:text>
-        </xsl:element>
-      </xsl:for-each>
+      <xsl:for-each-group select="//o[@name and @base='∅' and not(o)]" group-by="generate-id(..)">
+        <xsl:if test="count(current-group()) &gt; $max">
+          <xsl:for-each select="current-group()[1]/..">
+            <xsl:element name="defect">
+              <xsl:variable name="line" select="eo:lineno(@line)"/>
+              <xsl:attribute name="line">
+                <xsl:value-of select="$line"/>
+              </xsl:attribute>
+              <xsl:if test="$line = '0'">
+                <xsl:attribute name="context">
+                  <xsl:value-of select="eo:defect-context(.)"/>
+                </xsl:attribute>
+              </xsl:if>
+              <xsl:attribute name="severity">
+                <xsl:text>warning</xsl:text>
+              </xsl:attribute>
+              <xsl:text>The object </xsl:text>
+              <xsl:value-of select="eo:escape(@name)"/>
+              <xsl:text> has more than </xsl:text>
+              <xsl:value-of select="$max"/>
+              <xsl:text> void attributes, it's too many</xsl:text>
+            </xsl:element>
+          </xsl:for-each>
+        </xsl:if>
+      </xsl:for-each-group>
     </defects>
   </xsl:template>
 </xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/errors/many-void-attributes.xsl
+++ b/src/main/resources/org/eolang/lints/errors/many-void-attributes.xsl
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="many-void-attributes" version="2.0">
-  <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
@@ -12,7 +11,7 @@
   <xsl:variable name="max" select="5"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[count(o[@name and @base='∅' and not(eo:atom(.)) and count(o)=0]) &gt; $max]">
+      <xsl:for-each select="//o[count(o[@name and @base='∅' and count(o)=0]) &gt; $max]">
         <xsl:element name="defect">
           <xsl:variable name="line" select="eo:lineno(@line)"/>
           <xsl:attribute name="line">

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -59,6 +59,11 @@ import org.yaml.snakeyaml.Yaml;
 @SuppressWarnings("PMD.TooManyMethods")
 final class LtByXslTest {
 
+    /**
+     * XML attribute name.
+     */
+    private static final String NAME = "name";
+
     @Test
     void producesExpectedXmirWithFix() throws Exception {
         final FixPack pack = new FixPack(
@@ -248,10 +253,10 @@ final class LtByXslTest {
         final int count = 2000;
         final Directives dirs = new Directives()
             .add("object")
-            .add("o").attr("name", "root");
+            .add("o").attr(LtByXslTest.NAME, "root");
         for (int idx = 0; idx < count; idx += 1) {
             dirs.add("o")
-                .attr("name", String.format("obj%d", idx))
+                .attr(LtByXslTest.NAME, String.format("obj%d", idx))
                 .attr("base", String.format("ξ.obj%d", (idx + 1) % count))
                 .up();
         }
@@ -271,7 +276,7 @@ final class LtByXslTest {
         final int args = 500;
         final Directives dirs = new Directives().add("object");
         for (int parent = 0; parent < parents; parent += 1) {
-            dirs.add("o").attr("name", String.format("obj%d", parent));
+            dirs.add("o").attr(LtByXslTest.NAME, String.format("obj%d", parent));
             for (int arg = 0; arg < args; arg += 1) {
                 dirs.add("o")
                     .attr("base", String.format("Φ.f%d", arg))
@@ -294,16 +299,12 @@ final class LtByXslTest {
         throws ImpossibleModificationException {
         final int parents = 400;
         final int voids = 400;
-        final int grandchildren = 5;
+        final int depth = 5;
         final Directives dirs = new Directives().add("object");
         for (int parent = 0; parent < parents; parent += 1) {
-            dirs.add("o").attr("name", String.format("obj%d", parent));
+            dirs.add("o").attr(LtByXslTest.NAME, String.format("obj%d", parent));
             for (int idx = 0; idx < voids; idx += 1) {
-                dirs.add("o").attr("name", String.format("a%d", idx)).attr("base", "∅");
-                for (int grand = 0; grand < grandchildren; grand += 1) {
-                    dirs.add("o").attr("base", String.format("Φ.f%d", grand)).up();
-                }
-                dirs.up();
+                LtByXslTest.voidAttr(dirs, String.format("a%d", idx), depth);
             }
             dirs.up();
         }
@@ -382,6 +383,18 @@ final class LtByXslTest {
             failures,
             Matchers.empty()
         );
+    }
+
+    private static void voidAttr(
+        final Directives dirs,
+        final String name,
+        final int children
+    ) throws ImpossibleModificationException {
+        dirs.add("o").attr(LtByXslTest.NAME, name).attr("base", "∅");
+        for (int idx = 0; idx < children; idx += 1) {
+            dirs.add("o").attr("base", String.format("Φ.f%d", idx)).up();
+        }
+        dirs.up();
     }
 
     private static boolean schemaValid(final Map<Path, Map<String, Object>> pack) {

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -292,8 +292,8 @@ final class LtByXslTest {
     @Timeout(10L)
     void checksManyVoidAttributesLintOnLargeXmirInReasonableTime()
         throws ImpossibleModificationException {
-        final int parents = 500;
-        final int voids = 500;
+        final int parents = 400;
+        final int voids = 400;
         final int grandchildren = 5;
         final Directives dirs = new Directives().add("object");
         for (int parent = 0; parent < parents; parent += 1) {

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -59,11 +59,6 @@ import org.yaml.snakeyaml.Yaml;
 @SuppressWarnings("PMD.TooManyMethods")
 final class LtByXslTest {
 
-    /**
-     * XML attribute name.
-     */
-    private static final String NAME = "name";
-
     @Test
     void producesExpectedXmirWithFix() throws Exception {
         final FixPack pack = new FixPack(
@@ -253,10 +248,10 @@ final class LtByXslTest {
         final int count = 2000;
         final Directives dirs = new Directives()
             .add("object")
-            .add("o").attr(LtByXslTest.NAME, "root");
+            .add("o").attr("name", "root");
         for (int idx = 0; idx < count; idx += 1) {
             dirs.add("o")
-                .attr(LtByXslTest.NAME, String.format("obj%d", idx))
+                .attr("name", String.format("obj%d", idx))
                 .attr("base", String.format("ξ.obj%d", (idx + 1) % count))
                 .up();
         }
@@ -276,7 +271,7 @@ final class LtByXslTest {
         final int args = 500;
         final Directives dirs = new Directives().add("object");
         for (int parent = 0; parent < parents; parent += 1) {
-            dirs.add("o").attr(LtByXslTest.NAME, String.format("obj%d", parent));
+            dirs.add("o").attr("name", String.format("obj%d", parent));
             for (int arg = 0; arg < args; arg += 1) {
                 dirs.add("o")
                     .attr("base", String.format("Φ.f%d", arg))
@@ -302,7 +297,7 @@ final class LtByXslTest {
         final int depth = 5;
         final Directives dirs = new Directives().add("object");
         for (int parent = 0; parent < parents; parent += 1) {
-            dirs.add("o").attr(LtByXslTest.NAME, String.format("obj%d", parent));
+            dirs.add("o");
             for (int idx = 0; idx < voids; idx += 1) {
                 LtByXslTest.voidAttr(dirs, String.format("a%d", idx), depth);
             }
@@ -390,7 +385,7 @@ final class LtByXslTest {
         final String name,
         final int children
     ) throws ImpossibleModificationException {
-        dirs.add("o").attr(LtByXslTest.NAME, name).attr("base", "∅");
+        dirs.add("o").attr("name", name).attr("base", "∅");
         for (int idx = 0; idx < children; idx += 1) {
             dirs.add("o").attr("base", String.format("Φ.f%d", idx)).up();
         }

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -289,6 +289,33 @@ final class LtByXslTest {
     }
 
     @Test
+    @Timeout(10L)
+    void checksManyVoidAttributesLintOnLargeXmirInReasonableTime()
+        throws ImpossibleModificationException {
+        final int parents = 500;
+        final int voids = 500;
+        final int grandchildren = 5;
+        final Directives dirs = new Directives().add("object");
+        for (int parent = 0; parent < parents; parent += 1) {
+            dirs.add("o").attr("name", String.format("obj%d", parent));
+            for (int idx = 0; idx < voids; idx += 1) {
+                dirs.add("o").attr("name", String.format("a%d", idx)).attr("base", "∅");
+                for (int grand = 0; grand < grandchildren; grand += 1) {
+                    dirs.add("o").attr("base", String.format("Φ.f%d", grand)).up();
+                }
+                dirs.up();
+            }
+            dirs.up();
+        }
+        Assertions.assertDoesNotThrow(
+            () -> new LtByXsl("errors/many-void-attributes").defects(
+                new XMLDocument(new Xembler(dirs).xml())
+            ),
+            "Large XMIR with many void attributes must not time out for many-void-attributes lint"
+        );
+    }
+
+    @Test
     void returnsNonExperimentalWhenXslStaysQuiet() {
         MatcherAssert.assertThat(
             "Experimental flag should be set to false",


### PR DESCRIPTION
Optimizes `many-void-attributes` XSL to run within the 100ms threshold on large XMIR files by replacing the costly per-element predicate with `xsl:for-each-group`, and adds a regression test to prevent future performance regressions.

Fixes #985