### PR TITLE
fix(#1217): check throwing tests in bad-test-name

### DIFF
--- a/src/main/resources/org/eolang/lints/tests/bad-test-name.xsl
+++ b/src/main/resources/org/eolang/lints/tests/bad-test-name.xsl
@@ -7,13 +7,14 @@
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/test-name.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="/object//o[starts-with(@name, '+')]">
+      <xsl:for-each select="/object//o[eo:test-name(@name)]">
         <xsl:variable name="regexp" select="'^(can|cannot|accepts|rejects|stops-on)-'"/>
-        <xsl:if test="not(matches(eo:escape-plus(@name), $regexp))">
+        <xsl:if test="not(matches(substring(@name, 2), $regexp))">
           <defect>
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/lints/tests/bad-test-name.xsl
+++ b/src/main/resources/org/eolang/lints/tests/bad-test-name.xsl
@@ -14,7 +14,8 @@
     <defects>
       <xsl:for-each select="/object//o[eo:test-name(@name)]">
         <xsl:variable name="regexp" select="'^(can|cannot|accepts|rejects|stops-on)-'"/>
-        <xsl:if test="not(matches(substring(@name, 2), $regexp))">
+        <xsl:variable name="bare" select="replace(@name, '^[+-]', '')"/>
+        <xsl:if test="not(matches($bare, $regexp))">
           <defect>
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name/allows-throwing-prefix.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name/allows-throwing-prefix.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/bad-test-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [] > foo
+    [] > bar
+
+    [] -> stops-on-error

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-throwing-bad-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-throwing-bad-name.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/bad-test-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+input: |
+  [] > foo
+    [] > bar
+
+    [] -> it-works


### PR DESCRIPTION
Fixes #1217.

## Problem

`bad-test-name.xsl` selects test objects with an ad-hoc `starts-with(@name, '+')` instead of the shared `eo:test-name()` function. The EO parser marks a truthy test with a `+` prefix and a throwing test with a `-` prefix; the shared function (see `org/eolang/funcs/test-name.xsl`) treats both kinds as tests. As a result a throwing test like `[] -> it-works` never reached the regexp and any name it carried was accepted, even though the motive says the rule applies to every unit test object.

## Solution

Use `eo:test-name(@name)` in the `for-each` predicate and strip the single-char prefix with `substring(@name, 2)` before applying the regexp (same pattern as the sibling `misc/incorrect-test-object-name.xsl`).

## Changes

- `src/main/resources/org/eolang/lints/tests/bad-test-name.xsl` — import `funcs/test-name.xsl`, select via `eo:test-name(@name)`, match `substring(@name, 2)`.
- `src/test/resources/org/eolang/lints/packs/single/bad-test-name/allows-throwing-prefix.yaml` — new pack: `[] -> stops-on-error` produces no defects.
- `src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-throwing-bad-name.yaml` — new pack: `[] -> it-works` produces one defect.

## Tests

- `LtByXslTest` — 402 tests green (was 1 failure for the new throwing pack before the fix).
- `mvn -Pqulice install` — clean.