### PR TITLE
Skip redundant-object for a lone reference inside a recursive formation

### DIFF
--- a/.github/styles/config/vocabularies/Custom/accept.txt
+++ b/.github/styles/config/vocabularies/Custom/accept.txt
@@ -15,4 +15,6 @@ XMIR
 SPDX
 ASCII
 inlined
+[Ii]nlining
+[Ss]ubgraph
 [Aa]pplication

--- a/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
@@ -13,7 +13,8 @@
     <defects>
       <xsl:variable name="top" select="/object/o/generate-id()"/>
       <xsl:for-each select="//o[generate-id() != $top and @name and @name != 'φ' and @base and @base != '∅' and not(@base='ξ' and @name='xi🌵')]">
-        <xsl:if test="count(key('referenced-by-name', @name))&lt;=1 and not(@name and o[1]/@base = 'Φ.dataized')">
+        <xsl:variable name="in-recursive" select="some $r in key('referenced-by-name', @name), $f in $r/ancestor::o[@name and not(@base)] satisfies exists(key('referenced-by-name', $f/@name) intersect $f/descendant::o)"/>
+        <xsl:if test="count(key('referenced-by-name', @name))&lt;=1 and not(@name and o[1]/@base = 'Φ.dataized') and not($in-recursive)">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/motives/misc/redundant-object.md
+++ b/src/main/resources/org/eolang/motives/misc/redundant-object.md
@@ -19,3 +19,21 @@ Correct:
 [] > foo
   52.plus 2
 ```
+
+An object referenced only once is *not* redundant when that single reference
+sits inside a recursive formation. Syntactically the name is mentioned once, but
+at runtime the recursion evaluates it many times, and the named attribute lets
+all of those evaluations share a single node. Inlining it would give every level
+of the recursion its own copy of the subgraph, so the lint skips such objects:
+
+```eo
+# Series.
+[point] > series
+  point.times point > squared
+  poly 30 > @
+  [n] > poly
+    if. > @
+      n.eq 0
+      0
+      squared.plus (poly (n.minus 1))
+```

--- a/src/main/resources/org/eolang/motives/misc/redundant-object.md
+++ b/src/main/resources/org/eolang/motives/misc/redundant-object.md
@@ -23,7 +23,7 @@ Correct:
 An object referenced only once is *not* redundant when that single reference
 sits inside a recursive formation. Syntactically the name is mentioned once, but
 at runtime the recursion evaluates it many times, and the named attribute lets
-all of those evaluations share a single node. Inlining it would give every level
+all those evaluations share a single node. Inlining it would give every level
 of the recursion its own copy of the subgraph, so the lint skips such objects:
 
 ```eo

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-single-ref-inside-recursive-formation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-single-ref-inside-recursive-formation.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/lints/misc/redundant-object.xsl
+defects: 0
+input: |
+  # Series.
+  [point] > series
+    point.times point > squared
+    poly 30 > @
+    [n] > poly
+      if. > @
+        n.eq 0
+        0
+        squared.plus (poly (n.minus 1))

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/catches-single-ref-inside-non-recursive-formation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/catches-single-ref-inside-non-recursive-formation.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/lints/misc/redundant-object.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='3']
+  - /defects/defect[1][normalize-space()='The object "spb" is redundant and may be inlined']
+input: |
+  # Foo.
+  [] > foo
+    52 > spb
+    [n] > bar
+      spb.plus n > @
+    bar 2 > @


### PR DESCRIPTION
Closes #1132.

## Problem

`misc/redundant-object.xsl` reported an object as redundant when
`count(key('referenced-by-name', @name)) <= 1`, i.e. when the whole document
mentions its name at most once. That count is purely syntactic, so a lone
reference sitting inside a **recursive** formation was treated the same as a
lone reference in straight-line code.

Those are not the same. When the single reference lives inside a recursive
formation, the recursion evaluates it many times, and the named attribute lets
all of those evaluations share one node. Inlining the object gives every level
of the recursion its own copy of the subgraph — the case described in the issue
(`arc-sine.eo`) blows `EOarcSineTest` from ~9s to 189s and exhausts the heap
under the parallel suite.

## Fix

The lint now skips the defect when the single reference lies inside a formation
that is (ancestor-or-self of) a recursive one — operationally, when the
referring node has an ancestor formation whose own name is referenced by one of
its descendants:

```xslt
<xsl:variable name="in-recursive" select="some $r in key('referenced-by-name', @name), $f in $r/ancestor::o[@name and not(@base)] satisfies exists(key('referenced-by-name', $f/@name) intersect $f/descendant::o)"/>
```

This reuses the existing `referenced-by-name` key to detect recursion, so the
name-extraction logic stays in one place. This is distinct from #639 / #640,
which are about references the lint fails to see at all; here the reference is
counted correctly, but one syntactic mention is many dynamic ones.

## Tests

- `allows-single-ref-inside-recursive-formation.yaml` — the recursive `series`
  example from the issue; now yields 0 defects.
- `catches-single-ref-inside-non-recursive-formation.yaml` — a single reference
  inside a **non**-recursive nested formation still flags, guarding against
  over-suppression.

Full `LtByXslTest#testsAllLintsByEo` pack suite passes (349 tests, 0 failures).
The motive doc `misc/redundant-object.md` documents the exception.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYJkVbke1VcGNhBMDuM7rR)_