### PR TITLE
fix(#1055): detect aliases with overlapping prefixes

### DIFF
--- a/src/main/resources/org/eolang/lints/aliases/unused-alias.xsl
+++ b/src/main/resources/org/eolang/lints/aliases/unused-alias.xsl
@@ -12,7 +12,7 @@
     <defects>
       <xsl:for-each select="/object/metas/meta[head='alias' and count(part)=2]">
         <xsl:variable name="name" select="tokenize(tail, ' ')[last()]"/>
-        <xsl:if test="count(//o[starts-with(@base, $name)])=0">
+        <xsl:if test="count(//o[@base = $name or starts-with(@base, concat($name, '.'))]) = 0">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/single/unused-alias/detects-alias-prefix-collision.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unused-alias/detects-alias-prefix-collision.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+
+---
+sheets:
+  - /org/eolang/lints/aliases/unused-alias.xsl
+asserts:
+  - /defects[count(defect[@severity='error'])=1]
+  - /defects/defect[@line='1']
+input: |
+  +alias first org.example.alpha
+  +alias second org.example.alphabet
+
+  # No comments.
+  [] > foo
+    second > @


### PR DESCRIPTION
Closes #1055.

The `unused-alias` lint previously considered any object whose base started
with the alias target to be a usage of that alias.

For example, using `Φ.org.example.alphabet` incorrectly marked
`Φ.org.example.alpha` as used.

This change accepts only:

- an exact match with the alias target;
- access to an attribute of that target, separated by a dot.

A regression fixture with overlapping alias target prefixes was added.

Tests:

- `LtByXslTest`: 340 tests, 0 failures
- `mvn clean install -Pqulice`
