### PR TITLE
chore(#1177): update jtcop-maven-plugin to v1.4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
           <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
-            <version>1.4.3</version>
+            <version>1.4.4</version>
             <executions>
               <execution>
                 <goals>


### PR DESCRIPTION
Bump `jtcop-maven-plugin` from 1.4.3 to 1.4.4.

Fixes #1177