### PR TITLE
feat(#553): add test-word lint

### DIFF
--- a/src/main/resources/org/eolang/lints/tests/test-word.xsl
+++ b/src/main/resources/org/eolang/lints/tests/test-word.xsl
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="test-word" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/test-name.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:variable name="top" select="/object/o[1]"/>
+      <xsl:for-each select="//o[@name and not(@name='φ') and matches(@name, 'test', 'i') and not(generate-id() = generate-id($top))]">
+        <xsl:if test="eo:test-name(@name) or ancestor::o[eo:test-name(@name)] or matches($top/@name, '-tests$')">
+          <xsl:element name="defect">
+            <xsl:variable name="line" select="eo:lineno(@line)"/>
+            <xsl:attribute name="line">
+              <xsl:value-of select="$line"/>
+            </xsl:attribute>
+            <xsl:if test="$line = '0'">
+              <xsl:attribute name="context">
+                <xsl:value-of select="eo:defect-context(.)"/>
+              </xsl:attribute>
+            </xsl:if>
+            <xsl:attribute name="severity">
+              <xsl:text>warning</xsl:text>
+            </xsl:attribute>
+            <xsl:text>The name of the object </xsl:text>
+            <xsl:value-of select="eo:escape(@name)"/>
+            <xsl:text> must not contain the word 'test'</xsl:text>
+          </xsl:element>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/tests/test-word.md
+++ b/src/main/resources/org/eolang/motives/tests/test-word.md
@@ -1,0 +1,26 @@
+# Test word
+
+Names of objects in test files must not contain the word 'test'. If an object
+is a unit test, or a helper inside a unit test, or lives in a file whose top
+object name ends with `-tests`, its name should describe the behavior it
+verifies instead of repeating the word 'test'.
+
+Incorrect:
+
+```eo
+# Tests for foo.
+[] > foo-tests
+  # Test.
+  [] +> can-test-add
+    42 > @
+```
+
+Correct:
+
+```eo
+# Tests for foo.
+[] > foo-tests
+  # Test.
+  [] +> can-add-two-and-two
+    42 > @
+```

--- a/src/test/resources/org/eolang/lints/packs/single/test-word/allows-clean-test-names.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-word/allows-clean-test-names.yaml
@@ -5,12 +5,8 @@ sheets:
   - /org/eolang/lints/tests/test-word.xsl
 asserts:
   - /defects[count(defect[@severity='warning'])=0]
-ignore-schema: true
-document: |
-  <object author="tests">
-    <o line="1" name="foo-tests" pos="0">
-      <o line="3" name="+can-add" pos="2">
-        <o base="Q.number" line="4" name="φ" pos="4"/>
-      </o>
-    </o>
-  </object>
+input: |
+  [] > foo-tests
+
+    [] +> can-add
+      42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/test-word/allows-clean-test-names.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-word/allows-clean-test-names.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/test-word.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="1" name="foo-tests" pos="0">
+      <o line="3" name="+can-add" pos="2">
+        <o base="Q.number" line="4" name="φ" pos="4"/>
+      </o>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/test-word/allows-test-word-in-regular-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-word/allows-test-word-in-regular-object.yaml
@@ -5,10 +5,8 @@ sheets:
   - /org/eolang/lints/tests/test-word.xsl
 asserts:
   - /defects[count(defect[@severity='warning'])=0]
-ignore-schema: true
-document: |
-  <object author="tests">
-    <o line="1" name="app" pos="0">
-      <o base="Q.org.testing" line="3" name="testing-helper" pos="2"/>
-    </o>
-  </object>
+input: |
+  [] > app
+
+    testing-helper > testing-helper
+    TRUE > @

--- a/src/test/resources/org/eolang/lints/packs/single/test-word/allows-test-word-in-regular-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-word/allows-test-word-in-regular-object.yaml
@@ -7,6 +7,5 @@ asserts:
   - /defects[count(defect[@severity='warning'])=0]
 input: |
   [] > app
-
     testing-helper > testing-helper
-    TRUE > @
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/test-word/allows-test-word-in-regular-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-word/allows-test-word-in-regular-object.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/test-word.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="1" name="app" pos="0">
+      <o base="Q.org.testing" line="3" name="testing-helper" pos="2"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/test-word/catches-test-in-nested-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-word/catches-test-in-nested-object.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/test-word.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='5']
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="1" name="foo-tests" pos="0">
+      <o line="3" name="+can-setup" pos="2">
+        <o base="Q.number" line="5" name="tests-helper" pos="4"/>
+      </o>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/test-word/catches-test-in-nested-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-word/catches-test-in-nested-object.yaml
@@ -5,13 +5,10 @@ sheets:
   - /org/eolang/lints/tests/test-word.xsl
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
-  - /defects/defect[@line='5']
-ignore-schema: true
-document: |
-  <object author="tests">
-    <o line="1" name="foo-tests" pos="0">
-      <o line="3" name="+can-setup" pos="2">
-        <o base="Q.number" line="5" name="tests-helper" pos="4"/>
-      </o>
-    </o>
-  </object>
+  - /defects/defect[@line='4']
+input: |
+  [] > foo-tests
+
+    [] +> can-setup
+      tests-helper > tests-helper
+      42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/test-word/catches-test-in-test-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-word/catches-test-in-test-object.yaml
@@ -6,12 +6,8 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
   - /defects/defect[@line='3']
-ignore-schema: true
-document: |
-  <object author="tests">
-    <o line="1" name="foo-tests" pos="0">
-      <o line="3" name="+can-test-add" pos="2">
-        <o base="Q.number" line="4" name="φ" pos="4"/>
-      </o>
-    </o>
-  </object>
+input: |
+  [] > foo-tests
+
+    [] +> can-test-add
+      42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/test-word/catches-test-in-test-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-word/catches-test-in-test-object.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/test-word.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='3']
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="1" name="foo-tests" pos="0">
+      <o line="3" name="+can-test-add" pos="2">
+        <o base="Q.number" line="4" name="φ" pos="4"/>
+      </o>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/test-word/catches-test-word-in-helper.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-word/catches-test-word-in-helper.yaml
@@ -5,13 +5,10 @@ sheets:
   - /org/eolang/lints/tests/test-word.xsl
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
-  - /defects/defect[@line='5']
-ignore-schema: true
-document: |
-  <object author="tests">
-    <o line="1" name="foo-tests" pos="0">
-      <o line="3" name="can-run" pos="2">
-        <o base="Q.number" line="5" name="tests-helper" pos="4"/>
-      </o>
-    </o>
-  </object>
+  - /defects/defect[@line='4']
+input: |
+  [] > foo-tests
+
+    [] > can-run
+      tests-helper > tests-helper
+      42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/test-word/catches-test-word-in-helper.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-word/catches-test-word-in-helper.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/test-word.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='5']
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="1" name="foo-tests" pos="0">
+      <o line="3" name="can-run" pos="2">
+        <o base="Q.number" line="5" name="tests-helper" pos="4"/>
+      </o>
+    </o>
+  </object>


### PR DESCRIPTION
Fixes #553.

## Problem
Objects with names containing the word `test` (case-insensitive) are allowed, while the project convention requires test names to be clean. Such names should lead to lint warnings.

## Solution / What
New XSLT lint `test-word` that warns when an object name contains `test` in a test context: object names inside test objects (matched by the `eo:test-name()` helper), their ancestors, or when the top-level object name ends with `-tests`.

## Changes
- `src/main/resources/org/eolang/lints/tests/test-word.xsl` — the new lint.
- `src/main/resources/org/eolang/motives/tests/test-word.md` — motivation.
- `src/test/resources/org/eolang/lints/packs/single/test-word/` — 5 test packs.

## Tests
- `catches-test-in-test-object`
- `catches-test-word-in-helper`
- `catches-test-in-nested-object`
- `allows-clean-test-names`
- `allows-test-word-in-regular-object`
