### PR TITLE
test(#1109): add tests for unsorted-named-attributes lint

### DIFF
--- a/src/main/resources/org/eolang/lints/names/unsorted-named-attributes.xsl
+++ b/src/main/resources/org/eolang/lints/names/unsorted-named-attributes.xsl
@@ -11,26 +11,31 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[eo:abstract(.) and @name]/o[@name and @base != '∅' and not(eo:special(@name)) and not(starts-with(@name, '+'))]">
-        <xsl:variable name="previous" select="(preceding-sibling::o[@name and @base != '∅' and not(eo:special(@name)) and not(starts-with(@name, '+'))])[last()]"/>
-        <xsl:if test="$previous and @name &lt; $previous/@name">
-          <defect>
-            <xsl:variable name="line" select="eo:lineno(@line)"/>
-            <xsl:attribute name="line">
-              <xsl:value-of select="$line"/>
-            </xsl:attribute>
-            <xsl:if test="$line = '0'">
-              <xsl:attribute name="context">
-                <xsl:value-of select="eo:defect-context(.)"/>
+      <xsl:for-each select="//o[eo:abstract(.) and @name]">
+        <xsl:variable name="parent" select="."/>
+        <xsl:variable name="named" select="o[@name and @base != '∅' and not(eo:special(@name)) and not(starts-with(@name, '+'))]"/>
+        <xsl:for-each select="$named">
+          <xsl:variable name="pos" select="position()"/>
+          <xsl:variable name="previous" select="$named[$pos - 1]"/>
+          <xsl:if test="$pos &gt; 1 and @name &lt; $previous/@name">
+            <defect>
+              <xsl:variable name="line" select="eo:lineno(@line)"/>
+              <xsl:attribute name="line">
+                <xsl:value-of select="$line"/>
               </xsl:attribute>
-            </xsl:if>
-            <xsl:attribute name="severity">warning</xsl:attribute>
-            <xsl:text>Named attribute </xsl:text>
-            <xsl:value-of select="eo:escape(@name)"/>
-            <xsl:text> is out of order inside formation </xsl:text>
-            <xsl:value-of select="eo:escape(../@name)"/>
-          </defect>
-        </xsl:if>
+              <xsl:if test="$line = '0'">
+                <xsl:attribute name="context">
+                  <xsl:value-of select="eo:defect-context(.)"/>
+                </xsl:attribute>
+              </xsl:if>
+              <xsl:attribute name="severity">warning</xsl:attribute>
+              <xsl:text>Named attribute </xsl:text>
+              <xsl:value-of select="eo:escape(@name)"/>
+              <xsl:text> is out of order inside formation </xsl:text>
+              <xsl:value-of select="eo:escape($parent/@name)"/>
+            </defect>
+          </xsl:if>
+        </xsl:for-each>
       </xsl:for-each>
     </defects>
   </xsl:template>

--- a/src/test/resources/org/eolang/lints/packs/single/unsorted-named-attributes/catches-unsorted-attribute-among-many.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unsorted-named-attributes/catches-unsorted-attribute-among-many.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/unsorted-named-attributes.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - >-
+    /defects/defect[normalize-space()='Named attribute "b" is out of order
+    inside formation "app"']
+input: |
+  # No comments.
+  [x] > app
+    x.plus 1 > a
+    x.mul 3 > c
+    x.mul 2 > b

--- a/src/test/resources/org/eolang/lints/packs/single/unsorted-named-attributes/does-not-catch-sorted-named-attributes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unsorted-named-attributes/does-not-catch-sorted-named-attributes.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/unsorted-named-attributes.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  # No comments.
+  [x] > app
+    x.plus 1 > a
+    x.mul 2 > b
+    x.mul 3 > c


### PR DESCRIPTION
Refactor `unsorted-named-attributes` lint to improve performance by eliminating nested `preceding-sibling` axis lookups and add comprehensive test coverage.

Related to #1109