### PR TITLE
1079

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: DavidAnson/markdownlint-cli2-action@v24.0.0
+      - uses: DavidAnson/markdownlint-cli2-action@v24.1.0


### PR DESCRIPTION
Closes #1079
This PR bumps davidanson/markdownlint-cli2-action from v24.0.0 to v24.1.0. The previous attempt (#1054) failed due to unrelated xcop issue, but this PR contains only the version bump.