### PR TITLE
1103

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -498,7 +498,9 @@
                 <exclude>
                   generated/**
                 </exclude>
-		<exclude>**/org/junit/**</exclude>
+		<exclude>
+                  **/org/junit/**
+		</exclude>
               </excludes>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -871,3 +871,4 @@
     </plugins>
   </build>
 </project>
+

--- a/pom.xml
+++ b/pom.xml
@@ -426,9 +426,7 @@
             <configuration>
               <excludedGroups>!benchmark</excludedGroups>
               <excludes>
-                <exclude>
-                  generated/**
-                </exclude>
+                <exclude>generated/**</exclude>
               </excludes>
             </configuration>
           </plugin>
@@ -495,12 +493,8 @@
               <groups>deep</groups>
               <excludedGroups>benchmark,reserved</excludedGroups>
               <excludes>
-                <exclude>
-                  generated/**
-                </exclude>
-		<exclude>
-                  **/org/junit/**
-		</exclude>
+                <exclude>generated/**</exclude>
+                <exclude>**/org/junit/**</exclude>
               </excludes>
             </configuration>
           </plugin>
@@ -747,9 +741,8 @@
               <groups>reserved</groups>
               <excludedGroups>benchmark,deep</excludedGroups>
               <excludes>
-                <exclude>
-                  generated/**
-                </exclude>
+                <exclude>generated/**</exclude>
+                <exclude>**/org/junit/**</exclude>
               </excludes>
             </configuration>
           </plugin>
@@ -786,9 +779,7 @@
           <skipTests>${skipUTs}</skipTests>
           <excludedGroups>benchmark,deep,reserved</excludedGroups>
           <excludes>
-            <exclude>
-              generated/**
-            </exclude>
+            <exclude>generated/**</exclude>
           </excludes>
         </configuration>
       </plugin>
@@ -873,4 +864,3 @@
     </plugins>
   </build>
 </project>
-

--- a/pom.xml
+++ b/pom.xml
@@ -498,6 +498,7 @@
                 <exclude>
                   generated/**
                 </exclude>
+		<exclude>**/org/junit/**</exclude>
               </excludes>
             </configuration>
           </plugin>


### PR DESCRIPTION
Closes #1103
This PR adds an exclude pattern for JUnit classes in the reserved profile to prevent conflicts with the reserved word/name check. The JUnit version is already 6.1.2 via BOM.