### PR TITLE
fix(#954): ignore auto-named objects in wrong-test-order

### DIFF
--- a/src/main/resources/org/eolang/lints/tests/wrong-test-order.xsl
+++ b/src/main/resources/org/eolang/lints/tests/wrong-test-order.xsl
@@ -12,7 +12,10 @@
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="/object//o[starts-with(@name, '+')]">
-        <xsl:variable name="next" select="following-sibling::*[1]"/>
+        <xsl:variable
+          name="next"
+          select="following-sibling::o[not(starts-with(@name, 'a🌵'))][1]"
+        />
         <xsl:if test="$next[self::o] and not(starts-with($next/@name, '+'))">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>

--- a/src/main/resources/org/eolang/lints/tests/wrong-test-order.xsl
+++ b/src/main/resources/org/eolang/lints/tests/wrong-test-order.xsl
@@ -14,7 +14,7 @@
       <xsl:for-each select="/object//o[starts-with(@name, '+')]">
         <xsl:variable
           name="next"
-          select="following-sibling::o[not(starts-with(@name, 'a🌵'))][1]"
+          select="following-sibling::o[not(starts-with(@name, 'a&#x1F335;'))][1]"
         />
         <xsl:if test="$next[self::o] and not(starts-with($next/@name, '+'))">
           <xsl:element name="defect">

--- a/src/main/resources/org/eolang/lints/tests/wrong-test-order.xsl
+++ b/src/main/resources/org/eolang/lints/tests/wrong-test-order.xsl
@@ -12,10 +12,7 @@
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="/object//o[starts-with(@name, '+')]">
-        <xsl:variable
-          name="next"
-          select="following-sibling::o[not(starts-with(@name, 'a&#x1F335;'))][1]"
-        />
+        <xsl:variable name="next" select="following-sibling::o[not(starts-with(@name, 'a&#x1F335;'))][1]"/>
         <xsl:if test="$next[self::o] and not(starts-with($next/@name, '+'))">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>

--- a/src/main/resources/org/eolang/lints/tests/wrong-test-order.xsl
+++ b/src/main/resources/org/eolang/lints/tests/wrong-test-order.xsl
@@ -12,7 +12,7 @@
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="/object//o[starts-with(@name, '+')]">
-        <xsl:variable name="next" select="following-sibling::o[not(starts-with(@name, 'a&#x1F335;'))][1]"/>
+        <xsl:variable name="next" select="following-sibling::o[not(starts-with(@name, 'a🌵'))][1]"/>
         <xsl:if test="$next[self::o] and not(starts-with($next/@name, '+'))">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/allows-auto-named-anonymous-after-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/allows-auto-named-anonymous-after-tests.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/wrong-test-order.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+document: |
+  <object author="tests">
+    <o name="filtered">
+      <o name="+tests-filtered-with-bools" line="10"/>
+      <o name="a🌵18-4" line="18"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/allows-auto-named-anonymous-after-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/allows-auto-named-anonymous-after-tests.yaml
@@ -9,6 +9,6 @@ document: |
   <object author="tests">
     <o name="filtered">
       <o name="+tests-filtered-with-bools" line="10"/>
-      <o name="a🌵18-4" line="18"/>
+      <o name="a&#x1F335;18-4" line="18"/>
     </o>
   </object>


### PR DESCRIPTION
This closes #954.

The wrong-test-order lint currently inspects only the immediately following sibling after a test object. After ars-float-up, anonymous helper objects can be appended to the end of the parent object with auto-generated names like ??18-4, which makes correctly placed tests look as if they are followed by a non-test object.

This patch skips those auto-named siblings when searching for the first meaningful object after a test. A regression test was added with a minimal XMIR document where +tests-filtered-with-bools is followed only by ??18-4; master reports a false positive there, while the patch keeps the defect list empty.
