### PR TITLE
feat(#566): add invalid-name-notation lint

### DIFF
--- a/src/main/resources/org/eolang/funcs/special-name.xsl
+++ b/src/main/resources/org/eolang/funcs/special-name.xsl
@@ -7,6 +7,6 @@
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:function name="eo:special" as="xs:boolean">
     <xsl:param name="name"/>
-    <xsl:sequence select="$name = '&#x3C6;' or $name = $eo:lambda or contains($name, $eo:cactoos)"/>
+    <xsl:sequence select="$name = '&#x3C6;' or $name = $eo:lambda or $name = $eo:xi or contains($name, $eo:cactoos)"/>
   </xsl:function>
 </xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/names/invalid-name-notation.xsl
+++ b/src/main/resources/org/eolang/lints/names/invalid-name-notation.xsl
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="invalid-name-notation" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:import href="/org/eolang/funcs/special-name.xsl"/>
+  <xsl:import href="/org/eolang/funcs/test-name.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[@name and not(eo:special(@name)) and not(eo:test-name(@name)) and not(matches(@name, '^[a-z]+(-[a-z]+)*$'))]">
+        <defect>
+          <xsl:variable name="line" select="eo:lineno(@line)"/>
+          <xsl:attribute name="line">
+            <xsl:value-of select="$line"/>
+          </xsl:attribute>
+          <xsl:if test="$line = '0'">
+            <xsl:attribute name="context">
+              <xsl:value-of select="eo:defect-context(.)"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:attribute name="severity">warning</xsl:attribute>
+          <xsl:text>Object name </xsl:text>
+          <xsl:value-of select="eo:escape(@name)"/>
+          <xsl:text> must match the regular expression [a-z]+(-[a-z]+)*</xsl:text>
+        </defect>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/names/invalid-name-notation.md
+++ b/src/main/resources/org/eolang/motives/names/invalid-name-notation.md
@@ -1,0 +1,23 @@
+# Invalid name notation
+
+The name of any object must match the regular expression `[a-z]+(-[a-z]+)*`.
+Basically, it must follow kebab-case notation, using only Latin letters.
+No digits, no underscores, no uppercase characters.
+
+Incorrect:
+
+```eo
+# App.
+[] > mainApp
+  foo > x1
+  bar > y_
+```
+
+Correct:
+
+```eo
+# App.
+[] > main-app
+  foo > x
+  bar > y
+```

--- a/src/test/resources/org/eolang/lints/canonical.eo
+++ b/src/test/resources/org/eolang/lints/canonical.eo
@@ -16,7 +16,7 @@
         *
           x.put 2
           while
-            x.as-number.lt 6 > [i1] >>
+            x.as-number.lt 6 > [i] >>
             [i] >>
               seq > @
                 *

--- a/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/allows-good-names.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/allows-good-names.yaml
@@ -5,11 +5,7 @@ sheets:
   - /org/eolang/lints/names/invalid-name-notation.xsl
 asserts:
   - /defects[count(defect[@severity='warning'])=0]
-ignore-schema: true
-document: |
-  <object author="tests">
-    <o line="1" name="main-app" pos="0">
-      <o base="Q.foo" line="2" name="x" pos="2"/>
-      <o base="Q.bar" line="3" name="y" pos="2"/>
-    </o>
-  </object>
+input: |
+  [] > main-app
+    x > x
+    y > y

--- a/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/allows-good-names.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/allows-good-names.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/invalid-name-notation.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="1" name="main-app" pos="0">
+      <o base="Q.foo" line="2" name="x" pos="2"/>
+      <o base="Q.bar" line="3" name="y" pos="2"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/allows-special-names.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/allows-special-names.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/invalid-name-notation.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="1" name="app" pos="0">
+      <o base="Q.x" line="2" name="f" pos="2">
+        <o line="3" name="a🌵3-5" pos="4"/>
+        <o line="4" name="φ" pos="4">
+          <o base="Q.q" line="5" name="ξ" pos="6"/>
+        </o>
+      </o>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/allows-throwing-test-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/allows-throwing-test-name.yaml
@@ -1,15 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
-# yamllint disable rule:line-length
 ---
 sheets:
   - /org/eolang/lints/names/invalid-name-notation.xsl
 asserts:
   - /defects[count(defect[@severity='warning'])=0]
-ignore-schema: true
-document: |
-  <object author="tests">
-    <o line="1" name="foo" pos="0">
-      <o base="Q.number" line="2" name="-on-bytes-of-wrong-size-as-i16" pos="2"/>
-    </o>
-  </object>
+input: |
+  [] > foo
+    [] > -rejects-wrong-size-as-i16
+      TRUE > @

--- a/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/allows-throwing-test-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/allows-throwing-test-name.yaml
@@ -7,5 +7,6 @@ asserts:
   - /defects[count(defect[@severity='warning'])=0]
 input: |
   [] > foo
-    [] > -rejects-wrong-size-as-i16
-      TRUE > @
+
+    [] -> rejects-wrong-size-as-i16
+      42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/allows-throwing-test-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/allows-throwing-test-name.yaml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
+# yamllint disable rule:line-length
 ---
 sheets:
   - /org/eolang/lints/names/invalid-name-notation.xsl

--- a/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/allows-throwing-test-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/allows-throwing-test-name.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/invalid-name-notation.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="1" name="foo" pos="0">
+      <o base="Q.number" line="2" name="-on-bytes-of-wrong-size-as-i16" pos="2"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/catches-invalid-names.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/catches-invalid-names.yaml
@@ -8,12 +8,8 @@ asserts:
   - /defects/defect[@line='2']
   - /defects/defect[@line='3']
   - /defects/defect[@line='4']
-ignore-schema: true
-document: |
-  <object author="tests">
-    <o line="1" name="main" pos="0">
-      <o base="Q.foo" line="2" name="x1" pos="2"/>
-      <o base="Q.foo" line="3" name="xApp" pos="2"/>
-      <o base="Q.foo" line="4" name="x_snake" pos="2"/>
-    </o>
-  </object>
+input: |
+  [] > main
+    x1 > x1
+    xApp > xApp
+    x_snake > x_snake

--- a/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/catches-invalid-names.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/catches-invalid-names.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/invalid-name-notation.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=3]
+  - /defects/defect[@line='2']
+  - /defects/defect[@line='3']
+  - /defects/defect[@line='4']
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="1" name="main" pos="0">
+      <o base="Q.foo" line="2" name="x1" pos="2"/>
+      <o base="Q.foo" line="3" name="xApp" pos="2"/>
+      <o base="Q.foo" line="4" name="x_snake" pos="2"/>
+    </o>
+  </object>


### PR DESCRIPTION
fix #566

New lint `invalid-name-notation` checks that every `@name` in the XMIR matches `[a-z]+(-[a-z]+)*` — kebab-case, Latin letters only, no digits/underscores/uppercase, as requested in #566.

- `src/main/resources/org/eolang/lints/names/invalid-name-notation.xsl` — the lint (warning severity, same `defect` shape as `non-kebab-name`).
- `src/main/resources/org/eolang/motives/names/invalid-name-notation.md` — motive.
- `eo:special` now also recognizes `ξ` (xi), an internal parser symbol alongside `φ`/`λ`; otherwise parser-generated `<o name="ξ"/>` inside atoms would be flagged.
- 4 YAML packs: allows-good-names, allows-special-names (incl. `φ`, `λ`, `a🌵N-N` auto-names and test names), allows-throwing-test-name, catches-invalid-names.
- `canonical.eo`: renamed the `[i1]` lambda parameter to `[i]` in `canonical.eo` — digits are now forbidden by design (confirmed by @yegor256 in #566).

Verified: `mvn clean install -Pqulice` green (404 LtByXslTest + all suites), `mvn jmh:benchmark` passed.