### PR TITLE
ci(#723): Enable hone workflows

### DIFF
--- a/.github/workflows/hone.yml
+++ b/.github/workflows/hone.yml
@@ -10,18 +10,10 @@ name: hone
   pull_request:
     branches:
       - master
-env:
-  RUN_WORKFLOW: false
 jobs:
   hone:
     timeout-minutes: 45
     runs-on: ubuntu-24.04
-    # @todo #716:35min Enable hone.yml and jmh.yml (hone-dependent workflow) after hone will be fixed.
-    #  At present, the hone is unable to generate the correct optimized byte code for Groovy, see
-    #  this issue: https://github.com/objectionary/hone-maven-plugin/issues/297. Also, the plugin run
-    #  is time-consuming, we should enable it only after the plugin will have stable execution time,
-    #  in order to not disturb the development in this repository.
-    if: ${{ vars.RUN_WORKFLOW == 'true' }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5

--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@
     <profile>
       <id>hone</id>
       <activation>
-        <jdk>[11,)</jdk>
+        <activeByDefault>false</activeByDefault>
       </activation>
       <build>
         <plugins>


### PR DESCRIPTION
Resolves puzzle #716 by removing the conditional guard from the `hone` workflow and updating the Maven profile activation logic to use explicit default configuration instead of JDK version detection.

Fixes #723