### PR TITLE
perf(#977): fix quadratic XPath in named-object-abstract-nested lint

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/named-object-abstract-nested.xsl
+++ b/src/main/resources/org/eolang/lints/critical/named-object-abstract-nested.xsl
@@ -11,7 +11,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[@name]//o[@name and not(parent::o[eo:abstract(.)])]">
+      <xsl:for-each select="//o[@name and ancestor::o[@name] and not(parent::o[eo:abstract(.)])]">
         <defect>
           <xsl:variable name="line" select="eo:lineno(@line)"/>
           <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/motives/critical/named-object-abstract-nested.md
+++ b/src/main/resources/org/eolang/motives/critical/named-object-abstract-nested.md
@@ -5,6 +5,12 @@ abstract object.
 
 Incorrect:
 
+```eo
+[] > foo
+  xyz
+    num > abc
+```
+
 ```xml
 <o base="x" name="φ">
   <o base="y" name="a">
@@ -14,6 +20,12 @@ Incorrect:
 ```
 
 Correct:
+
+```eo
+[] > foo
+  num > abc
+  xyz $.abc > @
+```
 
 ```xml
 <o name="f">

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -312,6 +312,29 @@ final class LtByXslTest {
     }
 
     @Test
+    @Timeout(5L)
+    void checksNamedObjectAbstractNestedLintOnLargeXmirInReasonableTime()
+        throws ImpossibleModificationException {
+        final int chains = 500;
+        final int depth = 100;
+        final Directives dirs = new Directives().add("object");
+        for (int chain = 0; chain < chains; chain += 1) {
+            for (int idx = 0; idx < depth; idx += 1) {
+                dirs.add("o").attr("name", String.format("n%d_%d", chain, idx));
+            }
+            for (int idx = 0; idx < depth; idx += 1) {
+                dirs.up();
+            }
+        }
+        Assertions.assertDoesNotThrow(
+            () -> new LtByXsl("critical/named-object-abstract-nested").defects(
+                new XMLDocument(new Xembler(dirs).xml())
+            ),
+            "Large XMIR with many nested named objects must not time out for named-object-abstract-nested lint"
+        );
+    }
+
+    @Test
     void returnsNonExperimentalWhenXslStaysQuiet() {
         MatcherAssert.assertThat(
             "Experimental flag should be set to false",

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -56,7 +56,7 @@ import org.yaml.snakeyaml.Yaml;
  * @since 0.0.1
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"})
 final class LtByXslTest {
 
     @Test


### PR DESCRIPTION
Fixes O(n²) XPath in `named-object-abstract-nested` lint and adds a performance regression test.

Fixes #977