### PR TITLE
Upgrade setup-python to v7

### DIFF
--- a/.github/workflows/bashate.yml
+++ b/.github/workflows/bashate.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: 3.14
       - run: pip install bashate


### PR DESCRIPTION
## Summary

Upgrade `actions/setup-python` from v6 to v7 in the Bashate workflow.

## Why

The earlier automated update was closed because of an unrelated repository-wide `xcop` failure. That formatting blocker has since been corrected on `master`, while the workflow still references v6.

## Verification

- parsed `.github/workflows/bashate.yml` successfully as YAML;
- `git diff --check`.

Closes #1078
