### PR TITLE
#1045: add same-package-alias lint

### DIFF
--- a/src/main/resources/org/eolang/lints/aliases/same-package-alias.xsl
+++ b/src/main/resources/org/eolang/lints/aliases/same-package-alias.xsl
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="same-package-alias" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:variable name="pkg" select="/object/metas/meta[head='package']/tail"/>
+      <xsl:for-each select="/object/metas/meta[head='alias' and count(part)=2]">
+        <xsl:variable name="local" select="part[1]"/>
+        <xsl:variable name="fqn" select="replace(part[2], '^Φ\.', '')"/>
+        <xsl:if test="$pkg != '' and $fqn = concat($pkg, '.', $local)">
+          <xsl:element name="defect">
+            <xsl:variable name="line" select="eo:lineno(@line)"/>
+            <xsl:attribute name="line">
+              <xsl:value-of select="$line"/>
+            </xsl:attribute>
+            <xsl:if test="$line = '0'">
+              <xsl:attribute name="context">
+                <xsl:value-of select="eo:defect-context(.)"/>
+              </xsl:attribute>
+            </xsl:if>
+            <xsl:attribute name="severity">
+              <xsl:text>error</xsl:text>
+            </xsl:attribute>
+            <xsl:text>The alias </xsl:text>
+            <xsl:value-of select="eo:escape($fqn)"/>
+            <xsl:text> is redundant, because it refers to the same package as the current file</xsl:text>
+          </xsl:element>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/aliases/same-package-alias.md
+++ b/src/main/resources/org/eolang/motives/aliases/same-package-alias.md
@@ -1,0 +1,30 @@
+# Same-package alias
+
+An `+alias` meta that points to an object in the same package as the
+current file is redundant. Since the compiler auto-homes a bare
+reference to an object of the same package, the alias adds nothing and
+should be removed.
+
+Incorrect (the file's package is `org.eolang.txt`):
+
+```eo
++package org.eolang.txt
++alias org.eolang.txt.sprintf
+
+# Foo.
+[x] > foo
+  sprintf x > @
+```
+
+Correct:
+
+```eo
++package org.eolang.txt
+
+# Foo.
+[x] > foo
+  sprintf x > @
+```
+
+A cross-package alias, or an alias that renames the object to a new
+local name, is not redundant and stays untouched.

--- a/src/main/resources/org/eolang/motives/aliases/same-package-alias.md
+++ b/src/main/resources/org/eolang/motives/aliases/same-package-alias.md
@@ -1,9 +1,9 @@
 # Same-package alias
 
 An `+alias` meta that points to an object in the same package as the
-current file is redundant. Since the compiler auto-homes a bare
-reference to an object of the same package, the alias adds nothing and
-should be removed.
+current file is redundant. Since the compiler resolves a bare
+reference to an object of the same package on its own, the alias adds
+nothing and should be removed.
 
 Incorrect (the file's package is `org.eolang.txt`):
 

--- a/src/test/resources/org/eolang/lints/packs/single/same-package-alias/allows-cross-package-alias.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/same-package-alias/allows-cross-package-alias.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/aliases/same-package-alias.xsl
+asserts:
+  - /defects[count(defect[@severity='error'])=0]
+input: |
+  +package org.eolang.txt
+  +alias org.eolang.io.stdout
+
+  # Foo.
+  [x] > foo
+    stdout x > @

--- a/src/test/resources/org/eolang/lints/packs/single/same-package-alias/allows-renamed-same-package-alias.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/same-package-alias/allows-renamed-same-package-alias.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/aliases/same-package-alias.xsl
+asserts:
+  - /defects[count(defect[@severity='error'])=0]
+input: |
+  +package org.eolang.txt
+  +alias sp org.eolang.txt.sprintf
+
+  # Foo.
+  [x] > foo
+    sp x > @

--- a/src/test/resources/org/eolang/lints/packs/single/same-package-alias/catches-same-package-alias.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/same-package-alias/catches-same-package-alias.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/aliases/same-package-alias.xsl
+asserts:
+  - /defects[count(defect[@severity='error'])=1]
+input: |
+  +package org.eolang.txt
+  +alias org.eolang.txt.sprintf
+
+  # Foo.
+  [x] > foo
+    sprintf x > @

--- a/src/test/resources/org/eolang/lints/packs/single/same-package-alias/prints-context-when-lines-empty.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/same-package-alias/prints-context-when-lines-empty.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/aliases/same-package-alias.xsl
+asserts:
+  - /defects[count(defect[@context and @severity='error'])=1]
+document: |
+  <object author="tests">
+    <metas>
+      <meta>
+        <head>package</head>
+        <tail>org.eolang.txt</tail>
+        <part>org.eolang.txt</part>
+      </meta>
+      <meta>
+        <head>alias</head>
+        <tail>sprintf Φ.org.eolang.txt.sprintf</tail>
+        <part>sprintf</part>
+        <part>Φ.org.eolang.txt.sprintf</part>
+      </meta>
+    </metas>
+    <o name="foo"/>
+  </object>


### PR DESCRIPTION
Closes #1045.

Adds a new lint `same-package-alias` that catches `+alias` metas which refer to an object in the same package as the file's own `+package` meta. Since #5425 the compiler auto-homes a bare reference to an object in the same package, so such an alias is dead weight (see objectionary/eo#5527, which removed all the existing ones by hand).

The parser expands `+alias org.eolang.txt.sprintf` into the two-part form `sprintf Φ.org.eolang.txt.sprintf`. The lint flags a meta when the fully qualified name (without the `Φ.` prefix) equals `<package>.<local-name>`. A renamed alias (`+alias sp org.eolang.txt.sprintf`) or a cross-package alias is left alone, since those are not redundant.

Includes a motive document and four pack tests: catches the redundant case, allows a cross-package alias, allows a renamed same-package alias, and checks the context is printed when line numbers are missing.
