### PR TITLE
fix(#1055): fix unused-alias detection with overlapping prefixes

### DIFF
--- a/src/main/resources/org/eolang/lints/aliases/unused-alias.xsl
+++ b/src/main/resources/org/eolang/lints/aliases/unused-alias.xsl
@@ -12,7 +12,7 @@
     <defects>
       <xsl:for-each select="/object/metas/meta[head='alias' and count(part)=2]">
         <xsl:variable name="name" select="tokenize(tail, ' ')[last()]"/>
-        <xsl:if test="count(//o[starts-with(@base, $name)])=0">
+        <xsl:if test="count(//o[@base=$name or starts-with(@base, concat($name, '.'))])=0">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/single/unused-alias/catches-unused-alias-with-overlapping-prefix.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unused-alias/catches-unused-alias-with-overlapping-prefix.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/aliases/unused-alias.xsl
+asserts:
+  - /defects[count(defect[@severity='error'])=1]
+  - /defects/defect[@line='1']
+input: |
+  +alias first org.example.alpha
+  +alias second org.example.alphabet
+
+  # No comments
+  [] > foo
+    second > @


### PR DESCRIPTION
Fix `unused-alias` lint to correctly detect unused aliases with overlapping target prefixes by updating the matching logic to distinguish between exact matches and attribute access patterns.

Fixes #1055