### PR TITLE
Add anemic-getter lint for redundant renaming (#1110)

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/anemic-getter.xsl
+++ b/src/main/resources/org/eolang/lints/misc/anemic-getter.xsl
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="anemic-getter" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <!--
+  A named object that does nothing but give access to a sibling attribute
+  of the same formation is an "anemic getter". Such renaming is redundant,
+  since the original attribute may be used directly. For example:
+
+    [title] > book
+      title > t
+
+  Here 't' just renames 'title' and adds nothing, so it should be removed.
+  -->
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[@name and @name!='φ' and @base and matches(@base, '^ξ\.[^.]+$') and not(o)]">
+        <xsl:variable name="ref" select="substring-after(@base, 'ξ.')"/>
+        <xsl:if test="../o[@name=$ref]">
+          <defect>
+            <xsl:variable name="line" select="eo:lineno(@line)"/>
+            <xsl:attribute name="line">
+              <xsl:value-of select="$line"/>
+            </xsl:attribute>
+            <xsl:if test="$line = '0'">
+              <xsl:attribute name="context">
+                <xsl:value-of select="eo:defect-context(.)"/>
+              </xsl:attribute>
+            </xsl:if>
+            <xsl:attribute name="severity">warning</xsl:attribute>
+            <xsl:text>The object </xsl:text>
+            <xsl:value-of select="eo:escape(@name)"/>
+            <xsl:text> is a redundant getter, it just renames </xsl:text>
+            <xsl:value-of select="eo:escape($ref)"/>
+            <xsl:text> without adding anything, use </xsl:text>
+            <xsl:value-of select="eo:escape($ref)"/>
+            <xsl:text> directly instead</xsl:text>
+          </defect>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/misc/anemic-getter.xsl
+++ b/src/main/resources/org/eolang/lints/misc/anemic-getter.xsl
@@ -9,14 +9,11 @@
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
   <!--
-  A named object that does nothing but give access to a sibling attribute
-  of the same formation is an "anemic getter". Such renaming is redundant,
-  since the original attribute may be used directly. For example:
-
-    [title] > book
-      title > t
-
-  Here 't' just renames 'title' and adds nothing, so it should be removed.
+  A named object whose whole body is a reference to a sibling attribute of
+  the same formation is an "anemic getter". For example, "title > t" inside
+  a "[title] > book" formation just renames "title" without adding anything.
+  Such renaming is redundant, since the original attribute may be used
+  directly, so we complain about it here.
   -->
   <xsl:template match="/">
     <defects>

--- a/src/main/resources/org/eolang/motives/misc/anemic-getter.md
+++ b/src/main/resources/org/eolang/motives/misc/anemic-getter.md
@@ -1,0 +1,35 @@
+# Anemic Getter
+
+A named object that does nothing but give access to a sibling attribute of the
+same formation is an "anemic getter". Such renaming is redundant, since the
+original attribute may be used directly, without an extra name in between.
+
+Incorrect:
+
+```eo
+# Book.
+[title] > book
+  title > t
+```
+
+Here, `t` is a getter that only gives access to `title`. It adds nothing and
+just introduces a second name for the same object.
+
+Correct:
+
+```eo
+# Book.
+[title] > book
+```
+
+Simply use `title` directly wherever `t` was needed. The same applies to any
+sibling attribute, not only void ones:
+
+```eo
+# Foo.
+[] > foo
+  42 > x
+  x > y
+```
+
+Here `y` is an anemic getter for `x` and should be removed.

--- a/src/main/resources/org/eolang/motives/misc/anemic-getter.md
+++ b/src/main/resources/org/eolang/motives/misc/anemic-getter.md
@@ -1,8 +1,8 @@
 # Anemic Getter
 
 A named object that does nothing but give access to a sibling attribute of the
-same formation is an "anemic getter". Such renaming is redundant, since the
-original attribute may be used directly, without an extra name in between.
+same formation is an "anemic getter." Such renaming is redundant, since the
+original attribute may be used directly, with no extra name added.
 
 Incorrect:
 

--- a/src/test/resources/org/eolang/lints/packs/single/anemic-getter/allows-application.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anemic-getter/allows-application.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/anemic-getter.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # Foo.
+  [x] > foo
+    x.plus 1 > y

--- a/src/test/resources/org/eolang/lints/packs/single/anemic-getter/allows-external-reference.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anemic-getter/allows-external-reference.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/anemic-getter.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # Foo.
+  [] > foo
+    QQ.io.stdout > b

--- a/src/test/resources/org/eolang/lints/packs/single/anemic-getter/allows-external-reference.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anemic-getter/allows-external-reference.yaml
@@ -8,4 +8,4 @@ asserts:
 input: |
   # Foo.
   [] > foo
-    QQ.io.stdout > b
+    bar > b

--- a/src/test/resources/org/eolang/lints/packs/single/anemic-getter/allows-phi-decoration.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anemic-getter/allows-phi-decoration.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/anemic-getter.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # Book.
+  [title] > book
+    title > @

--- a/src/test/resources/org/eolang/lints/packs/single/anemic-getter/catches-sibling-rename.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anemic-getter/catches-sibling-rename.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/anemic-getter.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='4']
+input: |
+  # Foo.
+  [] > foo
+    42 > x
+    x > y

--- a/src/test/resources/org/eolang/lints/packs/single/anemic-getter/catches-void-rename.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anemic-getter/catches-void-rename.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/anemic-getter.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='3']
+input: |
+  # Book.
+  [title] > book
+    title > t

--- a/src/test/resources/org/eolang/lints/packs/single/anemic-getter/prints-context-when-lines-empty.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anemic-getter/prints-context-when-lines-empty.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/anemic-getter.xsl
+asserts:
+  - /defects[count(defect[@context and @severity='warning'])=1]
+document: |
+  <object author="tests">
+    <o name="book">
+      <o base="∅" name="title"/>
+      <o base="ξ.title" name="t"/>
+    </o>
+  </object>


### PR DESCRIPTION
Closes #1110.

## What

Adds a new `misc/anemic-getter` lint that catches **redundant renaming**: a named object whose entire body is just a reference to a sibling attribute of the same formation, adding nothing.

For the example from the issue:

```eo
# Book.
[title] > book
  title > t
```

`t` is a getter that only gives access to `title`. It is redundant, since `title` can be used directly. The lint reports a `warning`:

> The object "t" is a redundant getter, it just renames "title" without adding anything, use "title" directly instead

## How it detects

In XMIR, `title > t` becomes `<o base="ξ.title" name="t"/>`. The lint flags an `<o>` that:

- has a `@name` other than `φ` (so decoration `title > @` is left alone);
- has a single-hop self reference base `ξ.<name>` (so external `Φ.…` references and multi-hop applications like `x.plus 1` are left alone);
- has no child objects (so anything with arguments/body is left alone);
- has a matching sibling attribute `<o name="<name>">` in the same formation (void or concrete).

It fires for both void-attribute renames and sibling renames (`42 > x` then `x > y`).

## Files

- `src/main/resources/org/eolang/lints/misc/anemic-getter.xsl` — the lint;
- `src/main/resources/org/eolang/motives/misc/anemic-getter.md` — its motive;
- `src/test/resources/org/eolang/lints/packs/single/anemic-getter/*.yaml` — packs covering the void rename, sibling rename, empty-line context, and the application / `φ`-decoration / external-reference cases that must be ignored.

## Testing

`mvn test -Dtest=LtByXslTest,SourceTest` (with the Docker-only `hone` profile disabled) passes — 394 tests, 0 failures. This exercises all YAML packs, motive/XSL-id/naming validation, and confirms the existing clean sources are not newly flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEPdjsE89MuZUAXJTjcBJQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEPdjsE89MuZUAXJTjcBJQ)_