### PR TITLE
style(#1220): fix Javadoc formatting for qulice v0.30.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.30.1</version>
+            <version>0.30.6</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>pmd:/src/it/.*</exclude>

--- a/src/main/java/org/eolang/lints/Defect.java
+++ b/src/main/java/org/eolang/lints/Defect.java
@@ -9,13 +9,13 @@ import java.util.Objects;
 
 /**
  * A single defect found.
- * <p>
- * Defect is a node in the XMIR under `/program/defects`, that describes the
+ *
+ * <p>Defect is a node in the XMIR under `/program/defects`, that describes the
  * issue with EO/XMIR source code. Defect contains the message that addresses
  * source code and points to the problem in it. Some defects report the problems
  * on XMIR format itself, consider checking resources on XMIR in order to get
- * understanding how intermediate representation of EO is structured in XML format.
- * </p>
+ * understanding how intermediate representation of EO is structured in XML format.</p>
+ *
  * @see <a href="https://news.eolang.org/2022-11-25-xmir-guide.html">XMIR guide</a>
  * @see <a href="https://www.eolang.org/XMIR.html">XMIR specification</a>
  * @see <a href="https://www.eolang.org/XMIR.xsd">XMIR schema</a>
@@ -25,55 +25,55 @@ public interface Defect {
 
     /**
      * Rule name.
-     * <p>
-     * Returns the unique identifier of the rule that detected this defect.
-     * </p>
+     *
+     * <p>Returns the unique identifier of the rule that detected this defect.</p>
+     *
      * @return Unique name of the rule
      */
     String rule();
 
     /**
      * Severity level.
-     * <p>
-     * Returns the severity level of this defect.
-     * </p>
+     *
+     * <p>Returns the severity level of this defect.</p>
+     *
      * @return Severity of the defect
      */
     Severity severity();
 
     /**
      * Line where the defect was found.
-     * <p>
-     * Returns the line number in the source code where the defect was detected.
-     * </p>
+     *
+     * <p>Returns the line number in the source code where the defect was detected.</p>
+     *
      * @return Line number in the source code
      */
     int line();
 
     /**
      * Error message.
-     * <p>
-     * Returns the descriptive message explaining the defect.
-     * </p>
+     *
+     * <p>Returns the descriptive message explaining the defect.</p>
+     *
      * @return Text of the error message
      */
     String text();
 
     /**
      * The linter's current version.
-     * <p>
-     * Returns the version of the linting tool that detected this defect.
-     * </p>
+     *
+     * <p>Returns the version of the linting tool that detected this defect.</p>
+     *
      * @return Linter's current version string
      */
     String version();
 
     /**
      * Defect context.
-     * <p>
-     * Returns additional contextual information about the defect,
-     * which may help understand and fix the issue.
-     * </p>
+     *
+     * <p>Returns additional contextual information about the defect,
+     * which may help understand and fix the issue.</p>
+     *
      * @return Context of the defect as a string
      */
     String context();
@@ -86,9 +86,9 @@ public interface Defect {
 
     /**
      * Default implementation of {@link Defect}.
-     * <p>
-     * Provides a standard implementation with basic functionality.
-     * </p>
+     *
+     * <p>Provides a standard implementation with basic functionality.</p>
+     *
      * @since 0.0.1
      */
     final class Default implements Defect {
@@ -134,9 +134,9 @@ public interface Defect {
 
         /**
          * Ctor.
-         * <p>
-         * Constructs a defect with all required information.
-         * </p>
+         *
+         * <p>Constructs a defect with all required information.</p>
+         *
          * @param rule Rule name
          * @param severity Severity level
          * @param line Line number


### PR DESCRIPTION
Upgrade `qulice-maven-plugin` to v0.30.6 and fix Javadoc formatting to comply with stricter linting rules in the new plugin version.

Fixes #1220