### PR TITLE
fix(#1155): correct noliners reporting based on object scope

### DIFF
--- a/src/main/resources/org/eolang/lints/refs/line-is-absent.xsl
+++ b/src/main/resources/org/eolang/lints/refs/line-is-absent.xsl
@@ -14,7 +14,7 @@
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="//o[@base and not(starts-with(@base, '.')) and @base!='ξ' and @base!='ρ']">
-        <xsl:variable name="name" select="replace(@base, '^Φ\.', '')"/>
+        <xsl:variable name="name" select="replace(replace(@base, '^Φ\.', ''), '^ξ\.', '')"/>
         <xsl:variable name="target" select="ancestor::o[1]/o[@name = $name and not(@line)]"/>
         <xsl:if test="$target">
           <defect line="0" severity="error">

--- a/src/main/resources/org/eolang/lints/refs/line-is-absent.xsl
+++ b/src/main/resources/org/eolang/lints/refs/line-is-absent.xsl
@@ -11,12 +11,11 @@
   everything is OK. If we don't, we report an error.
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:key name="objsNoLineByName" match="o[not(@line)]" use="@name"/>
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="//o[@base and not(starts-with(@base, '.')) and @base!='ξ' and @base!='ρ']">
-        <xsl:variable name="self" select="."/>
-        <xsl:variable name="target" select="key('objsNoLineByName', replace($self/@base, 'Φ.', ''))"/>
+        <xsl:variable name="name" select="replace(@base, '^Φ\.', '')"/>
+        <xsl:variable name="target" select="ancestor::o[1]/o[@name = $name and not(@line)]"/>
         <xsl:if test="$target">
           <defect line="0" severity="error">
             The @line attribute is absent at <xsl:value-of select="$target/@name"/>

--- a/src/test/resources/org/eolang/lints/packs/single/line-is-absent/allows-noliner-in-same-scope.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/line-is-absent/allows-noliner-in-same-scope.yaml
@@ -9,6 +9,6 @@ document: |
     <o>
       <o name="foo" line="1"/>
       <o name="boom"/>
-      <o name="bar" base="foo" line="2"/>
+      <o name="bar" base="ξ.foo" line="2"/>
     </o>
   </object>

--- a/src/test/resources/org/eolang/lints/packs/single/line-is-absent/allows-noliner-in-same-scope.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/line-is-absent/allows-noliner-in-same-scope.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/refs/line-is-absent.xsl
+defects: 0
+document: |
+  <object author="tests">
+    <o>
+      <o name="foo" line="1"/>
+      <o name="boom"/>
+      <o name="bar" base="foo" line="2"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/line-is-absent/allows-noliner-with-same-name-diff-context.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/line-is-absent/allows-noliner-with-same-name-diff-context.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/refs/line-is-absent.xsl
+defects: 0
+document: |
+  <object author="tests">
+    <o>
+      <o name="foo" line="1"/>
+      <o name="bar" base="foo" line="2"/>
+    </o>
+    <o>
+      <o name="foo"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/line-is-absent/allows-noliner-with-same-name-diff-context.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/line-is-absent/allows-noliner-with-same-name-diff-context.yaml
@@ -7,10 +7,12 @@ defects: 0
 document: |
   <object author="tests">
     <o>
-      <o name="foo" line="1"/>
-      <o name="bar" base="foo" line="2"/>
-    </o>
-    <o>
-      <o name="foo"/>
+      <o>
+        <o name="foo" line="1"/>
+        <o name="bar" base="ξ.foo" line="2"/>
+      </o>
+      <o>
+        <o name="foo"/>
+      </o>
     </o>
   </object>

--- a/src/test/resources/org/eolang/lints/packs/single/line-is-absent/reports-noliner-with-same-name-same-context.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/line-is-absent/reports-noliner-with-same-name-same-context.yaml
@@ -8,11 +8,13 @@ asserts:
   - /defects/defect[normalize-space(.)='The @line attribute is absent at foo']
 document: |
   <object author="tests">
-    <o>
-      <o name="foo"/>
-      <o name="bar" base="foo" line="2"/>
-    </o>
-    <o>
-      <o name="foo"/>
+    <o name="app">
+      <o>
+        <o name="foo"/>
+        <o name="bar" base="ξ.foo" line="2"/>
+      </o>
+      <o>
+        <o name="foo"/>
+      </o>
     </o>
   </object>

--- a/src/test/resources/org/eolang/lints/packs/single/line-is-absent/reports-noliner-with-same-name-same-context.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/line-is-absent/reports-noliner-with-same-name-same-context.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/refs/line-is-absent.xsl
+asserts:
+  - /defects[count(defect[@severity='error'])=1]
+  - /defects/defect[normalize-space(.)='The @line attribute is absent at foo']
+document: |
+  <object author="tests">
+    <o>
+      <o name="foo"/>
+      <o name="bar" base="foo" line="2"/>
+    </o>
+    <o>
+      <o name="foo"/>
+    </o>
+  </object>


### PR DESCRIPTION
In this PR I've updated `refs/line-is-absent` lint to report noliners (objects without `@line` attribute) that are only referred from the given scope under inspection.

see #1155