### PR TITLE
ci(#1180): fix vale CI check failing on INFO-level violations

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -10,9 +10,8 @@ jobs:
       - uses: actions/checkout@v7
       - uses: errata-ai/vale-action@2.1.2
         with:
+          version: '3.17.0'
           files: 'src/main/resources/org/eolang/motives'
-          # Disabled until #1180 is resolved: fail_on_error fails the whole
-          # check even on INFO-level violations, blocking unrelated PRs.
-          fail_on_error: 'false'
+          fail_on_error: 'true'
           reporter: 'github-pr-review'
           filter_mode: 'nofilter'

--- a/.vale.ini
+++ b/.vale.ini
@@ -4,7 +4,9 @@
 StylesPath = .github/styles
 Vocab = Custom
 MinAlertLevel = suggestion
-Packages = Google, Microsoft, proselint
+; Pinned to specific releases so CI doesn't break when upstream style
+; packages silently add or tighten rules (see #1180).
+Packages = https://github.com/errata-ai/Google/releases/download/v0.7.0/Google.zip, https://github.com/errata-ai/Microsoft/releases/download/v0.15.0/Microsoft.zip, https://github.com/errata-ai/proselint/releases/download/v0.3.4/proselint.zip
 
 [*.md]
 ;; @todo #540:60min Add a new style package - `write-good` - to both this list and the package list.

--- a/src/main/resources/org/eolang/motives/critical/unknown-rt.md
+++ b/src/main/resources/org/eolang/motives/critical/unknown-rt.md
@@ -1,7 +1,7 @@
 # Unknown `+rt`
 
-The special `+rt` meta must use only allowed values in its first part. Currently,
-the following runtimes are supported:
+The special `+rt` meta must use only allowed values in its first part. The
+following runtimes are supported:
 
 * [JVM](https://github.com/objectionary/eo)
 * [node](https://github.com/objectionary/eo2js)


### PR DESCRIPTION
Fixes the `vale` CI check failing on pre-existing `INFO`-level violations by pinning style package versions, upgrading the vale action, enabling error-only reporting, and correcting the flagged style issue in documentation.

Fixes #1180