### PR TITLE
feat: add excessive-visibility lint

### DIFF
--- a/src/main/resources/org/eolang/lints/design/excessive-visibility.xsl
+++ b/src/main/resources/org/eolang/lints/design/excessive-visibility.xsl
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="excessive-visibility">
+  <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/special-name.xsl"/>
+  <xsl:import href="/org/eolang/funcs/test-name.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[eo:abstract(.) and @name]/o[@name and @base and @base != '∅' and @name != 'φ' and not(eo:special(@name)) and not(eo:test-name(@name))]">
+        <xsl:variable name="method" select="@name"/>
+        <xsl:variable name="tests" select="../descendant::o[eo:test-name(@name)]"/>
+        <xsl:variable name="references" select="$tests//o[@name = $method or contains(concat('.', @base, '.'), concat('.', $method, '.'))]"/>
+        <xsl:if test="exists($tests) and empty($references)">
+          <defect>
+            <xsl:variable name="line" select="eo:lineno(@line)"/>
+            <xsl:attribute name="line">
+              <xsl:value-of select="$line"/>
+            </xsl:attribute>
+            <xsl:if test="$line = '0'">
+              <xsl:attribute name="context">
+                <xsl:value-of select="eo:defect-context(.)"/>
+              </xsl:attribute>
+            </xsl:if>
+            <xsl:attribute name="severity">warning</xsl:attribute>
+            <xsl:attribute name="experimental">true</xsl:attribute>
+            <xsl:text>The method </xsl:text>
+            <xsl:value-of select="eo:escape(@name)"/>
+            <xsl:text> is public but is not used by any unit test; obfuscate it with &gt;&gt;</xsl:text>
+          </defect>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/design/excessive-visibility.md
+++ b/src/main/resources/org/eolang/motives/design/excessive-visibility.md
@@ -1,0 +1,18 @@
+# Excessive visibility
+
+Public methods should be exercised by a unit test. If a method is only an
+implementation detail and no test refers to it, make it private with the
+`>>` decoration instead of exposing it as part of the object's public API.
+
+Incorrect:
+
+```eo
+[text] > phrase
+  text.index-of " " > position
+
+  [] +> checks-phrase
+    phrase "Object Thinking" > @
+```
+
+`position` is public but the test never refers to it. It should be written as
+`text.index-of " " >> position`.

--- a/src/test/resources/org/eolang/lints/packs/single/excessive-visibility/allows-public-method-used-by-test.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/excessive-visibility/allows-public-method-used-by-test.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/excessive-visibility.xsl
+defects: 0
+input: |
+  # Phrase.
+  [text] > phrase
+    text.index-of " " > position
+    [] +> checks-phrase
+      position > @

--- a/src/test/resources/org/eolang/lints/packs/single/excessive-visibility/catches-public-method-not-used-by-test.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/excessive-visibility/catches-public-method-not-used-by-test.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/excessive-visibility.xsl
+asserts:
+  - /defects[count(defect[@severity='warning' and @experimental])=1]
+  - /defects/defect[@line='3']
+  - /defects/defect[contains(text(), 'position')]
+input: |
+  # Phrase.
+  [text] > phrase
+    text.index-of " " > position
+    [] +> checks-phrase
+      phrase "Object Thinking" > @


### PR DESCRIPTION
Fixes #1207\n\n## Summary\n- add an experimental excessive-visibility design lint\n- flag public named methods that have no matching unit-test reference\n- include the requested warning motive and positive/negative YAML fixtures\n\n## Validation\n- xmllint --noout on the new XSL\n- Java/Maven validation was not available in the local environment; the repository CI can run the native lint fixture suite