### PR TITLE
ci(#1203): replace macos-15 with macos-15-intel runner

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2022, macos-15]
+        os: [ubuntu-24.04, windows-2022, macos-15-intel]
         java: [23]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Swap `macos-15` for `macos-15-intel` in the CI workflow matrix to reduce runner queue times and improve CI feedback speed on pull requests.

Fixes #1203