### PR TITLE
build(#1151): upgrade qulice-maven-plugin to 0.27.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -331,7 +331,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.27.8</version>
+            <version>0.27.9</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>pmd:/src/it/.*</exclude>

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -57,7 +57,6 @@ import org.yaml.snakeyaml.Yaml;
  * @since 0.0.1
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
-@SuppressWarnings("PMD.TooManyMethods")
 final class LtByXslTest {
 
     @Test

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -68,7 +68,6 @@ import org.objectweb.asm.Opcodes;
  * @checkstyle MethodBodyCommentsCheck (50 lines)
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
-@SuppressWarnings("PMD.TooManyMethods")
 @ExtendWith(MktmpResolver.class)
 final class SourceTest {
 


### PR DESCRIPTION
Upgrade `qulice-maven-plugin` to v0.27.9 and remove unnecessary `@SuppressWarnings` annotations that are no longer required by the new version's stricter PMD rules.

Fixes #1151