### PR TITLE
Handle non-numeric unlint line suffixes

### DIFF
--- a/src/main/java/org/eolang/lints/DefectMissing.java
+++ b/src/main/java/org/eolang/lints/DefectMissing.java
@@ -57,14 +57,33 @@ final class DefectMissing implements Function<String, Boolean> {
                 names = new SetOf<>();
             }
             if (split.length > 1) {
-                missing = (!names.contains(name)
-                    || lines == null
-                    || !lines.contains(Integer.parseInt(split[1])))
-                    && !this.excluded.contains(name);
+                missing = this.missingAtLine(unlint, lines, names);
             } else {
                 missing = !names.contains(name) && !this.excluded.contains(name);
             }
         }
         return missing;
+    }
+
+    /**
+     * Is a defect missing at the requested line?
+     * @param unlint Unlint selector
+     * @param lines Defect lines
+     * @param names Defect names
+     * @return Whether the defect is missing
+     */
+    private boolean missingAtLine(
+        final String unlint,
+        final List<Integer> lines,
+        final Set<String> names
+    ) {
+        final String[] split = unlint.split(":", -1);
+        final String name = split[0];
+        boolean missing = !names.contains(name) || lines == null;
+        if (!missing) {
+            missing = !unlint.matches(String.format("%s:\\d+", name))
+                || !lines.contains(Integer.parseInt(split[1]));
+        }
+        return missing && !this.excluded.contains(name);
     }
 }

--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.cactoos.list.ListOf;
 
@@ -20,11 +19,6 @@ import org.cactoos.list.ListOf;
  * @since 0.0.1
  */
 final class LtUnlint implements Lint {
-
-    /**
-     * Line number to unlint.
-     */
-    private static final Pattern LINE_NUMBER = Pattern.compile(".*:\\d+$");
 
     /**
      * The original lint.
@@ -66,13 +60,13 @@ final class LtUnlint implements Lint {
             unlint -> {
                 if (unlint.matches(String.format("%s:\\d+-\\d+", lname))) {
                     problematic.removeIf(new UnlintInRange(unlint));
-                } else if (LtUnlint.LINE_NUMBER.matcher(unlint).matches()) {
+                } else if (unlint.matches(String.format("%s:\\d+", lname))) {
                     problematic.removeIf(
                         line -> line == Integer.parseInt(
                             new ListOf<>(unlint.split(":")).get(1)
                         )
                     );
-                } else {
+                } else if (unlint.equals(lname)) {
                     problematic.clear();
                 }
             }

--- a/src/test/java/org/eolang/lints/DefectMissingTest.java
+++ b/src/test/java/org/eolang/lints/DefectMissingTest.java
@@ -40,6 +40,16 @@ final class DefectMissingTest {
     }
 
     @Test
+    void returnsTrueForNonNumericLine() {
+        MatcherAssert.assertThat(
+            "Non-numeric line selector should be reported as missing",
+            new DefectMissing(new MapOf<>("foo", new ListOf<>(42)), new ListOf<>())
+                .apply("foo:not-a-number"),
+            Matchers.equalTo(true)
+        );
+    }
+
+    @Test
     void returnsTrueWhenLineOutOfRange() {
         MatcherAssert.assertThat(
             "Defect should be missing, but it was not",

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -109,6 +109,22 @@ final class LtUnlintNonExistingDefectTest {
     }
 
     @Test
+    void catchesUnlintWithNonNumericLine() throws IOException {
+        MatcherAssert.assertThat(
+            "Non-numeric unlint line should be reported without an exception",
+            new LtUnlintNonExistingDefect(
+                new ListOf<>(new LtAsciiOnly()),
+                new ListOf<>()
+            ).defects(
+                new EoProgram(
+                    "org/eolang/lints/unlint-ascii-only-non-numeric.eo"
+                ).parse()
+            ),
+            Matchers.iterableWithSize(1)
+        );
+    }
+
+    @Test
     void allowsUnlintForDefectsInTheLineRange() throws IOException {
         MatcherAssert.assertThat(
             "Defects are not empty, but they should",

--- a/src/test/java/org/eolang/lints/LtUnlintTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintTest.java
@@ -39,6 +39,19 @@ final class LtUnlintTest {
     }
 
     @Test
+    void ignoresNonNumericLineSelector() throws IOException {
+        MatcherAssert.assertThat(
+            "Malformed unlint must not suppress a real defect",
+            new LtUnlint(new LtAsciiOnly()).defects(
+                new EoProgram(
+                    "org/eolang/lints/unlint-ascii-only-non-numeric.eo"
+                ).parse()
+            ),
+            Matchers.iterableWithSize(1)
+        );
+    }
+
+    @Test
     void unlintsGrainy() throws IOException {
         MatcherAssert.assertThat(
             "Only one defect should be unlinted",

--- a/src/test/resources/org/eolang/lints/unlint-ascii-only-non-numeric.eo
+++ b/src/test/resources/org/eolang/lints/unlint-ascii-only-non-numeric.eo
@@ -1,0 +1,6 @@
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint ascii-only:not-a-number
+
+# Мы тут.
+[] > boom


### PR DESCRIPTION
## What changed

- validate single-line `+unlint` selectors before parsing their line number
- keep malformed selectors from suppressing real lint defects
- report a malformed selector through `unlint-non-existing-defect`
- add regression coverage for the public failure path and underlying suppression behavior

## Why

`Source.defects()` treated every non-range `name:suffix` selector as numeric and passed the suffix to `Integer.parseInt()`. A selector such as `comment-too-short:not-a-number` therefore raised `NumberFormatException`. The same malformed selector was also interpreted as a global suppression by `LtUnlint`, hiding the original defect.

Malformed selectors now remain ineffective: linting completes, the original defect stays visible, and the invalid selector receives a diagnostic.

## Validation

- `mvn -ntp --batch-mode --errors test`: 534 tests, 0 failures, 0 errors, 1 skipped
- `mvn -ntp --batch-mode --errors -Pqulice -DskipTests qulice:check`: `BUILD SUCCESS`
- the issue reproducer completes without an exception and reports both the real lint defect and the malformed-selector diagnostic

Fixes #1070
