### PR TITLE
perf(#978): optimize bytes-without-data XSL selector

### DIFF
--- a/src/main/resources/org/eolang/lints/critical/bytes-without-data.xsl
+++ b/src/main/resources/org/eolang/lints/critical/bytes-without-data.xsl
@@ -11,7 +11,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:apply-templates select="//o[not(eo:has-data(.)) and parent::o[@base='Φ.bytes'] and eo:abstract(.)]" mode="with-data"/>
+      <xsl:apply-templates select="//o[@base='Φ.bytes']/o[eo:abstract(.) and not(eo:has-data(.))]" mode="with-data"/>
     </defects>
   </xsl:template>
   <xsl:template match="o" mode="with-data">


### PR DESCRIPTION
Optimize `bytes-without-data` XSL transformation performance by reordering XPath predicates to filter by cheaper conditions first, reducing expensive `eo:has-data()` calls on large XMIR files.

Fixes #978