### PR TITLE
#951: Recognize incorrect-unlint as a valid lint name

### DIFF
--- a/src/main/java/org/eolang/lints/MonoLints.java
+++ b/src/main/java/org/eolang/lints/MonoLints.java
@@ -38,7 +38,8 @@ final class MonoLints extends IterableEnvelope<Lint> {
         new Joined<Lint>(
             MonoLints.LINTS,
             new ListOf<>(
-                new LtUnlintNonExistingDefect(MonoLints.LINTS)
+                new LtUnlintNonExistingDefect(MonoLints.LINTS),
+                new LtIncorrectUnlint(List.of())
             )
         )
     ).stream()

--- a/src/test/java/org/eolang/lints/MonoLintsTest.java
+++ b/src/test/java/org/eolang/lints/MonoLintsTest.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.stream.Collectors;
+import org.cactoos.io.InputOf;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -45,6 +46,22 @@ final class MonoLintsTest {
             Matchers.hasItem(
                 "incorrect-unlint"
             )
+        );
+    }
+
+    @Test
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
+    void acceptsIncorrectUnlintSuppression() throws IOException {
+        final String source = "+unlint incorrect-unlint";
+        final Lint lint = new ListOf<>(new MonoLints()).stream()
+            .filter(item -> "incorrect-unlint".equals(item.name()))
+            .findFirst().orElseThrow(
+                () -> new IllegalStateException("Lint `incorrect-unlint` is absent")
+            );
+        MatcherAssert.assertThat(
+            "Valid `incorrect-unlint` suppression must not cause defects",
+            lint.defects(new EoProgram(source, new InputOf(source)).parse()),
+            Matchers.emptyIterable()
         );
     }
 


### PR DESCRIPTION
Fixes #951.

## Summary

`LtIncorrectUnlint` validates `+unlint` metas against
`MonoLints.ALL_NAMES`. However, `incorrect-unlint` was absent from this
collection because the lint is registered only after `ALL_NAMES` is
initialized.

This change:

- adds `LtIncorrectUnlint` to the collection used to build `ALL_NAMES`;
- allows `+unlint incorrect-unlint` without reporting a false-positive defect;
- adds a regression test covering the suppression through `MonoLints`.

## Testing

- `mvn -Dtest=MonoLintsTest test`
- `mvn clean verify -PskipTests -Pqulice --errors --batch-mode`