### PR TITLE
fix(#992): optimize rt-without-atoms XSL with xsl:key

### DIFF
--- a/src/main/resources/org/eolang/lints/atoms/rt-without-atoms.xsl
+++ b/src/main/resources/org/eolang/lints/atoms/rt-without-atoms.xsl
@@ -8,9 +8,10 @@
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:key name="atoms" match="o" use="exists(o[@name='lambda'])"/>
   <xsl:template match="/">
     <defects>
-      <xsl:if test="not(//o[eo:atom(.)])">
+      <xsl:if test="not(key('atoms', true()))">
         <xsl:if test="/object/metas/meta[head='rt']">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(/object/metas/meta[head='rt'][1]/@line)"/>


### PR DESCRIPTION
Closes #992.

## Problem
The `rt-without-atoms` XSL transformation exceeds 100ms threshold on large XMIR files (~128-129ms).

## Root Cause
The check `not(//o[eo:atom(.)])` scans the entire document when no atom is found. 
`eo:atom(.) = exists($o/o[@name=$eo:lambda])` performs a child lookup per element.
When the XMIR file has no atoms, every element is visited, making the cost O(n × degree).

## Solution
Added `xsl:key` for fast lookup of atoms.