### PR TITLE
fix(#1216): escape unlint tails in XPath

### DIFF
--- a/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
+++ b/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
@@ -55,26 +55,28 @@ final class LtUnlintNonExistingDefect implements Lint {
 
     @Override
     public Collection<Defect> defects(final XML xmir) throws IOException {
-        return new Xnav(xmir.inner()).path("/object/metas/meta[head='unlint']/tail")
-            .map(xnav -> xnav.text().get())
-            .distinct()
-            .filter(new DefectMissing(this.existingDefects(xmir), this.excluded)::apply).flatMap(
-                unlint -> new Xnav(xmir.inner()).path(
+        final List<Xnav> unlints = new Xnav(xmir.inner())
+            .path("/object/metas/meta[head='unlint']")
+            .collect(Collectors.toList());
+        return unlints.stream().map(
+            meta -> meta.element("tail").text().orElse("unknown")
+        ).distinct().filter(
+            new DefectMissing(this.existingDefects(xmir), this.excluded)::apply
+        ).flatMap(
+            tail -> unlints.stream().filter(
+                meta -> tail.equals(meta.element("tail").text().orElse("unknown"))
+            ).map(
+                meta -> new Defect.Default(
+                    this.name(),
+                    Severity.WARNING,
+                    Integer.parseInt(meta.attribute("line").text().orElse("0")),
                     String.format(
-                        "object/metas/meta[head='unlint' and tail='%s']/@line", unlint
-                    )
-                ).map(
-                    xnav -> new Defect.Default(
-                        this.name(),
-                        Severity.WARNING,
-                        Integer.parseInt(xnav.text().get()),
-                        String.format(
-                            "Unlinting rule '%s' doesn't make sense, since there are no defects with it",
-                            unlint
-                        )
+                        "Unlinting rule '%s' doesn't make sense, since there are no defects with it",
+                        tail
                     )
                 )
-            ).collect(Collectors.toList());
+            )
+        ).collect(Collectors.toList());
     }
 
     @Override

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -171,4 +171,20 @@ final class LtUnlintNonExistingDefectTest {
             Matchers.iterableWithSize(1)
         );
     }
+
+    @Test
+    void catchesUnlintWithApostrophe() throws IOException {
+        MatcherAssert.assertThat(
+            "An unlint with an apostrophe should be reported, not crash",
+            new LtUnlintNonExistingDefect(
+                new ListOf<>(new LtAsciiOnly()),
+                new ListOf<>()
+            ).defects(
+                new EoProgram(
+                    "org/eolang/lints/unlint-ascii-only-apostrophe.eo"
+                ).parse()
+            ),
+            Matchers.iterableWithSize(1)
+        );
+    }
 }

--- a/src/test/resources/org/eolang/lints/unlint-ascii-only-apostrophe.eo
+++ b/src/test/resources/org/eolang/lints/unlint-ascii-only-apostrophe.eo
@@ -1,0 +1,7 @@
+# We are here.
+
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint don't-lint-me
+
+[] > boom


### PR DESCRIPTION
Fixes #1216.

## Problem

`LtUnlintNonExistingDefect.defects()` builds an XPath expression by pasting the raw `+unlint` tail into a single-quoted string literal:

```java
new Xnav(xmir.inner()).path(String.format("object/metas/meta[head='unlint' and tail='%s']/@line", unlint))
```

The EO parser copies any text after `+unlint` into `<tail>` verbatim, so an apostrophe in the tail closes the string literal early and the resulting XPath is broken. `Xnav` throws `IllegalStateException`, which propagates out of `Source.defects()` and silently loses every other defect in the file. The same input is exactly what `incorrect-unlint` exists to report.

## Solution

Stop interpolating the dynamic tail into an XPath string at all. The `unlint` metas are selected once with a fixed path (`/object/metas/meta[head='unlint']`) and filtered in Java streams, preserving the previous semantics: `distinct()` over tails, a defect per matching meta line.

## Changes

- `src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java` — build no dynamic XPath; read `tail`/`line` via `element()`/`attribute()`.
- `src/test/resources/org/eolang/lints/unlint-ascii-only-apostrophe.eo` — new fixture with `+unlint don't-lint-me`.
- `src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java` — new test `catchesUnlintWithApostrophe`.

## Tests

- `LtUnlintNonExistingDefectTest` — 11 tests green (incl. new apostrophe case).
- Regression: `LtUnlintTest`, `LtIncorrectUnlintTest`, `SourceTest`, `PkMonoTest`, `MonoLintsTest` — 48 tests green.