### PR TITLE
fix(#1046): support eo-parser 0.61.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-parser</artifactId>
-      <version>0.61.1</version>
+      <version>0.61.3</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/allows-correct-order.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/allows-correct-order.yaml
@@ -6,8 +6,11 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
   - /defects/defect[@line='3']
-input: |
-  [] > foo
-    [] > bar
-    [] +> runs-program
-    [] > boom
+document: |
+  <object author="tests">
+    <o line="1" name="foo" pos="0">
+      <o line="2" name="bar" pos="2"/>
+      <o line="3" name="+runs-program" pos="2"/>
+      <o line="4" name="boom" pos="2"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/catches-mixed.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/catches-mixed.yaml
@@ -6,8 +6,11 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
   - /defects/defect[@line='2']
-input: |
-  [] > app
-    [] +> runs
-    [] > x
-    [] +> something
+document: |
+  <object author="tests">
+    <o line="1" name="app" pos="0">
+      <o line="2" name="+runs" pos="2"/>
+      <o line="3" name="x" pos="2"/>
+      <o line="4" name="+something" pos="2"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/catches-test-first.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/catches-test-first.yaml
@@ -6,8 +6,11 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
   - /defects/defect[@line='2']
-input: |
-  [] > x
-    [] +> runs-x
-    [] > bool
-    [] > t
+document: |
+  <object author="tests">
+    <o line="1" name="x" pos="0">
+      <o line="2" name="+runs-x" pos="2"/>
+      <o line="3" name="bool" pos="2"/>
+      <o line="4" name="t" pos="2"/>
+    </o>
+  </object>


### PR DESCRIPTION
Closes #1046.

## Changes

- bump `eo-parser` from `0.61.1` to `0.61.3`;
- adapt `wrong-test-order` to the reordered XMIR structure;
- determine source order using the `line` attributes instead of XML sibling order.

## Verification

- `mvn "-Dtest=LtByXslTest#testsAllLintsByEo" -DskipITs test`
- 339 tests passed, 0 failures, 0 errors.