### PR TITLE
fix(#944): remove obsolete SpotBugs exclusion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -753,9 +753,6 @@
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>4.10.3.0</version>
-        <configuration>
-          <excludeFilterFile>${project.basedir}/spotbugs-exclude.xml</excludeFilterFile>
-        </configuration>
         <dependencies>
           <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
--->
-<FindBugsFilter>
-  <Class name="org.apache.hadoop.hdfs.server.namenode.FSNamesystem"/>
-</FindBugsFilter>


### PR DESCRIPTION
Closes #944.

The SpotBugs exclusion filter references a Hadoop class that is not present in this project.

This change:

- removes `spotbugs-exclude.xml`;
- removes the corresponding `excludeFilterFile` configuration from `pom.xml`.

The project successfully builds after the change:

- `mvn clean install -Pqulice`