### PR TITLE
ci(#1196): replace benchmark workflow paths-ignore with allowlist

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,7 +7,7 @@ name: benchmark
   push:
     branches:
       - master
-    paths-ignore: ['README.md', '.github']
+    paths: ['src/main/**']
 concurrency:
   group: benchmark-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Replace `paths-ignore` denylist with `paths` allowlist in `benchmark.yml` to prevent unnecessary workflow triggers on non-code-related pushes to `master`.

Fixes #1196