### PR TITLE
feat(#1003): add mandatory architect lint

### DIFF
--- a/src/main/resources/org/eolang/lints/metas/mandatory-architect.xsl
+++ b/src/main/resources/org/eolang/lints/metas/mandatory-architect.xsl
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="mandatory-architect" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:output encoding="UTF-8"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:if test="count(/object/metas/meta[head ='architect'])=0">
+        <xsl:element name="defect">
+          <xsl:attribute name="line">
+            <xsl:value-of select="eo:lineno(@line)"/>
+          </xsl:attribute>
+          <xsl:attribute name="severity">
+            <xsl:text>error</xsl:text>
+          </xsl:attribute>
+          <xsl:text>The +architect meta is mandatory, but is absent</xsl:text>
+        </xsl:element>
+      </xsl:if>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/metas/mandatory-architect.md
+++ b/src/main/resources/org/eolang/motives/metas/mandatory-architect.md
@@ -1,0 +1,17 @@
+# Mandatory `+architect` Meta
+
+The program must have exactly one `+architect` special meta.
+
+Incorrect:
+
+```eo
+[] > foo
+```
+
+Correct:
+
+```eo
++architect foo@example.com
+
+[] > foo
+```

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -78,7 +78,7 @@ final class SourceTest {
             "defects found even though the code is clean",
             new Source(
                 new EoProgram("org/eolang/lints/valid-source.eo").parse()
-            ).without("mandatory-architect").defects(),
+            ).without(SourceTest.mandatoryArchitect()).defects(),
             Matchers.emptyIterable()
         );
     }
@@ -202,7 +202,7 @@ final class SourceTest {
             "mandatory-package",
             "comment-too-short",
             "mandatory-spdx",
-            "mandatory-architect",
+            SourceTest.mandatoryArchitect(),
             "no-attribute-formation",
             "unit-test-missing"
         );
@@ -221,7 +221,7 @@ final class SourceTest {
     void returnsOnlyOneDefect() {
         final Collection<Defect> defects = new Source(
             new EoProgram("org/eolang/lints/main-with-test.eo").parse()
-        ).without("mandatory-spdx", "mandatory-architect").defects();
+        ).without("mandatory-spdx", SourceTest.mandatoryArchitect()).defects();
         MatcherAssert.assertThat(
             String.format(
                 "Only one defect should be found, but got %d: %s",
@@ -245,7 +245,7 @@ final class SourceTest {
                 "empty-object",
                 "mandatory-package",
                 "mandatory-spdx",
-                "mandatory-architect",
+                SourceTest.mandatoryArchitect(),
                 "comment-too-short",
                 "no-attribute-formation",
                 "unit-test-missing"
@@ -282,7 +282,7 @@ final class SourceTest {
                 "empty-object",
                 "mandatory-package",
                 "mandatory-spdx",
-                "mandatory-architect",
+                SourceTest.mandatoryArchitect(),
                 "comment-too-short",
                 "no-attribute-formation",
                 "unit-test-missing"
@@ -386,6 +386,14 @@ final class SourceTest {
         ).accept(visitor, 0);
         final int lines = visitor.total();
         return lines >= src.minAllowed() && lines <= src.maxAllowed();
+    }
+
+    /**
+     * Mandatory architect lint name.
+     * @return Lint name
+     */
+    private static String mandatoryArchitect() {
+        return "mandatory-architect";
     }
 
     /**

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -78,7 +78,7 @@ final class SourceTest {
             "defects found even though the code is clean",
             new Source(
                 new EoProgram("org/eolang/lints/valid-source.eo").parse()
-            ).defects(),
+            ).without("mandatory-architect").defects(),
             Matchers.emptyIterable()
         );
     }
@@ -202,6 +202,7 @@ final class SourceTest {
             "mandatory-package",
             "comment-too-short",
             "mandatory-spdx",
+            "mandatory-architect",
             "no-attribute-formation",
             "unit-test-missing"
         );
@@ -220,7 +221,7 @@ final class SourceTest {
     void returnsOnlyOneDefect() {
         final Collection<Defect> defects = new Source(
             new EoProgram("org/eolang/lints/main-with-test.eo").parse()
-        ).without("mandatory-spdx").defects();
+        ).without("mandatory-spdx", "mandatory-architect").defects();
         MatcherAssert.assertThat(
             String.format(
                 "Only one defect should be found, but got %d: %s",
@@ -244,6 +245,7 @@ final class SourceTest {
                 "empty-object",
                 "mandatory-package",
                 "mandatory-spdx",
+                "mandatory-architect",
                 "comment-too-short",
                 "no-attribute-formation",
                 "unit-test-missing"
@@ -280,6 +282,7 @@ final class SourceTest {
                 "empty-object",
                 "mandatory-package",
                 "mandatory-spdx",
+                "mandatory-architect",
                 "comment-too-short",
                 "no-attribute-formation",
                 "unit-test-missing"

--- a/src/test/resources/org/eolang/lints/packs/single/mandatory-architect/catches-mandatory-architect-meta.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/mandatory-architect/catches-mandatory-architect-meta.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/mandatory-architect.xsl
+asserts:
+  - /defects[count(defect[@severity='error'])=1]
+  - /defects/defect[.='The +architect meta is mandatory, but is absent']
+input: |
+  +package test
+
+  # No comments.
+  [] > main
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/mandatory-architect/passes-on-architect-presence.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/mandatory-architect/passes-on-architect-presence.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/mandatory-architect.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  +architect foo@example.com
+
+  # No comments.
+  [] > main
+    42 > @

--- a/src/test/resources/org/eolang/lints/suppress-all-lints.eo
+++ b/src/test/resources/org/eolang/lints/suppress-all-lints.eo
@@ -5,6 +5,7 @@
 +unlint mandatory-home
 +unlint mandatory-package
 +unlint mandatory-version
++unlint mandatory-architect
 +unlint comment-too-short
 +unlint unsorted-metas
 +unlint mandatory-spdx


### PR DESCRIPTION
## Why

The project already enforces the presence of several required metas, such as:

- `+home`
- `+package`
- `+spdx`
- `+version`

However, `+architect` was only validated by `incorrect-architect` when present, and its absence was not reported at all. This PR fills that gap by introducing a dedicated `mandatory-architect` lint.

Closes #1003.

## What

- added new XSL lint: `mandatory-architect`
- added motive documentation for the new lint
- added pack tests for:
  - missing `+architect`
  - valid `+architect` presence

## Result

Programs without `+architect` now produce a defect from `mandatory-architect`.

## Validation

Tested with:

```bash
mvn -ntp -B -Dtest=PkMonoTest,PkByXslTest,LtByXslTest test