### PR TITLE
build(#1174): upgrade qulice-maven-plugin to 0.30.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.27.9</version>
+            <version>0.30.1</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>pmd:/src/it/.*</exclude>

--- a/src/main/java/org/eolang/lints/Defect.java
+++ b/src/main/java/org/eolang/lints/Defect.java
@@ -124,7 +124,6 @@ public interface Defect {
          * @param severity Severity level
          * @param line Line number
          * @param text Description of the defect
-         * @checkstyle ParameterNumberCheck (5 lines)
          */
         public Default(
             final String rule, final Severity severity,
@@ -143,7 +142,6 @@ public interface Defect {
          * @param line Line number
          * @param text Description of the defect
          * @param exprmnt Experimental?
-         * @checkstyle ParameterNumberCheck (5 lines)
          */
         public Default(
             final String rule, final Severity severity,

--- a/src/main/java/org/eolang/lints/LtAsciiOnly.java
+++ b/src/main/java/org/eolang/lints/LtAsciiOnly.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
  *  ArrayList<>() without a constructor argument in whole project. Add ignore warning
  *  ConditionalRegexpMultilineCheck from Checkstyle (it doesn't seem to be possible at the moment
  *  <a href="https://github.com/yegor256/qulice/issues/1328">issue 1328</a>)
- * @checkstyle StringLiteralsConcatenationCheck (30 lines)
  * @checkstyle UnnecessaryParenthesesCheck (30 lines)
  */
 final class LtAsciiOnly implements Lint {

--- a/src/main/java/org/eolang/lints/Vocabulary.java
+++ b/src/main/java/org/eolang/lints/Vocabulary.java
@@ -67,7 +67,7 @@ final class Vocabulary {
     /**
      * Check if the given kebab-case name starts with a verb in third-person singular.
      *
-     * <p>The check uses the "It [verb]s" rule: "It generates-report" → the
+     * <p>The check uses the "It [verb]s" rule: "It generates-report" -> the
      * first word must be tagged {@code VBZ} (verb, 3rd-person singular present).</p>
      *
      * @param name Kebab-case name without any leading {@code +} sigil

--- a/src/test/java/benchmarks/SourceBench.java
+++ b/src/test/java/benchmarks/SourceBench.java
@@ -26,7 +26,6 @@ import org.openjdk.jmh.annotations.Warmup;
 /**
  * Benchmark for {@link Source}.
  * @since 0.0.34
- * @checkstyle DesignForExtensionCheck (10 lines)
  * @checkstyle NonStaticMethodCheck (100 lines)
  */
 @Fork(1)

--- a/src/test/java/fixtures/EoProgram.java
+++ b/src/test/java/fixtures/EoProgram.java
@@ -81,7 +81,6 @@ public final class EoProgram {
      * @return Parsed XMIR document
      * @throws IOException If parsing fails
      */
-    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     private XML doParse() throws IOException {
         final long start = System.currentTimeMillis();
         final XML xmir = new EoSyntax(this.resource).parsed();

--- a/src/test/java/fixtures/FixPack.java
+++ b/src/test/java/fixtures/FixPack.java
@@ -27,7 +27,6 @@ public final class FixPack {
     /**
      * Constructor.
      * @param yaml Raw YAML string containing 'sheets', 'input' and 'output' fields
-     * @checkstyle ConstructorsCodeFreeCheck (5 lines)
      */
     @SuppressWarnings("unchecked")
     public FixPack(final String yaml) {

--- a/src/test/java/fixtures/SourceSize.java
+++ b/src/test/java/fixtures/SourceSize.java
@@ -66,7 +66,6 @@ public enum SourceSize {
      * @param start Minimum size in executable lines
      * @param end Maximum size in executable lines
      * @param java Java bytecode class path
-     * @checkstyle ParameterNumberCheck (3 lines)
      */
     SourceSize(final String txt, final int start, final int end, final String java) {
         this.largeness = txt;

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -65,8 +65,6 @@ import org.objectweb.asm.Opcodes;
  *  As for now, most lints are too slow, we need to optimize them first, so they
  *  run in milliseconds, not seconds/minutes. It should decrease our build time too.
  *  After that, we need to decrease our test timeouts. Don't forget to remove this puzzle.
- * @checkstyle MethodBodyCommentsCheck (50 lines)
- * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
 @ExtendWith(MktmpResolver.class)
 final class SourceTest {
@@ -184,7 +182,7 @@ final class SourceTest {
             new Source(
                 new EoProgram("org/eolang/lints/non-ascii-cyrillic.eo").parse()
             ).without("ascii-only").defects().stream()
-                .filter(defect -> defect.rule().equals("ascii-only"))
+                .filter(defect -> "ascii-only".equals(defect.rule()))
                 .collect(Collectors.toList()),
             Matchers.emptyIterable()
         );
@@ -474,7 +472,6 @@ final class SourceTest {
          * @param lnts Lints to apply
          * @param tmngs Timings
          * @param size Source size
-         * @checkstyle ParameterNumberCheck (5 lines)
          */
         BcSource(
             final XML source, final Iterable<Lint> lnts, final Tojos tmngs, final String size
@@ -551,7 +548,6 @@ final class SourceTest {
          * @param xmr XML
          * @param tmngs Timings
          * @param mrkr Marker
-         * @checkstyle ParameterNumberCheck (5 lines)
          */
         TimedLint(final Lint lnt, final XML xmr, final Tojos tmngs, final String mrkr) {
             this.lint = lnt;

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 
+junit.jupiter.execution.parallel.enabled = true
 # @todo #107:45min Configure default timeout for tests running on windows to 10s and 3s on other platforms.
 #  Currently, it fails with the 3s timeout on windows platform. Let's try to configure
 #  test default timeout exclusively for windows, and keep 3s for other platforms.
 junit.jupiter.execution.timeout.test.method.default = 45s
-junit.jupiter.execution.parallel.enabled = true

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,11 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 
-log4j.rootLogger=INFO, CONSOLE
-
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=com.jcabi.log.MulticolorLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%d{HH:mm:ss} [%p] %c: %m%n
-
-log4j.logger.org.eolang.parser.CheckPack=INFO
 log4j.logger.com.yegor256.MayBeSlow=INFO
+log4j.logger.org.eolang.parser.CheckPack=INFO
+log4j.rootLogger=INFO, CONSOLE


### PR DESCRIPTION
This PR upgrades `qulice-maven-plugin` to version 0.30.1 and resolves code quality violations flagged by the stricter checks in the new qulice version. The changes ensure the codebase complies with the updated linting standards while maintaining code quality and integrity.

Fixes #1174