### PR TITLE
fix(#1198): changed `refs/line-is-absent` to report all noliners

### DIFF
--- a/src/main/resources/org/eolang/lints/refs/line-is-absent.xsl
+++ b/src/main/resources/org/eolang/lints/refs/line-is-absent.xsl
@@ -18,9 +18,11 @@
           <xsl:attribute name="line">
             <xsl:value-of select="0"/>
           </xsl:attribute>
-          <xsl:attribute name="context">
-            <xsl:value-of select="eo:defect-context(.)"/>
-          </xsl:attribute>
+          <xsl:if test="not(@name)">
+            <xsl:attribute name="context">
+              <xsl:value-of select="eo:defect-context(.)"/>
+            </xsl:attribute>
+          </xsl:if>
           <xsl:attribute name="severity">
             <xsl:text>error</xsl:text>
           </xsl:attribute>

--- a/src/main/resources/org/eolang/lints/refs/line-is-absent.xsl
+++ b/src/main/resources/org/eolang/lints/refs/line-is-absent.xsl
@@ -5,7 +5,6 @@
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="line-is-absent" version="2.0">
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
-  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <!--
   Here we go through all objects. If it has @line attribute,
   everything is OK. If it's not, we report an error.
@@ -13,31 +12,22 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[not(@line)]">
-        <xsl:element name="defect">
-          <xsl:attribute name="line">
-            <xsl:value-of select="0"/>
-          </xsl:attribute>
-          <xsl:if test="not(@name)">
-            <xsl:attribute name="context">
-              <xsl:value-of select="eo:defect-context(.)"/>
-            </xsl:attribute>
-          </xsl:if>
-          <xsl:attribute name="severity">
-            <xsl:text>error</xsl:text>
-          </xsl:attribute>
-          <xsl:text>The @line attribute is absent at the </xsl:text>
-          <xsl:choose>
-            <xsl:when test="@name">
-              <xsl:text>object </xsl:text>
-              <xsl:value-of select="eo:escape(@name)"/>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:text>anonymous object</xsl:text>
-            </xsl:otherwise>
-          </xsl:choose>
-        </xsl:element>
-      </xsl:for-each>
+      <xsl:apply-templates select="/object//o[not(@line)]" mode="defect"/>
     </defects>
+  </xsl:template>
+  <xsl:template match="o" mode="defect">
+    <xsl:variable name="name" select="@name"/>
+    <defect line="0" severity="error">
+      <xsl:text>The @line attribute is absent at the </xsl:text>
+      <xsl:choose>
+        <xsl:when test="$name">
+          <xsl:text>object </xsl:text>
+          <xsl:value-of select="eo:escape($name)"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:text>anonymous object</xsl:text>
+        </xsl:otherwise>
+      </xsl:choose>
+    </defect>
   </xsl:template>
 </xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/refs/line-is-absent.xsl
+++ b/src/main/resources/org/eolang/lints/refs/line-is-absent.xsl
@@ -7,8 +7,8 @@
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <!--
-  Here we go through all objects. If we find the object they refer to,
-  everything is OK. If we don't, we report an error.
+  Here we go through all objects. If it has @line attribute,
+  everything is OK. If it's not, we report an error.
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">

--- a/src/main/resources/org/eolang/lints/refs/line-is-absent.xsl
+++ b/src/main/resources/org/eolang/lints/refs/line-is-absent.xsl
@@ -3,25 +3,38 @@
 * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="line-is-absent" version="2.0">
-  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="line-is-absent" version="2.0">
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <!--
-  Here we go through all objects and find what their @base
-  are referring to. If we find the object they refer to,
+  Here we go through all objects. If we find the object they refer to,
   everything is OK. If we don't, we report an error.
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:key name="objsNoLineByName" match="o[not(@line)]" use="@name"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[@base and not(starts-with(@base, '.')) and @base!='ξ' and @base!='ρ']">
-        <xsl:variable name="self" select="."/>
-        <xsl:variable name="target" select="key('objsNoLineByName', replace($self/@base, 'Φ.', ''))"/>
-        <xsl:if test="$target">
-          <defect line="0" severity="error">
-            The @line attribute is absent at <xsl:value-of select="$target/@name"/>
-          </defect>
-        </xsl:if>
+      <xsl:for-each select="//o[not(@line)]">
+        <xsl:element name="defect">
+          <xsl:attribute name="line">
+            <xsl:value-of select="0"/>
+          </xsl:attribute>
+          <xsl:attribute name="context">
+            <xsl:value-of select="eo:defect-context(.)"/>
+          </xsl:attribute>
+          <xsl:attribute name="severity">
+            <xsl:text>error</xsl:text>
+          </xsl:attribute>
+          <xsl:text>The @line attribute is absent at the </xsl:text>
+          <xsl:choose>
+            <xsl:when test="@name">
+              <xsl:text>object </xsl:text>
+              <xsl:value-of select="eo:escape(@name)"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:text>anonymous object</xsl:text>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:element>
       </xsl:for-each>
     </defects>
   </xsl:template>

--- a/src/main/resources/org/eolang/motives/refs/line-is-absent.md
+++ b/src/main/resources/org/eolang/motives/refs/line-is-absent.md
@@ -1,13 +1,13 @@
 # `@line` is absent
 
-In [XMIR], each `<o/>` element with a `@base` attribute must also have a `@line` attribute.
+In [XMIR], each `<o/>` element must also have a `@line` attribute.
 
 Incorrect:
 
 ```xml
 <object>
   <o>
-    <o name="bar" base="foo"/>
+    <o name="bar"/>
   </o>
 </object>
 ```
@@ -16,8 +16,8 @@ Correct:
 
 ```xml
 <object>
-  <o>
-    <o name="bar" base="foo" line="1"/>
+  <o line="1">
+    <o name="bar" line="1"/>
   </o>
 </object>
 ```

--- a/src/test/resources/org/eolang/lints/packs/single/line-is-absent/allows-all-lines-present-in-diff-scopes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/line-is-absent/allows-all-lines-present-in-diff-scopes.yaml
@@ -3,13 +3,11 @@
 ---
 sheets:
   - /org/eolang/lints/refs/line-is-absent.xsl
-asserts:
-  - /defects[count(defect[@severity='error'])=1]
-  - /defects[count(defect[@context])]
-document: |
+defects: 0
+document:
   <object author="tests">
     <o line="1">
-      <o name="foo"/>
-      <o name="bar" base="Φ.foo" line="3"/>
+      <o line="2"><o name="foo" line="2"/></o>
+      <o line="3"><o name="bar" base="ξ.foo" line="3"/></o>
     </o>
   </object>

--- a/src/test/resources/org/eolang/lints/packs/single/line-is-absent/allows-all-lines-present.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/line-is-absent/allows-all-lines-present.yaml
@@ -3,13 +3,11 @@
 ---
 sheets:
   - /org/eolang/lints/refs/line-is-absent.xsl
-asserts:
-  - /defects[count(defect[@severity='error'])=1]
-  - /defects[count(defect[@context])]
+defects: 0
 document: |
   <object author="tests">
-    <o line="1">
-      <o name="foo"/>
-      <o name="bar" base="Φ.foo" line="3"/>
+    <o name="app" line="1">
+      <o name="xyz" line="2"/>
+      <o name="boom" base="Φ.ss" line="3"/>
     </o>
   </object>

--- a/src/test/resources/org/eolang/lints/packs/single/line-is-absent/reports-anonymous-with-context.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/line-is-absent/reports-anonymous-with-context.yaml
@@ -5,7 +5,6 @@ sheets:
   - /org/eolang/lints/refs/line-is-absent.xsl
 asserts:
   - /defects[count(defect[@severity='error'])=1]
-  - /defects[count(defect[@context])]
 document:
   <object author="tests">
     <o line="1">

--- a/src/test/resources/org/eolang/lints/packs/single/line-is-absent/reports-anonymous-with-context.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/line-is-absent/reports-anonymous-with-context.yaml
@@ -5,10 +5,11 @@ sheets:
   - /org/eolang/lints/refs/line-is-absent.xsl
 asserts:
   - /defects[count(defect[@severity='error'])=1]
-document: |
+  - /defects[count(defect[@context])]
+document:
   <object author="tests">
     <o line="1">
-      <o name="foo"/>
-      <o name="bar" base="Φ.foo" line="3"/>
+      <o line="2"><o name="app" line="2"/></o>
+      <o base="Φ.stranger"><o name="boom" line="3"/></o>
     </o>
   </object>

--- a/src/test/resources/org/eolang/lints/packs/single/line-is-absent/reports-noliner-from-diff-scopes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/line-is-absent/reports-noliner-from-diff-scopes.yaml
@@ -5,7 +5,6 @@ sheets:
   - /org/eolang/lints/refs/line-is-absent.xsl
 asserts:
   - /defects[count(defect[@severity='error'])=1]
-  - /defects[count(defect[@context])]
 document:
   <object author="tests">
     <o line="1">

--- a/src/test/resources/org/eolang/lints/packs/single/line-is-absent/reports-noliner-from-diff-scopes.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/line-is-absent/reports-noliner-from-diff-scopes.yaml
@@ -6,10 +6,10 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='error'])=1]
   - /defects[count(defect[@context])]
-document: |
+document:
   <object author="tests">
     <o line="1">
-      <o name="foo"/>
-      <o name="bar" base="Φ.foo" line="3"/>
+      <o line="2"><o name="foo" line="2"/></o>
+      <o line="3"><o name="bar" base="ξ.foo"/></o>
     </o>
   </object>


### PR DESCRIPTION
In this PR I've changed `refs/line-is-absent` lint to report all objects without `@line` in the XMIR.

see #1198