### PR TITLE
fix(#990): optimize incorrect-test-object-name XSL with cached regexp

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/incorrect-test-object-name.xsl
+++ b/src/main/resources/org/eolang/lints/misc/incorrect-test-object-name.xsl
@@ -3,34 +3,33 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
  * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="incorrect-test-object-name">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="incorrect-test-object-name" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:variable name="regexp" select="'^[a-z0-9]+(-[a-z0-9]+)*$'"/>
+  
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="/object//o[starts-with(@name, '+')]">
-        <xsl:variable name="regexp" select="'^[a-z][a-z0-9]*(-[a-z0-9]+)*$'"/>
-        <xsl:if test="not(matches(eo:escape-plus(@name), $regexp))">
-          <defect>
-            <xsl:variable name="line" select="eo:lineno(@line)"/>
-            <xsl:attribute name="line">
-              <xsl:value-of select="$line"/>
+      <xsl:for-each select="//o[@name and starts-with(@name, '+') and not(matches(substring-after(@name, '+'), $regexp))]">
+        <xsl:element name="defect">
+          <xsl:variable name="line" select="eo:lineno(@line)"/>
+          <xsl:attribute name="line">
+            <xsl:value-of select="$line"/>
+          </xsl:attribute>
+          <xsl:if test="$line = '0'">
+            <xsl:attribute name="context">
+              <xsl:value-of select="eo:defect-context(.)"/>
             </xsl:attribute>
-            <xsl:if test="$line = '0'">
-              <xsl:attribute name="context">
-                <xsl:value-of select="eo:defect-context(.)"/>
-              </xsl:attribute>
-            </xsl:if>
-            <xsl:attribute name="severity">warning</xsl:attribute>
-            <xsl:text>The name of the object </xsl:text>
-            <xsl:value-of select="eo:escape(@name)"/>
-            <xsl:text> doesn't match </xsl:text>
-            <xsl:value-of select="eo:escape($regexp)"/>
-          </defect>
-        </xsl:if>
+          </xsl:if>
+          <xsl:attribute name="severity">
+            <xsl:text>error</xsl:text>
+          </xsl:attribute>
+          <xsl:text>Incorrect test object name: </xsl:text>
+          <xsl:value-of select="eo:escape(@name)"/>
+        </xsl:element>
       </xsl:for-each>
     </defects>
   </xsl:template>


### PR DESCRIPTION
Closes #990.

## Problem
The `incorrect-test-object-name` XSL transformation exceeds 100ms threshold on large XMIR files (~107-119ms).

## Root Cause
For each test object the transformation calls `eo:escape-plus(@name)` (a user-defined function) and then `matches(..., $regexp)` where `$regexp` is a constant defined inside the for-each. On large files the per-element function-call overhead adds up.

## Solution
1. Moved `$regexp` to a top-level variable so Saxon can cache the compiled pattern
2. Replaced `eo:escape-plus(@name)` with `substring-after(@name, '+')` for better performance