### PR TITLE
fix(#950): keep line-zero defects with line-specific unlint

### DIFF
--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -74,7 +74,7 @@ final class LtUnlint implements Lint {
         problematic.forEach(
             line -> found.forEach(
                 defect -> {
-                    if (line != 0 && defect.line() == line) {
+                    if (defect.line() == line) {
                         defects.add(defect);
                         added.set(true);
                     }

--- a/src/test/java/org/eolang/lints/LtUnlintTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintTest.java
@@ -151,4 +151,17 @@ final class LtUnlintTest {
             Matchers.iterableWithSize(1)
         );
     }
+
+    @Test
+    void keepsLineZeroDefectWithLineSpecificUnlint() throws IOException {
+        MatcherAssert.assertThat(
+            "A line-0 defect must not be silently dropped by a line-specific unlint",
+            new LtUnlint(new LtByXsl("metas/mandatory-package")).defects(
+                new EoProgram(
+                    "org/eolang/lints/unlint-mandatory-package-line.eo"
+                ).parse()
+            ),
+            Matchers.iterableWithSize(1)
+        );
+    }
 }

--- a/src/test/resources/org/eolang/lints/unlint-mandatory-package-line.eo
+++ b/src/test/resources/org/eolang/lints/unlint-mandatory-package-line.eo
@@ -1,0 +1,11 @@
+# Missing package, but it should be reported anyway.
+
++architect yegor256@gmail.com
++home https://www.eolang.org
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package:5
+
+# Boo.
+[] > foo


### PR DESCRIPTION
Fixes #950.

## Problem

In `LtUnlint.defects()` the loop that re-adds non-suppressed defects uses the guard `line != 0 && defect.line() == line`. When a lint produces a defect at line 0 (e.g. `mandatory-package` reports at line 0 when the whole `+package` meta is absent) and the EO program also contains a line-specific `+unlint mandatory-package:5`, the defect at line 0 is silently discarded: `global` is set, line 0 stays in `problematic` but is skipped by `line != 0`, and the fallback `if (!added.get() && !global)` is also skipped because `global` is true.

## Solution

Drop the `line != 0` guard in the re-add loop and compare `defect.line() == line` only. Line 0 is an intentional production case (`lineno.xsl` and `empty-object.xsl` handle it explicitly) and is only meant to be suppressed by a global `+unlint lint-name`, never by a line-specific `+unlint lint-name:N`.

## Changes

- `src/main/java/org/eolang/lints/LtUnlint.java` — re-add defects on line 0 when their line stays problematic.
- `src/test/resources/org/eolang/lints/unlint-mandatory-package-line.eo` — new fixture: no `+package`, `+unlint mandatory-package:5`.
- `src/test/java/org/eolang/lints/LtUnlintTest.java` — new test `keepsLineZeroDefectWithLineSpecificUnlint` (failed before the fix).

## Tests

- `LtUnlintTest` — 12 tests green (incl. new one).
- Regression `LtByXslTest`, `SourceTest`, `PkMonoTest`, `MonoLintsTest`, `LtUnlintNonExistingDefectTest` — 443 tests green after `mvn clean`.
- `mvn -Pqulice install` — clean.