### PR TITLE
Normalize XML and XSL formatting for xcop

### DIFF
--- a/build-scripts/validate-markdown.xml
+++ b/build-scripts/validate-markdown.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <project name="validate-markdown" default="validate">
   <target name="validate">

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -381,10 +381,10 @@
       <activation>
         <activeByDefault>false</activeByDefault>
         <!--
-          @todo #711:45min Enable `hone` profile on all platforms after.
-           For now, `hone-maven-plugin` fails on `macOS` and `Windows` machines.
-           After the issue will be fixed, we should `<os/>` element from the `<activation/>`
-           and keep `activeByDefault=true`.
+        @todo #711:45min Enable `hone` profile on all platforms after.
+        For now, `hone-maven-plugin` fails on `macOS` and `Windows` machines.
+        After the issue will be fixed, we should `<os/>` element from the `<activation/>`
+        and keep `activeByDefault=true`.
         -->
       </activation>
       <build>
@@ -517,7 +517,7 @@
               <fork>true</fork>
               <release>11</release>
               <showWarnings>true</showWarnings>
-              <!--If you want to get all the errors at once, write false here and run-->
+              <!-- If you want to get all the errors at once, write false here and run -->
               <failOnWarning>true</failOnWarning>
               <compilerArgs>
                 <arg>-XDcompilePolicy=simple</arg>

--- a/src/it/lints-it/pom.xml
+++ b/src/it/lints-it/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
   <profiles>

--- a/src/main/resources/org/eolang/fixes/metas/unsorted-metas.xsl
+++ b/src/main/resources/org/eolang/fixes/metas/unsorted-metas.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="unsorted-metas-fix" version="2.0">
   <xsl:output encoding="UTF-8" method="xml"/>

--- a/src/main/resources/org/eolang/funcs/defect-context.xsl
+++ b/src/main/resources/org/eolang/funcs/defect-context.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="defect-context" version="2.0">
   <xsl:function name="eo:defect-context" as="xs:string">

--- a/src/main/resources/org/eolang/funcs/escape.xsl
+++ b/src/main/resources/org/eolang/funcs/escape.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="escape" version="2.0">
   <xsl:function name="eo:escape" as="xs:string">

--- a/src/main/resources/org/eolang/funcs/lineno.xsl
+++ b/src/main/resources/org/eolang/funcs/lineno.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="lineno" version="2.0">
   <xsl:function name="eo:lineno" as="xs:string">

--- a/src/main/resources/org/eolang/funcs/special-name.xsl
+++ b/src/main/resources/org/eolang/funcs/special-name.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="special-name" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/aliases/alias-too-long.xsl
+++ b/src/main/resources/org/eolang/lints/aliases/alias-too-long.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="alias-too-long" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/aliases/broken-alias-first.xsl
+++ b/src/main/resources/org/eolang/lints/aliases/broken-alias-first.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="broken-alias-first" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/aliases/broken-alias-second.xsl
+++ b/src/main/resources/org/eolang/lints/aliases/broken-alias-second.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="broken-alias-second" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/aliases/duplicate-aliases.xsl
+++ b/src/main/resources/org/eolang/lints/aliases/duplicate-aliases.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="duplicate-aliases" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/aliases/empty-alias.xsl
+++ b/src/main/resources/org/eolang/lints/aliases/empty-alias.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="empty-alias" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/aliases/unused-alias.xsl
+++ b/src/main/resources/org/eolang/lints/aliases/unused-alias.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="unused-alias" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/atoms/atom-and-base.xsl
+++ b/src/main/resources/org/eolang/lints/atoms/atom-and-base.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="atom-and-base" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/atoms/atom-in-atom.xsl
+++ b/src/main/resources/org/eolang/lints/atoms/atom-in-atom.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="atom-in-atom" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/atoms/atom-without-rt.xsl
+++ b/src/main/resources/org/eolang/lints/atoms/atom-without-rt.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="atom-without-rt" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/atoms/lambda-with-inners.xsl
+++ b/src/main/resources/org/eolang/lints/atoms/lambda-with-inners.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="lambda-with-inners" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/atoms/not-empty-atom.xsl
+++ b/src/main/resources/org/eolang/lints/atoms/not-empty-atom.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="not-empty-atom" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/atoms/rt-without-atoms.xsl
+++ b/src/main/resources/org/eolang/lints/atoms/rt-without-atoms.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="rt-without-atoms" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/comments/comment-is-too-wide.xsl
+++ b/src/main/resources/org/eolang/lints/comments/comment-is-too-wide.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="comment-is-too-wide" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/comments/comment-not-capitalized.xsl
+++ b/src/main/resources/org/eolang/lints/comments/comment-not-capitalized.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="comment-not-capitalized" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/comments/comment-starts-with-article.xsl
+++ b/src/main/resources/org/eolang/lints/comments/comment-starts-with-article.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="comment-starts-with-article" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/comments/comment-too-short.xsl
+++ b/src/main/resources/org/eolang/lints/comments/comment-too-short.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="comment-too-short" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/comments/comment-without-dot.xsl
+++ b/src/main/resources/org/eolang/lints/comments/comment-without-dot.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="comment-without-dot" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/critical/atom-with-data.xsl
+++ b/src/main/resources/org/eolang/lints/critical/atom-with-data.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="atom-with-data" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/critical/bytes-without-data.xsl
+++ b/src/main/resources/org/eolang/lints/critical/bytes-without-data.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="bytes-without-data" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/critical/duplicate-names.xsl
+++ b/src/main/resources/org/eolang/lints/critical/duplicate-names.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="duplicate-names" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/critical/formation-with-as-attributes.xsl
+++ b/src/main/resources/org/eolang/lints/critical/formation-with-as-attributes.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="formation-with-as-attributes" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/critical/incorrect-bytes-format.xsl
+++ b/src/main/resources/org/eolang/lints/critical/incorrect-bytes-format.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="incorrect-bytes-format">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/critical/incorrect-rt-parts.xsl
+++ b/src/main/resources/org/eolang/lints/critical/incorrect-rt-parts.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="incorrect-rt-parts" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/critical/name-outside-of-abstract-object.xsl
+++ b/src/main/resources/org/eolang/lints/critical/name-outside-of-abstract-object.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="name-outside-of-abstract-object" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/critical/named-object-abstract-nested.xsl
+++ b/src/main/resources/org/eolang/lints/critical/named-object-abstract-nested.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="named-object-abstract-nested" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/critical/object-has-data.xsl
+++ b/src/main/resources/org/eolang/lints/critical/object-has-data.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="object-has-data">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/critical/package-without-tail.xsl
+++ b/src/main/resources/org/eolang/lints/critical/package-without-tail.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="package-without-tail" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/critical/pos-without-line.xsl
+++ b/src/main/resources/org/eolang/lints/critical/pos-without-line.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="pos-without-line" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/critical/schema-is-absent.xsl
+++ b/src/main/resources/org/eolang/lints/critical/schema-is-absent.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="schema-is-absent" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/critical/self-referencing.xsl
+++ b/src/main/resources/org/eolang/lints/critical/self-referencing.xsl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="self-referencing" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="self-referencing" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>

--- a/src/main/resources/org/eolang/lints/critical/unknown-rt.xsl
+++ b/src/main/resources/org/eolang/lints/critical/unknown-rt.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="unknown-rt" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/critical/void-attributes-not-higher-than-other.xsl
+++ b/src/main/resources/org/eolang/lints/critical/void-attributes-not-higher-than-other.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="void-attributes-not-higher-than-other" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/design/no-attribute-formation.xsl
+++ b/src/main/resources/org/eolang/lints/design/no-attribute-formation.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="no-attribute-formation">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/errors/anonymous-objects-inside-formation.xsl
+++ b/src/main/resources/org/eolang/lints/errors/anonymous-objects-inside-formation.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="anonymous-objects-inside-formation" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/errors/application-without-as-attributes.xsl
+++ b/src/main/resources/org/eolang/lints/errors/application-without-as-attributes.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="application-without-as-attributes" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/errors/decorated-formation.xsl
+++ b/src/main/resources/org/eolang/lints/errors/decorated-formation.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="decorated-formation" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/errors/direct-phi.xsl
+++ b/src/main/resources/org/eolang/lints/errors/direct-phi.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="direct-phi" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/errors/empty-object.xsl
+++ b/src/main/resources/org/eolang/lints/errors/empty-object.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="empty-object" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/errors/many-void-attributes.xsl
+++ b/src/main/resources/org/eolang/lints/errors/many-void-attributes.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="many-void-attributes" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/lines/error-line-out-of-listing.xsl
+++ b/src/main/resources/org/eolang/lints/lines/error-line-out-of-listing.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="error-line-out-of-listing" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/lines/meta-line-out-of-listing.xsl
+++ b/src/main/resources/org/eolang/lints/lines/meta-line-out-of-listing.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="meta-line-out-of-listing" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/lines/object-line-out-of-listing.xsl
+++ b/src/main/resources/org/eolang/lints/lines/object-line-out-of-listing.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="object-line-out-of-listing" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/metas/duplicate-metas.xsl
+++ b/src/main/resources/org/eolang/lints/metas/duplicate-metas.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="duplicate-metas" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/metas/empty-spdx-tail.xsl
+++ b/src/main/resources/org/eolang/lints/metas/empty-spdx-tail.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="empty-spdx-tail" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/metas/incorrect-architect.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-architect.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="incorrect-architect" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/metas/incorrect-home.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-home.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="incorrect-home" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/metas/incorrect-jvm-rt-location.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-jvm-rt-location.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="incorrect-jvm-rt-location" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/metas/incorrect-node-rt-location.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-node-rt-location.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="incorrect-node-rt-location" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/metas/incorrect-package.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-package.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="incorrect-package" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/metas/incorrect-spdx.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-spdx.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="incorrect-spdx" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/metas/incorrect-version.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-version.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="incorrect-version" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/metas/mandatory-home.xsl
+++ b/src/main/resources/org/eolang/lints/metas/mandatory-home.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="mandatory-home" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/metas/mandatory-package.xsl
+++ b/src/main/resources/org/eolang/lints/metas/mandatory-package.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="mandatory-package" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/metas/mandatory-spdx.xsl
+++ b/src/main/resources/org/eolang/lints/metas/mandatory-spdx.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="mandatory-spdx" version="2.0">
   <xsl:output encoding="UTF-8"/>

--- a/src/main/resources/org/eolang/lints/metas/mandatory-version.xsl
+++ b/src/main/resources/org/eolang/lints/metas/mandatory-version.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="mandatory-version" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/metas/package-contains-multiple-parts.xsl
+++ b/src/main/resources/org/eolang/lints/metas/package-contains-multiple-parts.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="package-contains-multiple-parts" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/metas/prohibited-package.xsl
+++ b/src/main/resources/org/eolang/lints/metas/prohibited-package.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="prohibited-package" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/metas/unique-metas.xsl
+++ b/src/main/resources/org/eolang/lints/metas/unique-metas.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="unique-metas" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/metas/unknown-metas.xsl
+++ b/src/main/resources/org/eolang/lints/metas/unknown-metas.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="unknown-metas" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/metas/unsorted-metas.xsl
+++ b/src/main/resources/org/eolang/lints/metas/unsorted-metas.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="unsorted-metas" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/misc/incorrect-test-object-name.xsl
+++ b/src/main/resources/org/eolang/lints/misc/incorrect-test-object-name.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="incorrect-test-object-name">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="redundant-object" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/misc/sparse-decoration.xsl
+++ b/src/main/resources/org/eolang/lints/misc/sparse-decoration.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:eo="https://www.eolang.org" id="sparse-decoration" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/misc/sparse-seq.xsl
+++ b/src/main/resources/org/eolang/lints/misc/sparse-seq.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="sparse-seq" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/misc/sprintf-without-formatters.xsl
+++ b/src/main/resources/org/eolang/lints/misc/sprintf-without-formatters.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:math="http://www.w3.org/2005/xpath-functions/math" xmlns:eo="https://www.eolang.org" version="2.0" id="sprintf-without-formatters">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/misc/wrong-sprintf-arguments.xsl
+++ b/src/main/resources/org/eolang/lints/misc/wrong-sprintf-arguments.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:eo="https://www.eolang.org" version="2.0" id="wrong-sprintf-arguments">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/names/anonymous-formation.xsl
+++ b/src/main/resources/org/eolang/lints/names/anonymous-formation.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:eo="https://www.eolang.org" id="anonymous-formation" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/names/compound-name.xsl
+++ b/src/main/resources/org/eolang/lints/names/compound-name.xsl
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-  * SPDX-License-Identifier: MIT
-  -->
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:eo="https://www.eolang.org" id="compound-name" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:import href="/org/eolang/funcs/special-name.xsl"/>
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <!--Since developers might decide not to use kebab-case, it's better to catch all such cases.-->
+  <!-- Since developers might decide not to use kebab-case, it's better to catch all such cases. -->
   <xsl:function name="eo:compound" as="xs:boolean">
     <xsl:param name="name"/>
     <xsl:sequence select="contains($name, '-') or contains($name, '_') or matches($name, '[A-Z]')"/>
   </xsl:function>
   <!--
-    These prefixes/suffixes are idiomatic in EO standard library:
-    - 'as-' for type conversions (as-bytes, as-i64, as-number, etc.)
-    - 'cant-' for capabilities or restrictions (cant-read, cant-write, etc.)
-    - 'is-' for boolean predicates (is-empty, is-nan, is-finite, etc.)
-    - '-of' for extracting parts (slice-of, value-of, length-of, etc.)
+  These prefixes/suffixes are idiomatic in EO standard library:
+  - 'as-' for type conversions (as-bytes, as-i64, as-number, etc.)
+  - 'cant-' for capabilities or restrictions (cant-read, cant-write, etc.)
+  - 'is-' for boolean predicates (is-empty, is-nan, is-finite, etc.)
+  - '-of' for extracting parts (slice-of, value-of, length-of, etc.)
   -->
   <xsl:function name="eo:idiomatic" as="xs:boolean">
     <xsl:param name="name"/>

--- a/src/main/resources/org/eolang/lints/names/duplicate-as-attribute.xsl
+++ b/src/main/resources/org/eolang/lints/names/duplicate-as-attribute.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="duplicate-as-attribute">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/names/non-kebab-name.xsl
+++ b/src/main/resources/org/eolang/lints/names/non-kebab-name.xsl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-  * SPDX-License-Identifier: MIT
-  -->
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="non-kebab-name" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>

--- a/src/main/resources/org/eolang/lints/names/phi-is-not-first.xsl
+++ b/src/main/resources/org/eolang/lints/names/phi-is-not-first.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="phi-is-not-first">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>

--- a/src/main/resources/org/eolang/lints/names/unsorted-named-attributes.xsl
+++ b/src/main/resources/org/eolang/lints/names/unsorted-named-attributes.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="unsorted-named-attributes">
   <xsl:import href="/org/eolang/funcs/special-name.xsl"/>

--- a/src/main/resources/org/eolang/lints/refs/line-is-absent.xsl
+++ b/src/main/resources/org/eolang/lints/refs/line-is-absent.xsl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="line-is-absent" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="line-is-absent" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <!--
   Here we go through all objects and find what their @base

--- a/src/main/resources/org/eolang/lints/tests/unit-test-missing.xsl
+++ b/src/main/resources/org/eolang/lints/tests/unit-test-missing.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="unit-test-missing" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/tests/unit-test-without-phi.xsl
+++ b/src/main/resources/org/eolang/lints/tests/unit-test-without-phi.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="unit-test-without-phi" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/main/resources/org/eolang/lints/tests/wrong-test-order.xsl
+++ b/src/main/resources/org/eolang/lints/tests/wrong-test-order.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="wrong-test-order" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>

--- a/src/test/resources/fake-schema.xsd
+++ b/src/test/resources/fake-schema.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="defects"/>

--- a/src/test/resources/org/eolang/lints/xmir-with-application-duality.xml
+++ b/src/test/resources/org/eolang/lints/xmir-with-application-duality.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <object>
   <o base="jeo.frame" name="x">


### PR DESCRIPTION
## Summary

- normalize every tracked XML, XSL, and XSD source processed by the current `xcop` action with `xcop` 0.11.0;
- apply the canonical SPDX and XML comment formatting expected by the action;
- remove namespace declarations that the formatter identifies as unused.

## Why

The workflow invokes `g4s8/xcop-action@master` and stops on the first formatting violation. Fixing only the first reported files moved the gate to further pre-existing violations. Running the current formatter over the complete repository XML family showed that all 87 tracked XML/XSL/XSD files must be covered, including `src/test/resources/fake-schema.xsd`, which the action also validates.

The changes are mechanical formatting only. The follow-up commit for the CI failure changes only two leading spaces inside the XSD SPDX comment; the schema structure and executable code are unchanged.

## Verification

- `xcop 0.11.0` on all 87 tracked XML/XSL/XSD files;
- `xmllint --noout` on all 87 tracked XML/XSL/XSD files;
- `mvn test --errors --batch-mode`: 531 tests, 0 failures, 0 errors, 1 skipped;
- `mvn clean verify -Pqulice -Dproguard.skip=true --errors --batch-mode`: build success, Maven Invoker integration test passed, Qulice completed, and JTCOP reported all tests valid.

The local Android Studio JBR does not contain `jmods`, so only ProGuard packaging was skipped locally. GitHub Actions runs the repository's configured full JDK 23 and validates that step.

Closes #1063
