### PR TITLE
Upgrade tojos to 0.19.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
     <dependency>
       <groupId>com.yegor256</groupId>
       <artifactId>tojos</artifactId>
-      <version>0.18.6</version>
+      <version>0.19.1</version>
     </dependency>
     <dependency>
       <groupId>com.opencsv</groupId>

--- a/src/main/groovy/org/eolang/lints/HomeNames.groovy
+++ b/src/main/groovy/org/eolang/lints/HomeNames.groovy
@@ -82,7 +82,7 @@ final class HomeNames {
       new TjCached(
         new TjSynchronized(
           new TjDefault(
-            new MnCsv(csv)
+            new MnCsv(Paths.get(csv))
           )
         )
       ),

--- a/src/main/java/org/eolang/lints/ReservedNames.java
+++ b/src/main/java/org/eolang/lints/ReservedNames.java
@@ -8,6 +8,7 @@ import com.yegor256.tojos.MnCsv;
 import com.yegor256.tojos.TjCached;
 import com.yegor256.tojos.TjDefault;
 import com.yegor256.tojos.TjSynchronized;
+import java.nio.file.Paths;
 import org.cactoos.iterable.IterableOf;
 import org.cactoos.map.MapEntry;
 import org.cactoos.map.MapEnvelope;
@@ -37,7 +38,7 @@ final class ReservedNames extends MapEnvelope<String, String> {
                 new IterableOf<>(
                     () -> new TjCached(
                         new TjSynchronized(
-                            new TjDefault(new MnCsv(path))
+                            new TjDefault(new MnCsv(Paths.get(path)))
                         )
                     ).select(tojo -> true).iterator()
                 )

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -455,7 +455,7 @@ final class SourceTest {
                 new Synced<>(new Sticky<>(new PkMono())),
                 new TjCached(
                     new TjDefault(
-                        new MnCsv("target/timings.csv")
+                        new MnCsv(Paths.get("target/timings.csv"))
                     )
                 ),
                 size

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -425,6 +425,11 @@ final class SourceTest {
     private static final class BcSource {
 
         /**
+         * Path to timings.
+         */
+        private static final Path TIMINGS = Paths.get("target/timings.csv");
+
+        /**
          * XMIR.
          */
         private final XML xmir;
@@ -455,7 +460,7 @@ final class SourceTest {
                 new Synced<>(new Sticky<>(new PkMono())),
                 new TjCached(
                     new TjDefault(
-                        new MnCsv(Paths.get("target/timings.csv"))
+                        new MnCsv(BcSource.TIMINGS)
                     )
                 ),
                 size


### PR DESCRIPTION
Bumps the `com.yegor256:tojos` dependency from 0.18.6 to 0.19.1.

The new release drops the `MnCsv(String)` constructor in favor of `MnCsv(Path)`, so the three call sites that built an `MnCsv` from a path string now wrap it in `Paths.get`: `ReservedNames`, the `HomeNames` Groovy generator, and the timing store in `SourceTest`.

Verified by running the full `reserved` profile suite, which exercises all three paths end to end and passes.