### PR TITLE
ci(#1194): bump typos to v1.49.0 and increase test timeout

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: crate-ci/typos@v1.48.0
+      - uses: crate-ci/typos@v1.49.0
         with:
           config: ./.github/typos.toml

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -265,7 +265,7 @@ final class LtByXslTest {
     }
 
     @Test
-    @Timeout(10L)
+    @Timeout(20L)
     void checksDuplicateAsAttributeLintOnLargeXmirInReasonableTime()
         throws ImpossibleModificationException {
         final int parents = 500;


### PR DESCRIPTION
Bump `crate-ci/typos` action to v1.49.0 and increase test timeout to stabilize Windows CI builds.

Fixes #1194