### PR TITLE
fix(#1114): synchronize shared timings CSV access in benchmarks

### DIFF
--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -14,6 +14,7 @@ import com.yegor256.Together;
 import com.yegor256.tojos.MnCsv;
 import com.yegor256.tojos.TjCached;
 import com.yegor256.tojos.TjDefault;
+import com.yegor256.tojos.TjSynchronized;
 import com.yegor256.tojos.Tojos;
 import fixtures.BytecodeClass;
 import fixtures.EoProgram;
@@ -430,6 +431,19 @@ final class SourceTest {
         private static final Path TIMINGS = Paths.get("target/timings.csv");
 
         /**
+         * Shared timings, one per JVM, so that concurrently running benchmark
+         * tests don't corrupt {@link BcSource#TIMINGS} by opening it through
+         * several unsynchronized {@link Tojos} instances at once.
+         */
+        private static final Tojos SHARED = new TjSynchronized(
+            new TjCached(
+                new TjDefault(
+                    new MnCsv(BcSource.TIMINGS)
+                )
+            )
+        );
+
+        /**
          * XMIR.
          */
         private final XML xmir;
@@ -458,11 +472,7 @@ final class SourceTest {
             this(
                 source,
                 new Synced<>(new Sticky<>(new PkMono())),
-                new TjCached(
-                    new TjDefault(
-                        new MnCsv(BcSource.TIMINGS)
-                    )
-                ),
+                BcSource.SHARED,
                 size
             );
         }


### PR DESCRIPTION
Fixes benchmark test failures by introducing a thread-safe shared `Tojos` instance for concurrent access to `timings.csv`, preventing `NullPointerException` when multiple benchmark tests write to the same file simultaneously.

Fixes #1114