### PR TITLE
feat(#1022): add lint to enforce kebab-case for formation names

### DIFF
--- a/src/main/resources/org/eolang/lints/names/non-kebab-name.xsl
+++ b/src/main/resources/org/eolang/lints/names/non-kebab-name.xsl
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  * SPDX-License-Identifier: MIT
+  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="non-kebab-name" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:import href="/org/eolang/funcs/special-name.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[@name and not(@base) and not(starts-with(@name, '+')) and not(eo:special(@name)) and not(matches(@name, '^[a-z][a-z0-9]*(-[a-z0-9]+)*$'))]">
+        <defect>
+          <xsl:variable name="line" select="eo:lineno(@line)"/>
+          <xsl:attribute name="line">
+            <xsl:value-of select="$line"/>
+          </xsl:attribute>
+          <xsl:if test="$line = '0'">
+            <xsl:attribute name="context">
+              <xsl:value-of select="eo:defect-context(.)"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:attribute name="severity">warning</xsl:attribute>
+          <xsl:text>Formation name </xsl:text>
+          <xsl:value-of select="eo:escape(@name)"/>
+          <xsl:text> must be in kebab-case</xsl:text>
+        </defect>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/names/non-kebab-name.md
+++ b/src/main/resources/org/eolang/motives/names/non-kebab-name.md
@@ -1,0 +1,22 @@
+# Formation Names Must Be in Kebab-case
+
+Formation names must use kebab-case: all lowercase letters and digits,
+with words separated by hyphens.
+camelCase and snake_case formation names are not allowed.
+
+Incorrect:
+
+```eo
+# CsvObject.
+[] > csvObject
+
+# Csv object.
+[] > csv_object
+```
+
+Correct:
+
+```eo
+# Csv object.
+[] > csv-object
+```

--- a/src/main/resources/org/eolang/motives/names/non-kebab-name.md
+++ b/src/main/resources/org/eolang/motives/names/non-kebab-name.md
@@ -2,7 +2,7 @@
 
 Formation names must use kebab-case: all lowercase letters and digits,
 with words separated by hyphens.
-camelCase and snake_case formation names are not allowed.
+`camelCase` and `snake_case` formation names are not allowed.
 
 Incorrect:
 

--- a/src/test/resources/org/eolang/lints/packs/single/non-kebab-name/allows-kebab-case.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/non-kebab-name/allows-kebab-case.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/non-kebab-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # Csv object.
+  [file] > csv-object
+    parse > records
+      read file

--- a/src/test/resources/org/eolang/lints/packs/single/non-kebab-name/allows-single-word.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/non-kebab-name/allows-single-word.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/non-kebab-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # No comments.
+  [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/non-kebab-name/catches-camel-case.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/non-kebab-name/catches-camel-case.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/non-kebab-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='2']
+input: |
+  # CsvObject.
+  [] > csvObject

--- a/src/test/resources/org/eolang/lints/packs/single/non-kebab-name/catches-snake-case.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/non-kebab-name/catches-snake-case.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/non-kebab-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='2']
+input: |
+  # Csv object.
+  [] > csv_object


### PR DESCRIPTION
Adds `non-kebab-name` lint to flag formation names not in kebab-case.

Related to #1022