### PR TITLE
#998: add `comment-starts-with-article` lint

### DIFF
--- a/src/main/resources/org/eolang/lints/comments/comment-starts-with-article.xsl
+++ b/src/main/resources/org/eolang/lints/comments/comment-starts-with-article.xsl
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="comment-starts-with-article" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="/object/comments/comment[matches(., '^(A|An|The)\s')]">
+        <xsl:element name="defect">
+          <xsl:variable name="line" select="eo:lineno(@line)"/>
+          <xsl:attribute name="line">
+            <xsl:value-of select="$line"/>
+          </xsl:attribute>
+          <xsl:if test="$line = '0'">
+            <xsl:attribute name="context">
+              <xsl:value-of select="eo:defect-context(.)"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:attribute name="severity">
+            <xsl:text>warning</xsl:text>
+          </xsl:attribute>
+          <xsl:text>Comment must not start with an article ("A", "An" or "The"), begin with the meaningful word instead</xsl:text>
+        </xsl:element>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/comments/comment-starts-with-article.md
+++ b/src/main/resources/org/eolang/motives/comments/comment-starts-with-article.md
@@ -1,0 +1,21 @@
+# Comment Starts With An Article
+
+Object comments should not start with an article ("A", "An", or "The"). Such
+articles add no information and make comments unnecessarily verbose. Begin the
+comment directly with the meaningful word instead.
+
+Incorrect:
+
+```eo
+# The object that calculates the sum.
+[] > foo
+  42 > @
+```
+
+Correct:
+
+```eo
+# Object that calculates the sum.
+[] > foo
+  42 > @
+```

--- a/src/test/resources/org/eolang/lints/packs/single/comment-starts-with-article/allows-comment-without-article.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/comment-starts-with-article/allows-comment-without-article.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/comments/comment-starts-with-article.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # Object that calculates the sum.
+  [] > foo
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/comment-starts-with-article/catches-comment-starting-with-article.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/comment-starts-with-article/catches-comment-starting-with-article.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/comments/comment-starts-with-article.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='2']
+input: |
+  # The object that calculates the sum.
+  [] > foo
+    42 > @


### PR DESCRIPTION
Closes #998.

Adds a `comment-starts-with-article` lint that warns when an object comment starts with an article ("A", "An", or "The"), since the article adds no information and makes the comment unnecessarily verbose.

- `src/main/resources/org/eolang/lints/comments/comment-starts-with-article.xsl` — flags `/object/comments/comment` matching `^(A|An|The)\s` (auto-discovered by `PkByXsl`, `@id` matches the filename).
- `src/main/resources/org/eolang/motives/comments/comment-starts-with-article.md` — the motive with incorrect/correct examples.
- Two test packs under `packs/single/comment-starts-with-article/`: `catches-*` (a `# The ...` comment produces one warning) and `allows-*` (a comment without a leading article produces none).

Verified locally with `jdk21`: the new packs pass and the change adds no new failures to the module (the run is byte-for-byte identical to `master` on the pre-existing local-only `foo"bar` cases).
