### PR TITLE
test(#1114): consolidate benchmark tests and fix NPE

### DIFF
--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -325,6 +325,7 @@ final class SourceTest {
     @Tag("benchmark")
     @ExtendWith(MayBeSlow.class)
     @Timeout(600L)
+    @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void benchmarksLintPerformance() throws IOException {
         final Map<Map<SourceSize, Collection<Defect>>, String> result =
             SourceTest.benchmarkResults();
@@ -339,8 +340,7 @@ final class SourceTest {
         MatcherAssert.assertThat(
             "All lint time entries must match the expected format",
             Arrays.stream(Pattern.compile("\\R").split(summary))
-                .filter(line -> line.startsWith("Lint time:"))
-                .allMatch(
+                .filter(line -> line.startsWith("Lint time:")).allMatch(
                     text -> Pattern.compile(
                         "^Lint time: (\\d+(?:\\.\\d+)?)(ms|s|min|h) \\(\\d+ ms\\)$"
                     ).matcher(text).matches()

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -323,10 +323,9 @@ final class SourceTest {
 
     @Test
     @Tag("benchmark")
-    @ExtendWith(MktmpResolver.class)
     @ExtendWith(MayBeSlow.class)
     @Timeout(600L)
-    void lintsBenchmarkSourcesFromJava() throws Exception {
+    void benchmarksLintPerformance() throws IOException {
         final Map<Map<SourceSize, Collection<Defect>>, String> result =
             SourceTest.benchmarkResults();
         MatcherAssert.assertThat(
@@ -336,29 +335,21 @@ final class SourceTest {
             ),
             Matchers.equalTo(true)
         );
-        Files.write(
-            Paths.get("target").resolve("lint-summary.txt"),
-            result.values().iterator().next().getBytes(StandardCharsets.UTF_8)
-        );
-    }
-
-    @Test
-    @Tag("benchmark")
-    @ExtendWith(MayBeSlow.class)
-    @Timeout(600L)
-    void checksLintTimeFormattingInBenchmarkResults() {
+        final String summary = result.values().iterator().next();
         MatcherAssert.assertThat(
             "All lint time entries must match the expected format",
-            Arrays.stream(
-                Pattern.compile("\\R").split(
-                    SourceTest.benchmarkResults().values().iterator().next()
-                )
-            ).filter(line -> line.startsWith("Lint time:")).allMatch(
-                text -> Pattern.compile(
-                    "^Lint time: (\\d+(?:\\.\\d+)?)(ms|s|min|h) \\(\\d+ ms\\)$"
-                ).matcher(text).matches()
-            ),
+            Arrays.stream(Pattern.compile("\\R").split(summary))
+                .filter(line -> line.startsWith("Lint time:"))
+                .allMatch(
+                    text -> Pattern.compile(
+                        "^Lint time: (\\d+(?:\\.\\d+)?)(ms|s|min|h) \\(\\d+ ms\\)$"
+                    ).matcher(text).matches()
+                ),
             Matchers.equalTo(true)
+        );
+        Files.write(
+            Paths.get("target").resolve("lint-summary.txt"),
+            summary.getBytes(StandardCharsets.UTF_8)
         );
     }
 


### PR DESCRIPTION
Consolidate benchmark tests to resolve NullPointerException when writing to shared `timings.csv` file. Merge two separate test methods into a single test that reuses benchmark results, eliminating multiple Tojos instance initializations on the same file.

Related to #1114