### PR TITLE
Fix sparse-decoration wrongly flagging void φ as decoration (#1130)

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/sparse-decoration.xsl
+++ b/src/main/resources/org/eolang/lints/misc/sparse-decoration.xsl
@@ -14,7 +14,7 @@
   </xsl:function>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[eo:abstract(.) and not(starts-with(@name, '+')) and count(o[not(@base='ξ' and @name='xi🌵')])=1 and o[not(@base='ξ' and @name='xi🌵')][1][@name='φ'] and not(eo:has-rho-ref(o[not(@base='ξ' and @name='xi🌵')][1]))]">
+      <xsl:for-each select="//o[eo:abstract(.) and not(starts-with(@name, '+')) and count(o[not(@base='ξ' and @name='xi🌵')])=1 and o[not(@base='ξ' and @name='xi🌵')][1][@name='φ'][not(@base='∅')] and not(eo:has-rho-ref(o[not(@base='ξ' and @name='xi🌵')][1]))]">
         <xsl:element name="defect">
           <xsl:variable name="line" select="eo:lineno(@line)"/>
           <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/single/sparse-decoration/no-sparse-because-void-phi.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sparse-decoration/no-sparse-because-void-phi.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/sparse-decoration.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # No comments.
+  [@] > input


### PR DESCRIPTION
Closes #1130.

## Problem

`misc/sparse-decoration.xsl` reported "Sparse decoration is prohibited" for a formation whose only attribute is a *void* φ, i.e. the abstract-interface idiom `[@] > input`. The predicate checked `count(o[...])=1` and `o[...][1][@name='φ']`, but never checked that the φ child carries a real `@base`. For `[@] > input` the parser emits a void φ (`@base='∅'`), and the lint counted it as a decoration.

A void φ is not a decoration — it is a free attribute the caller must supply. There is nothing to inline and the object has no body. This false-positive hit real objects in `objectionary/eo` such as `eo-runtime/src/main/eo/input.eo` and `output.eo`.

## Fix

Add a `not(@base='∅')` guard to the φ test in the predicate so a void φ is skipped, the same way other lints distinguish a bound φ from a void one.

The issue suggested `@base != '∅'`, but that would break the existing formation-as-decoratee case (`[] > @`), whose φ carries no `@base` attribute at all — `@base != '∅'` evaluates to false when `@base` is absent. Using `not(@base='∅')` excludes only void φ while still flagging bound-φ and formation-φ decoratees.

## Tests

Added `no-sparse-because-void-phi.yaml` covering `[@] > input`, which now yields zero defects. All 348 `LtByXslTest#testsAllLintsByEo` pack tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHPhak7n4mBMk4QfZgb2iP)_