### PR TITLE
Enable hone profile on all supported platforms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,20 +379,14 @@
     <profile>
       <id>hone</id>
       <activation>
-        <activeByDefault>false</activeByDefault>
-        <!--
-        @todo #711:45min Enable `hone` profile on all platforms after.
-        For now, `hone-maven-plugin` fails on `macOS` and `Windows` machines.
-        After the issue will be fixed, we should `<os/>` element from the `<activation/>`
-        and keep `activeByDefault=true`.
-        -->
+        <jdk>[11,)</jdk>
       </activation>
       <build>
         <plugins>
           <plugin>
             <groupId>org.eolang</groupId>
             <artifactId>hone-maven-plugin</artifactId>
-            <version>0.28.0</version>
+            <version>0.29.0</version>
             <executions>
               <execution>
                 <goals>
@@ -403,9 +397,14 @@
                   <rules>streams/*</rules>
                   <timeout>60</timeout>
                   <threads>0</threads>
+                  <skipWithoutDocker>true</skipWithoutDocker>
+                  <skipOnWindows>true</skipOnWindows>
                   <grepIn>(66-69-6C-74-65-72|6D-61-70)</grepIn>
-                  <!-- Used as benchmark resource. -->
-                  <excludes>/target/classes/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.class</excludes>
+                  <excludes>
+                    <!-- Used as benchmark resource. -->
+                    <exclude>/target/classes/org/apache/hadoop/hdfs/server/namenode/FSNamesystem.class</exclude>
+                    <exclude>/target/classes/org/eolang/lints/LtUnlintNonExistingDefect.class</exclude>
+                  </excludes>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
## Summary

- activate the Hone profile on every supported JDK;
- update hone-maven-plugin from 0.28.0 to 0.29.0;
- skip Hone execution on Windows and when Docker is unavailable;
- exclude LtUnlintNonExistingDefect from optimization because Hone emits
  invalid stack-map frames for this class;
- remove the resolved platform-specific activation puzzle.

## Why

JDK activation keeps the profile active alongside other profiles from this
POM. Maven disables active-by-default profiles as soon as another profile is
activated, including the automatically selected java-17-plus profile.

Hone 0.29.0 includes the latest upstream bytecode fixes.
The plugin's skipWithoutDocker and skipOnWindows options keep the profile
enabled on every supported platform while avoiding unsupported backend
execution on macOS runners without Docker and Windows runners.
The remaining class-specific VerifyError reproduced by the deep suite is
prevented by a targeted exclusion, while Hone stays enabled for the rest of
the project.

## Verification

- xmllint --noout pom.xml
- mvn help:active-profiles
- mvn clean install -P!proguard

The active-profile check lists Hone together with java-17-plus. The local
macOS build without Docker passed 531 unit tests and the integration test.
ProGuard was disabled locally because the available Android Studio JBR does
not include jmods; GitHub Actions exercises the normal JDK matrix.

Closes #1072
