### PR TITLE
fix(#601): simplify defect assertions

### DIFF
--- a/src/test/java/fixtures/XtDefects.java
+++ b/src/test/java/fixtures/XtDefects.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package fixtures;
+
+import com.jcabi.xml.XML;
+import com.yegor256.xsline.Xsline;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import org.eolang.xax.Xtory;
+
+/**
+ * A story with a short defect-count assertion.
+ * @since 1.0
+ */
+public final class XtDefects implements Xtory {
+
+    /**
+     * Original story.
+     */
+    private final Xtory origin;
+
+    /**
+     * New story.
+     * @param story Original story
+     */
+    public XtDefects(final Xtory story) {
+        this.origin = story;
+    }
+
+    @Override
+    public Map<String, Object> map() {
+        return this.origin.map();
+    }
+
+    @Override
+    public XML before() {
+        return this.origin.before();
+    }
+
+    @Override
+    public XML after() {
+        return this.origin.after();
+    }
+
+    @Override
+    public Xsline xsline() {
+        return this.origin.xsline();
+    }
+
+    @Override
+    public Collection<String> asserts() {
+        final Collection<String> assertions =
+            new ArrayList<>(this.origin.asserts());
+        final Object defects = this.map().get("defects");
+        if (defects != null) {
+            assertions.add(
+                String.format(
+                    "/defects[count(defect)=%s]",
+                    defects
+                )
+            );
+        }
+        return assertions;
+    }
+}

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -12,6 +12,7 @@ import com.yegor256.Together;
 import fixtures.BytecodeClass;
 import fixtures.EoProgram;
 import fixtures.FixPack;
+import fixtures.XtDefects;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -114,22 +115,15 @@ final class LtByXslTest {
                 "Pack '%s' doesn't tell the story as expected",
                 pack
             ),
-            new XtSticky(
-                new XtYaml(
-                    yaml,
-                    eo -> new EoProgram(pack, new InputOf(eo)).parse()
+            new XtDefects(
+                new XtSticky(
+                    new XtYaml(
+                        yaml,
+                        eo -> new EoProgram(pack, new InputOf(eo)).parse()
+                    )
                 )
             ),
             new XtoryMatcher(new DefectsMatcher())
-        );
-    }
-
-    @Test
-    void returnsMotive() throws Exception {
-        MatcherAssert.assertThat(
-            "The motive was not found or empty",
-            new LtByXsl("critical/duplicate-names").motive().isEmpty(),
-            Matchers.equalTo(false)
         );
     }
 
@@ -252,7 +246,7 @@ final class LtByXslTest {
         for (int idx = 0; idx < count; idx += 1) {
             dirs.add("o")
                 .attr("name", String.format("obj%d", idx))
-                .attr("base", String.format("ξ.obj%d", (idx + 1) % count))
+                .attr("base", String.format("Оѕ.obj%d", (idx + 1) % count))
                 .up();
         }
         Assertions.assertDoesNotThrow(
@@ -274,7 +268,7 @@ final class LtByXslTest {
             dirs.add("o").attr("name", String.format("obj%d", parent));
             for (int arg = 0; arg < args; arg += 1) {
                 dirs.add("o")
-                    .attr("base", String.format("Φ.f%d", arg))
+                    .attr("base", String.format("О¦.f%d", arg))
                     .attr("as", String.format("arg%d", arg))
                     .up();
             }
@@ -408,9 +402,9 @@ final class LtByXslTest {
         final String name,
         final int children
     ) throws ImpossibleModificationException {
-        dirs.add("o").attr("name", name).attr("base", "∅");
+        dirs.add("o").attr("name", name).attr("base", "в€…");
         for (int idx = 0; idx < children; idx += 1) {
-            dirs.add("o").attr("base", String.format("Φ.f%d", idx)).up();
+            dirs.add("o").attr("base", String.format("О¦.f%d", idx)).up();
         }
         dirs.up();
     }

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -128,6 +128,15 @@ final class LtByXslTest {
     }
 
     @Test
+    void returnsMotive() throws Exception {
+        MatcherAssert.assertThat(
+            "The motive was not found or empty",
+            new LtByXsl("critical/duplicate-names").motive().isEmpty(),
+            Matchers.equalTo(false)
+        );
+    }
+
+    @Test
     @SuppressWarnings("StreamResourceLeak")
     void checksLocationsOfYamlPacks() throws IOException {
         MatcherAssert.assertThat(
@@ -246,7 +255,7 @@ final class LtByXslTest {
         for (int idx = 0; idx < count; idx += 1) {
             dirs.add("o")
                 .attr("name", String.format("obj%d", idx))
-                .attr("base", String.format("Оѕ.obj%d", (idx + 1) % count))
+                .attr("base", String.format("ξ.obj%d", (idx + 1) % count))
                 .up();
         }
         Assertions.assertDoesNotThrow(
@@ -268,7 +277,7 @@ final class LtByXslTest {
             dirs.add("o").attr("name", String.format("obj%d", parent));
             for (int arg = 0; arg < args; arg += 1) {
                 dirs.add("o")
-                    .attr("base", String.format("О¦.f%d", arg))
+                    .attr("base", String.format("Φ.f%d", arg))
                     .attr("as", String.format("arg%d", arg))
                     .up();
             }
@@ -402,9 +411,9 @@ final class LtByXslTest {
         final String name,
         final int children
     ) throws ImpossibleModificationException {
-        dirs.add("o").attr("name", name).attr("base", "в€…");
+        dirs.add("o").attr("name", name).attr("base", "∅");
         for (int idx = 0; idx < children; idx += 1) {
-            dirs.add("o").attr("base", String.format("О¦.f%d", idx)).up();
+            dirs.add("o").attr("base", String.format("Φ.f%d", idx)).up();
         }
         dirs.up();
     }

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-accessing-its-own-void-in-auto.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-accessing-its-own-void-in-auto.yaml
@@ -4,8 +4,7 @@
 # yamllint disable rule:line-length
 sheets:
   - /org/eolang/lints/names/anonymous-formation.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # This unit test is supposed to check the functionality of the corresponding object.
   [] > go-tests

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-accessing-its-own-void-using-rho-ref.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-accessing-its-own-void-using-rho-ref.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/names/anonymous-formation.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # Foo.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-accessing-its-own-void-with-dot-notation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-accessing-its-own-void-with-dot-notation.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/names/anonymous-formation.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # App.
   [] > main

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-accessing-its-own-void.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-formation/allows-anonymous-accessing-its-own-void.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/names/anonymous-formation.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # App.
   [] > main

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-objects-inside-formation/allows-idempotent-in-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-objects-inside-formation/allows-idempotent-in-tests.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/errors/anonymous-objects-inside-formation.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   [] > foo
     [] +> tests-slice-foreign-literals

--- a/src/test/resources/org/eolang/lints/packs/single/anonymous-objects-inside-formation/allows-named-objects-inside.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anonymous-objects-inside-formation/allows-named-objects-inside.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/errors/anonymous-objects-inside-formation.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 document: |
   <object author="tests">
     <o line="1" name="li">

--- a/src/test/resources/org/eolang/lints/packs/single/application-without-as-attributes/allows-methods-without-as-attributes-in-eo.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/application-without-as-attributes/allows-methods-without-as-attributes-in-eo.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/errors/application-without-as-attributes.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # This is an object.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/application-without-as-attributes/allows-methods-without-as-attributes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/application-without-as-attributes/allows-methods-without-as-attributes.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/errors/application-without-as-attributes.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 document: |
   <object author="tests">
     <o base=".bar">

--- a/src/test/resources/org/eolang/lints/packs/single/application-without-as-attributes/allows-when-attributes-have-as.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/application-without-as-attributes/allows-when-attributes-have-as.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/errors/application-without-as-attributes.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 document: |
   <object author="tests">
     <o name="app">

--- a/src/test/resources/org/eolang/lints/packs/single/application-without-as-attributes/allows-when-nested-attributes-have-as.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/application-without-as-attributes/allows-when-nested-attributes-have-as.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/errors/application-without-as-attributes.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 document: |
   <object author="tests">
     <o name="app">

--- a/src/test/resources/org/eolang/lints/packs/single/atom-with-data/allows-atom-with-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/atom-with-data/allows-atom-with-tests.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/critical/atom-with-data.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # Boom.
   [] > boom /number

--- a/src/test/resources/org/eolang/lints/packs/single/broken-alias-first/accepts-good-aliases.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/broken-alias-first/accepts-good-aliases.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/aliases/broken-alias-first.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   +alias one
   +alias one-two

--- a/src/test/resources/org/eolang/lints/packs/single/broken-alias-second/accepts-good-aliases.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/broken-alias-second/accepts-good-aliases.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/aliases/broken-alias-second.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   +alias one
   +alias one-two

--- a/src/test/resources/org/eolang/lints/packs/single/bytes-without-data/allows-bytes-with-data.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bytes-without-data/allows-bytes-with-data.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/critical/bytes-without-data.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 document: |
   <object author="tests">
     <o name="bar" base="Φ.bytes" line="1">

--- a/src/test/resources/org/eolang/lints/packs/single/bytes-without-data/allows-non-abstract-without-data.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bytes-without-data/allows-non-abstract-without-data.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/critical/bytes-without-data.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 document: |
   <object author="tests">
     <o name="bar" base="Φ.bytes">

--- a/src/test/resources/org/eolang/lints/packs/single/direct-phi/allows-no-phi.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/direct-phi/allows-no-phi.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/errors/direct-phi.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   [args] > foo
     x.y > z

--- a/src/test/resources/org/eolang/lints/packs/single/duplicate-names/multi-anonymous.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/duplicate-names/multi-anonymous.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/critical/duplicate-names.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # Foo.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/error-line-out-of-listing/ignores-weird-line.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/error-line-out-of-listing/ignores-weird-line.yaml
@@ -4,8 +4,7 @@
 # yamllint disable rule:line-length
 sheets:
   - /org/eolang/lints/lines/error-line-out-of-listing.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 ignore-schema: true
 document: |
   <object author="tests">

--- a/src/test/resources/org/eolang/lints/packs/single/formation-with-as-attributes/allows-as-attributes-in-application.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/formation-with-as-attributes/allows-as-attributes-in-application.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/critical/formation-with-as-attributes.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 document: |
   <object author="tests">
     <o name='happl' base='Φ.f' line='1'>

--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-architect/good-architect.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-architect/good-architect.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/metas/incorrect-architect.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   +architect hello@gmail.com
 

--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-package/one-word-package.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-package/one-word-package.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/metas/incorrect-package.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   +package foo
 

--- a/src/test/resources/org/eolang/lints/packs/single/many-void-attributes/allows-absence-of-void-attrs.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/many-void-attributes/allows-absence-of-void-attrs.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/errors/many-void-attributes.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # No comments.
   [] > no-voids

--- a/src/test/resources/org/eolang/lints/packs/single/many-void-attributes/allows-acceptable-void-attrs.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/many-void-attributes/allows-acceptable-void-attrs.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/errors/many-void-attributes.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # No comments.
   [x y z] > main

--- a/src/test/resources/org/eolang/lints/packs/single/meta-line-out-of-listing/ignores-weird-line.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/meta-line-out-of-listing/ignores-weird-line.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/lines/meta-line-out-of-listing.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 ignore-schema: true
 document: |
   <object author="tests">

--- a/src/test/resources/org/eolang/lints/packs/single/no-attribute-formation/allows-formation-with-voids.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/no-attribute-formation/allows-formation-with-voids.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/design/no-attribute-formation.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # No comments.
   [x] > string-utils

--- a/src/test/resources/org/eolang/lints/packs/single/no-attribute-formation/allows-in-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/no-attribute-formation/allows-in-tests.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/design/no-attribute-formation.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # Foo.
   [x] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/no-attribute-formation/allows-nested-formation-to-be-attribute-free.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/no-attribute-formation/allows-nested-formation-to-be-attribute-free.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/design/no-attribute-formation.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # Foo.
   [x] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/no-attribute-formation/allows-recursive-nested-formation-to-be-attribute-free.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/no-attribute-formation/allows-recursive-nested-formation-to-be-attribute-free.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/design/no-attribute-formation.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # Foo.
   [x] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/not-empty-atom/allows-atom-with-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/not-empty-atom/allows-atom-with-tests.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/atoms/not-empty-atom.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # Some X atom.
   [] > x /number

--- a/src/test/resources/org/eolang/lints/packs/single/not-empty-atom/allows-atom-with-typed-lambda.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/not-empty-atom/allows-atom-with-typed-lambda.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/atoms/not-empty-atom.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 document: |
   <object author="tests">
     <o name="times">

--- a/src/test/resources/org/eolang/lints/packs/single/not-empty-atom/atom-with-void-attr.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/not-empty-atom/atom-with-void-attr.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/atoms/not-empty-atom.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 document: |
   <object author="tests">
     <o name="number">

--- a/src/test/resources/org/eolang/lints/packs/single/object-line-out-of-listing/ignores-weird-line.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/object-line-out-of-listing/ignores-weird-line.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/lines/object-line-out-of-listing.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 ignore-schema: true
 document: |
   <object author="tests">

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-autonamed.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-autonamed.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/misc/redundant-object.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # Foo.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-inlined.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-inlined.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/misc/redundant-object.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # Foo.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-redundant-phi-in-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-redundant-phi-in-tests.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/misc/redundant-object.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   [] > real
     [] +> tests-sqrt-check-nan-input

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-reused-via-dot-notation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-reused-via-dot-notation.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/misc/redundant-object.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # Foo.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-reused.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-reused.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/misc/redundant-object.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # Foo.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-top-unused.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-top-unused.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/misc/redundant-object.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # Foo.
   42 > foo

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-voids-used-once.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-voids-used-once.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/misc/redundant-object.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # Foo.
   [spb] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/respects-constants.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/respects-constants.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/misc/redundant-object.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # Foo.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/self-referencing/allows-different-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/self-referencing/allows-different-name.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/critical/self-referencing.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # App.
   [] > app

--- a/src/test/resources/org/eolang/lints/packs/single/self-referencing/allows-similar-name-with-dash.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/self-referencing/allows-similar-name-with-dash.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/critical/self-referencing.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # App.
   [] > app

--- a/src/test/resources/org/eolang/lints/packs/single/self-referencing/allows-similar-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/self-referencing/allows-similar-name.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/critical/self-referencing.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # App.
   [] > app

--- a/src/test/resources/org/eolang/lints/packs/single/self-referencing/self-referencing-no-catch.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/self-referencing/self-referencing-no-catch.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/critical/self-referencing.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # No comments.
   [] > first

--- a/src/test/resources/org/eolang/lints/packs/single/sparse-decoration/no-sparse-because-arguments.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sparse-decoration/no-sparse-because-arguments.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/misc/sparse-decoration.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # No comments.
   [free] > decorates-with-free-args

--- a/src/test/resources/org/eolang/lints/packs/single/unit-test-missing/allows-concrete-object-without-tests-xmir.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unit-test-missing/allows-concrete-object-without-tests-xmir.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/tests/unit-test-missing.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 document: |
   <object author="tests">
     <o base="Φ.number" name="nan">7F-F8-00-00-00-00-00-00</o>

--- a/src/test/resources/org/eolang/lints/packs/single/unit-test-missing/allows-concrete-object-without-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unit-test-missing/allows-concrete-object-without-tests.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/tests/unit-test-missing.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # The not a number object.
   number 7F-F8-00-00-00-00-00-00 > nan

--- a/src/test/resources/org/eolang/lints/packs/single/unit-test-missing/allows-object-with-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unit-test-missing/allows-object-with-tests.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/tests/unit-test-missing.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # Foo.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/unit-test-without-phi/allows-test-with-abstract-phi.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unit-test-without-phi/allows-test-with-abstract-phi.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/tests/unit-test-without-phi.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # Foo.
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/unsorted-metas/ignores-empty-metas.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unsorted-metas/ignores-empty-metas.yaml
@@ -3,8 +3,7 @@
 ---
 sheets:
   - /org/eolang/lints/metas/unsorted-metas.xsl
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   # No comments.
   [] > foo


### PR DESCRIPTION
This pull request simplifies zero-defect assertions in YAML lint tests.

Instead of repeating:

```yaml
asserts:
  - /defects[count(defect)=0]
```

tests can now use:

```yaml
defects: 0
```

The new `XtDefects` decorator converts the `defects` property into the corresponding XPath assertion. Existing zero-defect checks have been migrated to the shorter syntax.

The full build passes:

```text
mvn clean install -Pqulice
BUILD SUCCESS
```