### PR TITLE
ci(#1114): handle broken pipe in benchmark script and add failure notice

### DIFF
--- a/.github/benchmark-diff.sh
+++ b/.github/benchmark-diff.sh
@@ -56,11 +56,16 @@ as_table() {
 }
 
 biggest_movers() {
-  grep -v -e $'\tnew$' -e $'\tremoved$' "${diff}" \
-    | awk -F'\t' '{ d = $4; if (d < 0) { d = -d }; printf "%d\t%s\n", d, $0 }' \
-    | sort -t $'\t' -k1,1 -n -r \
-    | cut -f2- \
-    | head -10
+  # head truncates the pipeline early, which SIGPIPEs the upstream writer;
+  # pipefail would otherwise treat that expected broken pipe as a failure.
+  (
+    set +o pipefail
+    grep -v -e $'\tnew$' -e $'\tremoved$' "${diff}" \
+      | awk -F'\t' '{ d = $4; if (d < 0) { d = -d }; printf "%d\t%s\n", d, $0 }' \
+      | sort -t $'\t' -k1,1 -n -r \
+      | cut -f2- \
+      | head -10
+  )
 }
 
 printf '## Benchmark comparison for #%s\n\n' "${pr}"

--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -49,3 +49,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr comment "${{ github.event.issue.number }}" --body-file /tmp/report.md --repo "${{ github.repository }}"
+      - name: Post failure notice on PR
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "⚠️ The \`/benchmark\` run failed. See [the failed workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."


### PR DESCRIPTION
Fix benchmark workflow failures by handling broken pipe signals and improving error visibility.

This PR addresses issues in the benchmark scripts that cause CI failures. The `benchmark-diff.sh` script now properly handles the expected broken pipe signal when `head` truncates the pipeline early, preventing spurious failures. Additionally, the PR benchmark workflow now posts a failure notice to the PR when the benchmark run encounters errors, improving visibility into benchmark-related issues.

Related to #1114