### PR TITLE
fix(#1001): detect unsorted named attributes

### DIFF
--- a/src/main/resources/org/eolang/lints/names/unsorted-named-attributes.xsl
+++ b/src/main/resources/org/eolang/lints/names/unsorted-named-attributes.xsl
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="unsorted-named-attributes">
+  <xsl:import href="/org/eolang/funcs/special-name.xsl"/>
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[eo:abstract(.) and @name]/o[@name and @base != '∅' and not(eo:special(@name)) and not(starts-with(@name, '+'))]">
+        <xsl:variable name="previous" select="(preceding-sibling::o[@name and @base != '∅' and not(eo:special(@name)) and not(starts-with(@name, '+'))])[last()]"/>
+        <xsl:if test="$previous and @name &lt; $previous/@name">
+          <defect>
+            <xsl:variable name="line" select="eo:lineno(@line)"/>
+            <xsl:attribute name="line">
+              <xsl:value-of select="$line"/>
+            </xsl:attribute>
+            <xsl:if test="$line = '0'">
+              <xsl:attribute name="context">
+                <xsl:value-of select="eo:defect-context(.)"/>
+              </xsl:attribute>
+            </xsl:if>
+            <xsl:attribute name="severity">warning</xsl:attribute>
+            <xsl:text>Named attribute </xsl:text>
+            <xsl:value-of select="eo:escape(@name)"/>
+            <xsl:text> is out of order inside formation </xsl:text>
+            <xsl:value-of select="eo:escape(../@name)"/>
+          </defect>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/names/unsorted-named-attributes.md
+++ b/src/main/resources/org/eolang/motives/names/unsorted-named-attributes.md
@@ -1,0 +1,23 @@
+# Unsorted named attributes
+
+Named attributes inside a formation should be listed in alphabetical
+order. A stable order makes code easier to read, review, and maintain.
+
+The `@` attribute is allowed to stay first, and test objects prefixed
+with `+` keep their own order handled by another lint.
+
+Incorrect:
+
+```eo
+[] > app
+  x.plus 1 > b
+  x.mul 2 > a
+```
+
+Correct:
+
+```eo
+[] > app
+  x.mul 2 > a
+  x.plus 1 > b
+```

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -192,21 +192,26 @@ final class SourceTest {
 
     @Test
     void createsSourceWithoutMultipleLints() {
+        final Collection<String> disabled = List.of(
+            "ascii-only",
+            "object-does-not-match-filename",
+            "comment-not-capitalized",
+            "empty-object",
+            "mandatory-home",
+            "mandatory-version",
+            "mandatory-package",
+            "comment-too-short",
+            "mandatory-spdx",
+            "no-attribute-formation",
+            "unit-test-missing"
+        );
         MatcherAssert.assertThat(
             "Defects for disabled lints are not empty, but should be",
-            new Source(new EoProgram("org/eolang/lints/non-ascii-cyrillic.eo").parse()).without(
-                "ascii-only",
-                "object-does-not-match-filename",
-                "comment-not-capitalized",
-                "empty-object",
-                "mandatory-home",
-                "mandatory-version",
-                "mandatory-package",
-                "comment-too-short",
-                "mandatory-spdx",
-                "no-attribute-formation",
-                "unit-test-missing"
-            ).defects(),
+            new Source(
+                new EoProgram("org/eolang/lints/non-ascii-cyrillic.eo").parse()
+            ).without(disabled.toArray(new String[0])).defects().stream()
+                .filter(defect -> disabled.contains(defect.rule()))
+                .collect(Collectors.toList()),
             Matchers.emptyIterable()
         );
     }

--- a/src/test/resources/org/eolang/lints/packs/single/unsorted-named-attributes/allows-phi-first.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unsorted-named-attributes/allows-phi-first.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/unsorted-named-attributes.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # No comments.
+  [x] > app
+    x > @
+    x.mul 2 > a
+    x.plus 1 > b

--- a/src/test/resources/org/eolang/lints/packs/single/unsorted-named-attributes/allows-sorted-named-attributes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unsorted-named-attributes/allows-sorted-named-attributes.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/unsorted-named-attributes.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # No comments.
+  [x] > app
+    x.mul 2 > a
+    x.plus 1 > b

--- a/src/test/resources/org/eolang/lints/packs/single/unsorted-named-attributes/catches-unsorted-named-attributes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unsorted-named-attributes/catches-unsorted-named-attributes.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/unsorted-named-attributes.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='4']
+  - >-
+    /defects/defect[normalize-space()='Named attribute "a" is out of order
+    inside formation "app"']
+input: |
+  # No comments.
+  [x] > app
+    x.plus 1 > b
+    x.mul 2 > a

--- a/src/test/resources/org/eolang/lints/packs/single/unsorted-named-attributes/ignores-test-order.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unsorted-named-attributes/ignores-test-order.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/unsorted-named-attributes.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # No comments.
+  [] > app
+    [] +> runs-app
+    [] > alpha
+    [] +> checks-app
+    [] > beta


### PR DESCRIPTION
This PR closes #1001.

I added a new lint `unsorted-named-attributes` that reports a warning when named attributes inside a formation are not ordered alphabetically.

What was done:
- added the new `unsorted-named-attributes` lint
- added a motive for the new rule
- added test cases for:
  - unsorted named attributes
  - correctly sorted named attributes
  - formations where `@` stays first
  - test objects prefixed with `+`, which should keep their own order

The lint ignores:
- `@` / `phi`
- formation arguments
- parser-generated special names
- test objects handled by `wrong-test-order`