### PR TITLE
Skip pipe continuation φ in phi-is-not-first

### DIFF
--- a/src/main/resources/org/eolang/lints/names/phi-is-not-first.xsl
+++ b/src/main/resources/org/eolang/lints/names/phi-is-not-first.xsl
@@ -10,7 +10,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:apply-templates select="(//o[@name='φ'][preceding-sibling::o[not(@base='∅') and not(@base='ξ' and @name='xi🌵')]])[last()]" mode="unordered"/>
+      <xsl:apply-templates select="(//o[@name='φ'][not(@pipe)][preceding-sibling::o[not(@base='∅') and not(@base='ξ' and @name='xi🌵')]])[last()]" mode="unordered"/>
     </defects>
   </xsl:template>
   <xsl:template match="o" mode="unordered">

--- a/src/test/resources/org/eolang/lints/packs/single/phi-is-not-first/ignores-pipe-phi.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/phi-is-not-first/ignores-pipe-phi.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/phi-is-not-first.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o name="f">
+      <o base="Φ.x" name="a"/>
+      <o base="Φ.y" name="φ" pipe=""/>
+    </o>
+  </object>


### PR DESCRIPTION
Fixes #1131.

## Problem

`names/phi-is-not-first.xsl:13` flagged every `o[@name='φ']` that had a preceding sibling other than a void attribute or the `xi🌵` marker. It did not exempt a φ produced by a pipe continuation line (`| > @`), which the parser marks with an empty `@pipe` attribute.

That is a false positive: a pipe φ can never be moved first. The `wrap-applications` pass sets the node's `base` to the preceding sibling's name, so the pipe is by definition an application of the attribute declared immediately above it. Hoisting the φ to the top of the formation would rebind it to a different sibling — or to nothing at all. In `objectionary/eo` this accounted for all twelve `phi-is-not-first` warnings emitted by `eo-runtime` (e.g. `bytes/array.eo:23`, `i64.eo:87`).

## Fix

One predicate: `not(@pipe)` added to the φ selection, so a pipe continuation is skipped the same way void attributes already are.

## Test

New pack `ignores-pipe-phi.yaml` asserts that a formation whose φ carries `@pipe` and follows another attribute produces zero warnings. All existing `phi-is-not-first` packs continue to pass. Since the XMIR XSD pinned in this repo does not yet declare the `@pipe` attribute on `o`, the pack sets `ignore-schema: true` (as other packs do for constructs outside the pinned schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018S6iF6fgwoASnUJ45vyRTc)_