### PR TITLE
ci(#1144): pin Java 23 and enable pull_request trigger in infer workflow

### DIFF
--- a/.github/workflows/infer.yml
+++ b/.github/workflows/infer.yml
@@ -7,12 +7,19 @@ name: infer
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 jobs:
   infer:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 23
       - uses: srz-zumix/setup-infer@v1
         with:
           infer_version: v1.0.0

--- a/src/test/java/org/eolang/lints/PkByXslTest.java
+++ b/src/test/java/org/eolang/lints/PkByXslTest.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.function.Predicate;
 import org.cactoos.io.InputOf;
 import org.cactoos.io.ResourceOf;
@@ -140,7 +141,9 @@ final class PkByXslTest {
                 return new XMLDocument(
                     new UncheckedText(new TextOf(new InputOf(res.getInputStream()))).asString()
                 ).xpath("/xsl:stylesheet/@id").get(0).equals(
-                    res.getFilename().replaceAll(".xsl$", "")
+                    Objects.requireNonNull(
+                        res.getFilename(), "Resource filename must not be absent"
+                    ).replaceAll(".xsl$", "")
                 );
             } catch (final IOException ex) {
                 throw new IllegalStateException(ex);


### PR DESCRIPTION
This PR fixes the failing `infer` CI workflow by adding Java 23 setup via `actions/setup-java` and enabling pull request event triggers, ensuring consistent compilation behavior across all CI jobs.

Related to #1144