### PR TITLE
1074

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -392,7 +392,7 @@
           <plugin>
             <groupId>org.eolang</groupId>
             <artifactId>hone-maven-plugin</artifactId>
-            <version>0.28.0</version>
+            <version>0.29.0</version>
             <executions>
               <execution>
                 <goals>


### PR DESCRIPTION
Closes #1074
This PR bumps hone-maven-plugin from 0.28.0 to 0.29.0 as requested in the issue. The previous attempt (#1062) failed due to unrelated xcop issue, but this PR contains only the version bump.