### PR TITLE
build(#1141): upgrade qulice-maven-plugin to 0.27.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -331,7 +331,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.27.6</version>
+            <version>0.27.8</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>pmd:/src/it/.*</exclude>

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -57,7 +57,7 @@ import org.yaml.snakeyaml.Yaml;
  * @since 0.0.1
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
-@SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"})
+@SuppressWarnings("PMD.TooManyMethods")
 final class LtByXslTest {
 
     @Test
@@ -89,7 +89,6 @@ final class LtByXslTest {
 
     @Tag("deep")
     @RepeatedTest(5)
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void lintsInMultipleThreads() {
         final LtByXsl lint = new LtByXsl("critical/duplicate-names");
         MatcherAssert.assertThat(

--- a/src/test/java/org/eolang/lints/MonoLintsTest.java
+++ b/src/test/java/org/eolang/lints/MonoLintsTest.java
@@ -66,7 +66,6 @@ final class MonoLintsTest {
     }
 
     @Test
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void lintsProgramCorrectly() throws IOException {
         final XML xmir = MonoLintsTest.parse();
         final Collection<Defect> found = new ListOf<>();
@@ -94,7 +93,6 @@ final class MonoLintsTest {
      * @param xmir Parsed XMIR
      * @param into Accumulator
      */
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private static void collect(
         final Lint lint, final XML xmir, final Collection<Defect> into
     ) {

--- a/src/test/java/org/eolang/lints/PkByXslTest.java
+++ b/src/test/java/org/eolang/lints/PkByXslTest.java
@@ -88,7 +88,6 @@ final class PkByXslTest {
     }
 
     @Test
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     void doesNotDuplicateDefectsWhenMultipleDefectsOnTheSameLine() {
         final XML xmir = PkByXslTest.parse();
         final Collection<Defect> aggregated = new ListOf<>();

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -565,7 +565,6 @@ final class SourceTest {
          * @return Defects
          * @throws IOException If fails
          */
-        @SuppressWarnings("PMD.UnnecessaryLocalRule")
         Collection<Defect> defects() throws IOException {
             final long before = System.currentTimeMillis();
             try {


### PR DESCRIPTION
Upgrade `qulice-maven-plugin` to v0.27.8 and remove unnecessary PMD suppression annotations that are no longer needed with the newer plugin version.

Fixes #1141