### PR TITLE
Add `bad-test-name` lint for test object naming convention

### DIFF
--- a/src/main/resources/org/eolang/lints/tests/bad-test-name.xsl
+++ b/src/main/resources/org/eolang/lints/tests/bad-test-name.xsl
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="bad-test-name" version="2.0">
+  <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="/object//o[starts-with(@name, '+')]">
+        <xsl:variable name="regexp" select="'^(can|cannot|accepts|rejects|stops-on)-'"/>
+        <xsl:if test="not(matches(eo:escape-plus(@name), $regexp))">
+          <defect>
+            <xsl:variable name="line" select="eo:lineno(@line)"/>
+            <xsl:attribute name="line">
+              <xsl:value-of select="$line"/>
+            </xsl:attribute>
+            <xsl:if test="$line = '0'">
+              <xsl:attribute name="context">
+                <xsl:value-of select="eo:defect-context(.)"/>
+              </xsl:attribute>
+            </xsl:if>
+            <xsl:attribute name="severity">warning</xsl:attribute>
+            <xsl:text>The name of the test object </xsl:text>
+            <xsl:value-of select="eo:escape(@name)"/>
+            <xsl:text> must start with one of the prefixes </xsl:text>
+            <xsl:value-of select="eo:escape('can-, cannot-, accepts-, rejects-, stops-on-')"/>
+          </defect>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/tests/bad-test-name.md
+++ b/src/main/resources/org/eolang/motives/tests/bad-test-name.md
@@ -1,0 +1,21 @@
+# Bad test name
+
+Every unit test object must be named to describe the behavior it verifies,
+starting with one of these prefixes: `can-`, `cannot-`, `accepts-`,
+`rejects-`, or `stops-on-`.
+
+Incorrect:
+
+```eo
+[] > foo
+  [] +> it-works
+    42 > @
+```
+
+Correct:
+
+```eo
+[] > foo
+  [] +> can-add-two-numbers
+    42 > @
+```

--- a/src/test/resources/org/eolang/lints/main-with-test.eo
+++ b/src/test/resources/org/eolang/lints/main-with-test.eo
@@ -11,5 +11,5 @@
     Q.txt.sprintf
       "Hello %s"
       * c
-  [] +> starts-correctly
+  [] +> accepts-argument
     main 42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name/allows-all-prefixes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name/allows-all-prefixes.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/bad-test-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [] > foo
+    [] > bar
+    [] +> can-do-something
+    [] +> cannot-do-something
+    [] +> accepts-input
+    [] +> rejects-input
+    [] +> stops-on-error

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name/allows-can-prefix.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name/allows-can-prefix.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/bad-test-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [] > foo
+    [] > bar
+    [] +> can-add-two-numbers

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name/allows-no-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name/allows-no-tests.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/bad-test-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [] > foo
+    [] > bar
+    [] > baz

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-bad-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-bad-name.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/bad-test-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+input: |
+  [] > foo
+    [] > bar
+    [] +> it-works

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-multiple-bad-names.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-multiple-bad-names.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/bad-test-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=2]
+input: |
+  [] > foo
+    [] > bar
+    [] +> can-do-something
+    [] +> testing
+    [] +> should-not-pass

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-prefix-without-dash.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-prefix-without-dash.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/bad-test-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=2]
+input: |
+  [] > foo
+    [] > bar
+    [] +> cannonball
+    [] +> rejection

--- a/src/test/resources/org/eolang/lints/valid-source.eo
+++ b/src/test/resources/org/eolang/lints/valid-source.eo
@@ -9,5 +9,5 @@
 [i] > foo
   i > @
   # This is real unit test for object with no functionality.
-  [] +> does-something
+  [] +> accepts-something
     foo 1 > @


### PR DESCRIPTION
Closes #1125.

## What

Adds a new `bad-test-name` lint that checks every test object (an `o` with a name starting with `+`) is named with one of the required prefixes:

- `can-*`
- `cannot-*`
- `accepts-*`
- `rejects-*`
- `stops-on-*`

Any test object whose name does not start with one of these prefixes raises a `warning`.

## How

- `src/main/resources/org/eolang/lints/tests/bad-test-name.xsl` — the XSL lint. It iterates over `/object//o[starts-with(@name, '+')]` and flags names that don't match `^(can|cannot|accepts|rejects|stops-on)-`. It follows the same structure as the sibling `tests/*` lints (line/context/severity, `eo:escape` for the name so the message passes the grammar/spell checker).
- `src/main/resources/org/eolang/motives/tests/bad-test-name.md` — the motive documentation for the lint.
- `src/test/resources/org/eolang/lints/packs/single/bad-test-name/*.yaml` — YAML packs covering the allowed prefixes, absence of tests, and several bad-name cases (including prefixes that lack the trailing dash, e.g. `cannonball`, `rejection`).

## Fixture updates

Two shared fixtures that are linted with the full lint set and assert exact defect counts contained non-compliant test names, so they were renamed to compliant names that also satisfy the existing `unit-test-is-not-verb` lint (which requires a 3rd-person-singular verb as the first word):

- `valid-source.eo`: `does-something` → `accepts-something`
- `main-with-test.eo`: `starts-correctly` → `accepts-argument`

Note: `can-`/`cannot-` prefixes are intentionally not used in these fixtures because the existing `unit-test-is-not-verb` lint tags `can`/`cannot` as modal verbs (not `VBZ`), so `accepts-*` was chosen to keep both lints happy.

## Testing

`SourceTest`, `LtByXslTest` (all packs, plus the structural checks for XSL id / motive presence / pack locations), `LtTestNotVerbTest`, `PkMonoTest`, `PkByXslTest`, and `MonoLintsTest` all pass (the `hone` profile was disabled locally since Docker is unavailable in the sandbox; that plugin is unrelated to these changes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3L35CQqtH3Nys7bUenYQo)_