### PR TITLE
Upgrade action-actionlint to v1.73.0

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: reviewdog/action-actionlint@v1.72.0
+      - uses: reviewdog/action-actionlint@v1.73.0


### PR DESCRIPTION
## Summary

Upgrade `reviewdog/action-actionlint` from v1.72.0 to v1.73.0.

## Why

The earlier automated update was closed because of an unrelated repository-wide `xcop` failure. That formatting blocker has since been corrected on `master`, while the workflow still references v1.72.0.

## Verification

- parsed `.github/workflows/actionlint.yml` successfully as YAML;
- `git diff --check`.

Closes #1075
