### PR TITLE
build(#1124): bump hone-maven-plugin and exclude JUnit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -386,7 +386,7 @@
           <plugin>
             <groupId>org.eolang</groupId>
             <artifactId>hone-maven-plugin</artifactId>
-            <version>0.29.0</version>
+            <version>0.29.1</version>
             <executions>
               <execution>
                 <goals>
@@ -493,7 +493,6 @@
               <excludedGroups>benchmark,reserved</excludedGroups>
               <excludes>
                 <exclude>generated/**</exclude>
-                <exclude>**/org/junit/**</exclude>
               </excludes>
             </configuration>
           </plugin>
@@ -741,7 +740,6 @@
               <excludedGroups>benchmark,deep</excludedGroups>
               <excludes>
                 <exclude>generated/**</exclude>
-                <exclude>**/org/junit/**</exclude>
               </excludes>
             </configuration>
           </plugin>


### PR DESCRIPTION
Bump `hone-maven-plugin` to 0.29.1 and remove JUnit exclusion patterns from test profiles.

Fixes #1124