### PR TITLE
test(#1219): remove comments from test fixtures

### DIFF
--- a/src/test/resources/org/eolang/lints/packs/single/package-member-without-void/allows-nested-void-less-formation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/package-member-without-void/allows-nested-void-less-formation.yaml
@@ -7,7 +7,5 @@ defects: 0
 input: |
   +package foo
 
-  # Bar.
   [x] > bar
-    # Baz.
     [] > baz

--- a/src/test/resources/org/eolang/lints/packs/single/package-member-without-void/allows-package-member-with-void.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/package-member-without-void/allows-package-member-with-void.yaml
@@ -7,5 +7,4 @@ defects: 0
 input: |
   +package foo
 
-  # Bar.
   [x] > bar

--- a/src/test/resources/org/eolang/lints/packs/single/package-member-without-void/allows-void-less-formation-without-package.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/package-member-without-void/allows-void-less-formation-without-package.yaml
@@ -5,5 +5,4 @@ sheets:
   - /org/eolang/lints/design/package-member-without-void.xsl
 defects: 0
 input: |
-  # Stdin.
   [] > stdin

--- a/src/test/resources/org/eolang/lints/packs/single/package-member-without-void/catches-atom-package-member-without-void.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/package-member-without-void/catches-atom-package-member-without-void.yaml
@@ -5,9 +5,8 @@ sheets:
   - /org/eolang/lints/design/package-member-without-void.xsl
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
-  - /defects/defect[@line='4']
+  - /defects/defect[@line='3']
 input: |
   +package foo
 
-  # Bar.
   [] > bar /number

--- a/src/test/resources/org/eolang/lints/packs/single/package-member-without-void/catches-only-top-level-member.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/package-member-without-void/catches-only-top-level-member.yaml
@@ -5,11 +5,9 @@ sheets:
   - /org/eolang/lints/design/package-member-without-void.xsl
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
-  - /defects/defect[@line='4']
+  - /defects/defect[@line='3']
 input: |
   +package foo
 
-  # Bar.
   [] > bar
-    # Baz.
     [] > baz

--- a/src/test/resources/org/eolang/lints/packs/single/package-member-without-void/catches-package-member-without-void.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/package-member-without-void/catches-package-member-without-void.yaml
@@ -5,9 +5,8 @@ sheets:
   - /org/eolang/lints/design/package-member-without-void.xsl
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
-  - /defects/defect[@line='4']
+  - /defects/defect[@line='3']
 input: |
   +package foo
 
-  # Bar.
   [] > bar


### PR DESCRIPTION
Remove comments from test YAML fixtures in `package-member-without-void` test resources to align with linting standards.

Fixes #1219