### PR TITLE
fix(#967): trigger codecov workflow on pull requests

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,6 +7,9 @@ name: codecov
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 concurrency:
   group: codecov-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
This PR fixes #967.

The `codecov` workflow was configured to run only on pushes to `master`, which meant pull requests were not getting coverage checks.

In this PR, I added the `pull_request` trigger for the `master` branch in `.github/workflows/codecov.yml`.

As a result, Codecov will now run for pull requests as well, so coverage changes can be validated before merge.

Closes #967