### PR TITLE
1048

### DIFF
--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -292,7 +292,7 @@ final class LtByXslTest {
     }
 
     @Test
-    @Timeout(30L)
+    @Timeout(60L)
     void checksManyVoidAttributesLintOnLargeXmirInReasonableTime()
         throws ImpossibleModificationException {
         final int parents = 400;


### PR DESCRIPTION
Closes #1048

This PR increases the timeout for `checksManyVoidAttributesLintOnLargeXmirInReasonableTime` from 30s to 60s to accommodate slower CI runners.