### PR TITLE
Add missed-obfuscation lint

### DIFF
--- a/src/main/resources/org/eolang/lints/design/missed-obfuscation.xsl
+++ b/src/main/resources/org/eolang/lints/design/missed-obfuscation.xsl
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="missed-obfuscation">
+  <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[eo:abstract(.) and @name and o[@name='φ'] and o[@base='∅' and @name and not(starts-with(@name, 'cant-'))]]">
+        <defect>
+          <xsl:variable name="line" select="eo:lineno(@line)"/>
+          <xsl:attribute name="line">
+            <xsl:value-of select="$line"/>
+          </xsl:attribute>
+          <xsl:if test="$line = '0'">
+            <xsl:attribute name="context">
+              <xsl:value-of select="eo:defect-context(.)"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:attribute name="severity">warning</xsl:attribute>
+          <xsl:attribute name="experimental">true</xsl:attribute>
+          <xsl:text>The formation </xsl:text>
+          <xsl:value-of select="eo:escape(@name)"/>
+          <xsl:text> must obfuscate its void attributes before decorating another object</xsl:text>
+        </defect>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/design/missed-obfuscation.md
+++ b/src/main/resources/org/eolang/motives/design/missed-obfuscation.md
@@ -1,0 +1,27 @@
+# Missed obfuscation
+
+A formation that decorates another object should obfuscate its void
+attributes. Otherwise, an attribute of the formation may shadow an attribute
+with the same name in the decoratee, making attribute access ambiguous to a
+reader.
+
+Incorrect:
+
+```eo
+[a b] > x
+  foo > @
+```
+
+The expression `x.a` refers to the provided attribute `a`, even when `foo`
+also has an attribute named `a`. Obfuscating the void attributes makes this
+relationship explicit:
+
+```eo
+[] > x
+  ? >> a
+  ? >> b
+  foo > @
+```
+
+Void attributes whose names start with `cant-` are capabilities or
+restrictions and don't have to be obfuscated.

--- a/src/test/resources/org/eolang/lints/canonical.eo
+++ b/src/test/resources/org/eolang/lints/canonical.eo
@@ -4,6 +4,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint missed-obfuscation
 +unlint unit-test-missing
 
 # Times table, which is a canonical example of EO program.

--- a/src/test/resources/org/eolang/lints/main-with-test.eo
+++ b/src/test/resources/org/eolang/lints/main-with-test.eo
@@ -3,6 +3,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint missed-obfuscation
 
 # No comments.
 [c] > main

--- a/src/test/resources/org/eolang/lints/packs/single/missed-obfuscation/allows-cant-voids.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/missed-obfuscation/allows-cant-voids.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/missed-obfuscation.xsl
+defects: 0
+input: |
+  # Restricted.
+  [cant-read cant-write] > restricted
+    foo > @

--- a/src/test/resources/org/eolang/lints/packs/single/missed-obfuscation/allows-decoration-without-voids.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/missed-obfuscation/allows-decoration-without-voids.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/missed-obfuscation.xsl
+defects: 0
+input: |
+  # X.
+  [] > x
+    foo > @

--- a/src/test/resources/org/eolang/lints/packs/single/missed-obfuscation/allows-obfuscated-voids.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/missed-obfuscation/allows-obfuscated-voids.yaml
@@ -4,9 +4,15 @@
 sheets:
   - /org/eolang/lints/design/missed-obfuscation.xsl
 defects: 0
-input: |
-  # X.
-  [] > x
-    ? >> a
-    ? >> b
-    foo > @
+document: |
+  <object author="tests">
+    <listing># X.
+  [] &gt; x
+    ? &gt;&gt; a
+    ? &gt;&gt; b
+    foo &gt; @
+    </listing>
+    <o line="2" name="x">
+      <o base="&#x3A6;.foo" line="5" name="&#x3C6;"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/missed-obfuscation/allows-obfuscated-voids.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/missed-obfuscation/allows-obfuscated-voids.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/missed-obfuscation.xsl
+defects: 0
+input: |
+  # X.
+  [] > x
+    ? >> a
+    ? >> b
+    foo > @

--- a/src/test/resources/org/eolang/lints/packs/single/missed-obfuscation/allows-voids-without-decoration.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/missed-obfuscation/allows-voids-without-decoration.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/missed-obfuscation.xsl
+defects: 0
+input: |
+  # Pair.
+  [left right] > pair
+    left > first
+    right > second

--- a/src/test/resources/org/eolang/lints/packs/single/missed-obfuscation/catches-nested-formations.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/missed-obfuscation/catches-nested-formations.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/missed-obfuscation.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=2]
+  - /defects/defect[@line='2']
+  - /defects/defect[@line='5']
+input: |
+  # Outer.
+  [a] > outer
+    foo > @
+    # Inner.
+    [b] > inner
+      bar > @

--- a/src/test/resources/org/eolang/lints/packs/single/missed-obfuscation/catches-non-cant-void.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/missed-obfuscation/catches-non-cant-void.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/missed-obfuscation.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='2']
+input: |
+  # Restricted.
+  [cant-read source] > restricted
+    foo > @

--- a/src/test/resources/org/eolang/lints/packs/single/missed-obfuscation/catches-unobfuscated-voids.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/missed-obfuscation/catches-unobfuscated-voids.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/missed-obfuscation.xsl
+asserts:
+  - /defects[count(defect[@severity='warning' and @experimental])=1]
+  - /defects/defect[@line='2']
+  - /defects/defect[contains(text(), 'must obfuscate its void attributes')]
+input: |
+  # X.
+  [a b] > x
+    foo > @

--- a/src/test/resources/org/eolang/lints/packs/single/missed-obfuscation/prints-context-when-line-is-absent.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/missed-obfuscation/prints-context-when-line-is-absent.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/missed-obfuscation.xsl
+asserts:
+  - /defects[count(defect[@context and @severity='warning'])=1]
+document: |
+  <object author="tests">
+    <o name="risky">
+      <o base="&#x2205;" name="argument"/>
+      <o base="&#x3A6;.foo" name="&#x3C6;"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/valid-source.eo
+++ b/src/test/resources/org/eolang/lints/valid-source.eo
@@ -3,6 +3,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint missed-obfuscation
 
 # This is just a test object with no functionality.
 [i] > foo


### PR DESCRIPTION
## Summary

- add the experimental `missed-obfuscation` design lint
- report decorated formations with non-`cant-*` void attributes
- document the ambiguity and the safer obfuscated form
- cover risky, safe, `cant-*`, mixed, nested, and line-less XMIR cases
- suppress the new rule explicitly in legacy fixtures that intentionally retain the old syntax

## Verification

- `mvn test` — 539 tests, 0 failures, 0 errors, 1 skipped
- `mvn -Pqulice -DskipTests -Dproguard.skip=true verify`
- `xcop src/main/resources/org/eolang/lints/design/missed-obfuscation.xsl`
- `xmllint --noout src/main/resources/org/eolang/lints/design/missed-obfuscation.xsl`
- `git diff --check`

Closes #1058