### PR TITLE
ci(#1145): remove deep profile from pit workflow

### DIFF
--- a/.github/workflows/pit.yml
+++ b/.github/workflows/pit.yml
@@ -22,7 +22,7 @@ jobs:
           path: ~/.m2/repository
           key: ubuntu-jdk-21-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ubuntu-jdk-21-maven-
-      - run: mvn clean install "-Ppit,deep"
+      - run: mvn clean install "-Ppit"
   report:
     name: Create issue on failure
     needs: pit


### PR DESCRIPTION
Removes the `deep` profile from the PIT mutation testing workflow to resolve test discovery issues causing 0% mutation coverage.

Related to #1145