### PR TITLE
Upgrade labeler to v7

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@v7
         with:
           sync-labels: true


### PR DESCRIPTION
## Summary

Upgrade `actions/labeler` from v6 to v7.

## Why

The earlier automated update was closed because of unrelated repository-wide CI failures. The XML formatting blocker has since been corrected on `master`, while the workflow still references v6.

## Verification

- parsed `.github/workflows/labeler.yml` successfully as YAML;
- `git diff --check`.

Closes #1076
