### PR TITLE
fix(#1047): align JUnit dependencies with BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,17 @@
     <!-- This is the flag that allows to skip all tests -->
     <skipTests/>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>6.1.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>com.jcabi</groupId>
@@ -257,25 +268,21 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>6.0.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>6.0.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>6.0.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <version>6.0.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Closes #1047.

## Changes

- import the JUnit BOM at version 6.1.2;
- remove individual versions from Jupiter and Platform dependencies;
- ensure all JUnit modules use the same version during future updates.

## Verification

Before the fix, Surefire aborted with conflicting JUnit versions and ran 0 tests.

After the fix:
- all JUnit Jupiter and Platform modules resolve to 6.1.2;
- `LtByXslTest`: 356 tests, 0 failures, 0 errors;
- `mvn clean install -Pqulice`: BUILD SUCCESS.