### PR TITLE
1125

### DIFF
--- a/src/main/resources/org/eolang/lints/tests/bad-test-name.xsl
+++ b/src/main/resources/org/eolang/lints/tests/bad-test-name.xsl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="bad-test-name" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[@name]">
+        <xsl:call-template name="check-name"/>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+  <xsl:template name="check-name">
+    <xsl:variable name="name" select="@name"/>
+    <xsl:variable name="prefixes" select="('can-', 'cannot-', 'accepts-', 'rejects-', 'stops-on-')"/>
+    <xsl:variable name="is-valid">
+      <xsl:for-each select="$prefixes">
+        <xsl:if test="starts-with($name, .)">
+          <xsl:text>true</xsl:text>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+    <xsl:if test="string-length($is-valid) = 0">
+      <xsl:element name="defect">
+        <xsl:attribute name="line">
+          <xsl:value-of select="eo:lineno(@line)"/>
+        </xsl:attribute>
+        <xsl:attribute name="severity">
+          <xsl:text>warning</xsl:text>
+        </xsl:attribute>
+        <xsl:text>Test object name "</xsl:text>
+        <xsl:value-of select="eo:escape($name)"/>
+        <xsl:text>" does not start with one of: can-, cannot-, accepts-, rejects-, stops-on-</xsl:text>
+      </xsl:element>
+    </xsl:if>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/bad-test-name.md
+++ b/src/main/resources/org/eolang/motives/bad-test-name.md
@@ -1,0 +1,10 @@
+\# bad-test-name
+
+
+
+This lint checks that test objects are named with one of the allowed prefixes: can-, cannot-, accepts-, rejects-, stops-on-. This ensures that test names clearly describe their purpose and behavior.
+
+
+
+If a test object name does not start with any of these prefixes, a warning is raised.
+

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+input: |
+  [] > foo
+    can-do-something > test1
+      nop
+    invalid-name > test2
+      nop
+    accepts-valid > test3
+      nop
+    cannot-fail > test4
+      nop
+defects:
+  - rule: bad-test-name
+    location: /object/o[@name='invalid-name']
+    message: Test object name "invalid-name" does not start with one of: can-, cannot-, accepts-, rejects-, stops-on-

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name.yaml
@@ -1,3 +1,4 @@
+---
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 input: |
@@ -13,4 +14,4 @@ input: |
 defects:
   - rule: bad-test-name
     location: /object/o[@name='invalid-name']
-    message: Test object name "invalid-name" does not start with one of: can-, cannot-, accepts-, rejects-, stops-on-
+    message: 'Test object name "invalid-name" does not start with one of: can-, cannot-, accepts-, rejects-, stops-on-'

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name.yaml
@@ -14,4 +14,6 @@ input: |
 defects:
   - rule: bad-test-name
     location: /object/o[@name='invalid-name']
-    message: 'Test object name "invalid-name" does not start with one of: can-, cannot-, accepts-, rejects-, stops-on-'
+    message: >
+      Test object name "invalid-name" does not start with one of:
+      can-, cannot-, accepts-, rejects-, stops-on-


### PR DESCRIPTION
Closes #1125

This PR adds a new lint `bad-test-name` that checks whether test object names start with one of the allowed prefixes:
- can-
- cannot-
- accepts-
- rejects-
- stops-on-

If a test object name does not match, a warning is raised.

Tests are included.