### PR TITLE
fix(#978): speed up bytes-without-data lint

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/bytes-without-data.xsl
+++ b/src/main/resources/org/eolang/lints/critical/bytes-without-data.xsl
@@ -11,7 +11,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:apply-templates select="//o[not(eo:has-data(.)) and parent::o[@base='Φ.bytes'] and eo:abstract(.)]" mode="with-data"/>
+      <xsl:apply-templates select="//o[parent::o[@base='Φ.bytes'] and not(@base) and not(text()[normalize-space()])]" mode="with-data"/>
     </defects>
   </xsl:template>
   <xsl:template match="o" mode="with-data">


### PR DESCRIPTION
## What this PR does

Optimizes the `bytes-without-data` lint by replacing expensive XPath predicates with a cheaper structural check.

Instead of evaluating `eo:has-data()` and `eo:abstract()` for every matching node, the lint now selects only nodes that:

- are children of `Φ.bytes`
- have no `@base`
- have no non-empty text content

## Why

The previous XPath was too slow on large XMIR files.

On the benchmark source set, `bytes-without-data` improved on `XXL` from `138ms` to `69ms`, which brings it below the `100ms` threshold from the issue.

## Validation

- benchmark suite passed
- XSL test suite passed