### PR TITLE
fix(#297): make vocabulary thread-safe and return test-not-verb

### DIFF
--- a/src/main/java/org/eolang/lints/MonoLints.java
+++ b/src/main/java/org/eolang/lints/MonoLints.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.lints;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.cactoos.iterable.IterableEnvelope;
@@ -24,10 +25,7 @@ final class MonoLints extends IterableEnvelope<Lint> {
     private static final Iterable<Lint> LINTS = new Shuffled<>(
         new Joined<Lint>(
             new PkByXsl(),
-            List.of(
-                new LtAsciiOnly(),
-                new LtReservedName()
-            )
+            MonoLints.mono()
         )
     );
 
@@ -58,5 +56,21 @@ final class MonoLints extends IterableEnvelope<Lint> {
                 )
             )
         );
+    }
+
+    /**
+     * Java-based lints.
+     * @return Java-based lints
+     */
+    private static List<Lint> mono() {
+        try {
+            return List.of(
+                new LtAsciiOnly(),
+                new LtReservedName(),
+                new LtTestNotVerb()
+            );
+        } catch (final IOException ex) {
+            throw new IllegalArgumentException(ex);
+        }
     }
 }

--- a/src/main/java/org/eolang/lints/PkMono.java
+++ b/src/main/java/org/eolang/lints/PkMono.java
@@ -18,11 +18,6 @@ import org.cactoos.list.ListOf;
  * <p>This class is thread-safe.</p>
  *
  * @since 0.23
- * @todo #297:35min Return `LtTestNotVerb` back.
- *  For some reason this lint produces errors in EO-to-Java Compiler. Check
- *  <a href="https://github.com/objectionary/lints/issues/297#issuecomment-2636540673">this</a>
- *  issue for more details. We should return it in the fixed state, once we understand
- *  the root cause of the problem.
  */
 @ThreadSafe
 final class PkMono extends IterableEnvelope<Lint> {

--- a/src/main/java/org/eolang/lints/Vocabulary.java
+++ b/src/main/java/org/eolang/lints/Vocabulary.java
@@ -30,9 +30,9 @@ final class Vocabulary {
     private static final Pattern KEBAB = Pattern.compile("-");
 
     /**
-     * Part-Of-Speech tagger.
+     * Part-Of-Speech taggers, one per thread.
      */
-    private final POSTaggerME tagger;
+    private final ThreadLocal<POSTaggerME> taggers;
 
     /**
      * Ctor.
@@ -53,15 +53,12 @@ final class Vocabulary {
      * @param mdl Part-Of-Speech model
      */
     Vocabulary(final POSModel mdl) {
-        this(new POSTaggerME(mdl));
-    }
-
-    /**
-     * Ctor.
-     * @param pos Part-Of-Speech tagger
-     */
-    Vocabulary(final POSTaggerME pos) {
-        this.tagger = pos;
+        this.taggers = new ThreadLocal<>() {
+            @Override
+            protected POSTaggerME initialValue() {
+                return new POSTaggerME(mdl);
+            }
+        };
     }
 
     /**
@@ -75,7 +72,7 @@ final class Vocabulary {
      */
     boolean isVerb(final String name) {
         return "VBZ".equals(
-            this.tagger.tag(
+            this.taggers.get().tag(
                 Stream.concat(
                     Stream.of("It"),
                     Arrays.stream(Vocabulary.KEBAB.split(name))


### PR DESCRIPTION
fix #297

**Context.** The `unit-test-is-not-verb` lint was disabled in #297 because it occasionally produced `NullPointerException` when the EO-to-Java Compiler ran lints in parallel. The maintainers agreed to re-enable it once a thread-safety fix lands (see the `@todo #297` puzzle left in `PkMono`).

**Root cause:** OpenNLP's `POSTaggerME` is not thread-safe: a single shared instance mutates internal state (`bestSequence`) on every `tag()` call. `Vocabulary` kept one such instance and was invoked from multiple threads building `eo-runtime` with lints.

**Fix:**
- `Vocabulary` now holds a shared `POSModel` (immutable, safe to reuse) and creates one `POSTaggerME` **per thread** via `ThreadLocal`, so concurrent calls never share mutable tagger state.
- Re-enabled `LtTestNotVerb` (the `unit-test-is-not-verb` lint) in `MonoLints`, so it is back among the active default lints.
- Removed the resolved `@todo #297` from `PkMono`.

**Tests:** `mvn clean install -Pqulice` — 578 tests, all green, including the existing concurrent `VocabularyTest`, `LtTestNotVerbTest`, and `lintsInMultipleThreads`.