### PR TITLE
fix(#364): run only referenced lints in unlint-non-existing-defect

### DIFF
--- a/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
+++ b/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
@@ -7,9 +7,11 @@ package org.eolang.lints;
 import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.cactoos.list.ListOf;
@@ -55,10 +57,18 @@ final class LtUnlintNonExistingDefect implements Lint {
 
     @Override
     public Collection<Defect> defects(final XML xmir) throws IOException {
-        return new Xnav(xmir.inner()).path("/object/metas/meta[head='unlint']/tail")
+        final List<String> unlints = new Xnav(xmir.inner())
+            .path("/object/metas/meta[head='unlint']/tail")
             .map(xnav -> xnav.text().get())
             .distinct()
-            .filter(new DefectMissing(this.existingDefects(xmir), this.excluded)::apply).flatMap(
+            .collect(Collectors.toList());
+        final Collection<Defect> messages;
+        if (unlints.isEmpty()) {
+            messages = new ArrayList<>(0);
+        } else {
+            messages = unlints.stream().filter(
+                new DefectMissing(this.existing(unlints, xmir), this.excluded)::apply
+            ).flatMap(
                 unlint -> new Xnav(xmir.inner()).path(
                     String.format(
                         "object/metas/meta[head='unlint' and tail=%s]/@line",
@@ -76,6 +86,8 @@ final class LtUnlintNonExistingDefect implements Lint {
                     )
                 )
             ).collect(Collectors.toList());
+        }
+        return messages;
     }
 
     @Override
@@ -105,20 +117,31 @@ final class LtUnlintNonExistingDefect implements Lint {
         return result;
     }
 
-    private Map<String, List<Integer>> existingDefects(final XML xmir) {
-        return StreamSupport.stream(this.lints.spliterator(), false).flatMap(
-            lint -> {
-                try {
-                    return lint.defects(xmir).stream();
-                } catch (final IOException exception) {
-                    throw new IllegalStateException(exception);
+    /**
+     * Build a map of existing defects, checking only lints referenced by
+     * <code>+unlint</code> metas.
+     * @param unlints Tails of all <code>+unlint</code> metas in the document
+     * @param xmir The XMIR document
+     * @return Existing defects grouped by rule and line
+     */
+    private Map<String, List<Integer>> existing(final List<String> unlints, final XML xmir) {
+        final Set<String> names = unlints.stream()
+            .map(unlint -> unlint.split(":", -1)[0])
+            .collect(Collectors.toSet());
+        return StreamSupport.stream(this.lints.spliterator(), false)
+            .filter(lint -> names.contains(lint.name())).flatMap(
+                lint -> {
+                    try {
+                        return lint.defects(xmir).stream();
+                    } catch (final IOException exception) {
+                        throw new IllegalStateException(exception);
+                    }
                 }
-            }
-        ).collect(
-            Collectors.groupingBy(
-                Defect::rule,
-                Collectors.mapping(Defect::line, Collectors.toList())
-            )
-        );
+            ).collect(
+                Collectors.groupingBy(
+                    Defect::rule,
+                    Collectors.mapping(Defect::line, Collectors.toList())
+                )
+            );
     }
 }

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -4,8 +4,10 @@
  */
 package org.eolang.lints;
 
+import com.jcabi.xml.XML;
 import fixtures.EoProgram;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.stream.Collectors;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
@@ -186,5 +188,63 @@ final class LtUnlintNonExistingDefectTest {
             ),
             Matchers.iterableWithSize(1)
         );
+    }
+
+    @Test
+    void doesNotRunLintsWithoutUnlints() throws IOException {
+        MatcherAssert.assertThat(
+            "Lints should not be executed when there are no +unlint metas",
+            new LtUnlintNonExistingDefect(
+                new ListOf<>(new LtUnlintNonExistingDefectTest.Boom()),
+                new ListOf<>()
+            ).defects(
+                new EoProgram("org/eolang/lints/non-ascii-bar.eo").parse()
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void doesNotInvokeUnreferencedLint() throws IOException {
+        MatcherAssert.assertThat(
+            "Only the referenced lint should be executed",
+            new LtUnlintNonExistingDefect(
+                new ListOf<>(
+                    new LtAsciiOnly(),
+                    new LtUnlintNonExistingDefectTest.Boom()
+                ),
+                new ListOf<>()
+            ).defects(
+                new EoProgram("org/eolang/lints/unlint-ascii-only-no-defect.eo").parse()
+            ),
+            Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
+
+    /**
+     * Fake lint that explodes when invoked.
+     * @since 0.0.40
+     */
+    private static final class Boom implements Lint {
+
+        @Override
+        public String name() {
+            return "boom";
+        }
+
+        @Override
+        public Collection<Defect> defects(final XML xmir) {
+            throw new IllegalStateException("this lint must not be executed");
+        }
+
+        @Override
+        public String motive() {
+            return "";
+        }
+
+        @Override
+        public Fix fix() {
+            return new FxEmpty();
+        }
     }
 }


### PR DESCRIPTION
Fixes #364

**Problem:** The `unlint-non-existing-defect` lint is the slowest one, by an order of magnitude, according to the [benchmark](https://github.com/objectionary/lints?tab=readme-ov-file#benchmark). The reason: for every document it ran `defects()` on **all** lints, even when the document had no `+unlint` metas at all.

**Solution:** The lint now collects the `+unlint` tails first and, if the document has none, returns an empty result without touching any lint. Otherwise, only the lints whose names are referenced by the `+unlint` metas are executed, instead of the full set.

**Changes:**
- `src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java`: rewritten `defects()` to short-circuit on documents without `+unlint`; `existing()` filters `lints` by the referenced names before calling `defects()`.
- `src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java`: two new tests asserting that no lint runs when there are no `+unlint` metas and that unreferenced lints are not invoked (a lint that explodes when called would fail the test).

**Tests:** `mvn clean install -Pqulice` — 580 tests, all green.