### PR TITLE
fix(#950): keep line-zero defects with granular unlint

### DIFF
--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -80,7 +80,7 @@ final class LtUnlint implements Lint {
         problematic.forEach(
             line -> found.forEach(
                 defect -> {
-                    if (line != 0 && defect.line() == line) {
+                    if (defect.line() == line) {
                         defects.add(defect);
                         added.set(true);
                     }

--- a/src/test/java/org/eolang/lints/LtUnlintTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintTest.java
@@ -6,6 +6,7 @@ package org.eolang.lints;
 
 import fixtures.EoProgram;
 import java.io.IOException;
+import org.cactoos.io.InputOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -136,6 +137,23 @@ final class LtUnlintTest {
                 new EoProgram("org/eolang/lints/unlint-ascii-only-out-of-range.eo").parse()
             ),
             Matchers.iterableWithSize(2)
+        );
+    }
+
+    @Test
+    void keepsLineZeroDefectsWhenAnotherLineIsUnlinted() throws IOException {
+        final String src = String.join(
+            "\n",
+            "# This line only exists to place +unlint on a real EO line",
+            "+unlint always:5",
+            "[] > foo"
+        );
+        MatcherAssert.assertThat(
+            "A line-specific unlint must not suppress a line-zero defect",
+            new LtUnlint(new LtAlways()).defects(
+                new EoProgram(src, new InputOf(src)).parse()
+            ),
+            Matchers.hasSize(1)
         );
     }
 }

--- a/src/test/java/org/eolang/lints/LtUnlintTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintTest.java
@@ -143,7 +143,7 @@ final class LtUnlintTest {
     @Test
     void keepsLineZeroDefectsWhenAnotherLineIsUnlinted() throws IOException {
         final String src = String.join(
-            "\n",
+            System.lineSeparator(),
             "# This line only exists to place +unlint on a real EO line",
             "+unlint always:5",
             "[] > foo"


### PR DESCRIPTION
## What this PR does
- preserves line-0 defects when +unlint suppresses another line of the same lint
- adds a focused regression test for a line-specific +unlint against LtAlways`n
## Notes
- local Maven test execution was not available in this environment because mvn is not installed