### PR TITLE
feat(#20): add mystery-object lint

### DIFF
--- a/src/main/java/org/eolang/lints/LtMystery.java
+++ b/src/main/java/org/eolang/lints/LtMystery.java
@@ -1,0 +1,124 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XML;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Lint to catch mystery objects.
+ *
+ * <p>A mystery object is a free application of an object that is neither
+ * declared anywhere in the program nor is one of the {@code org.eolang}
+ * prime objects (like {@code number} or {@code bytes}). It almost always
+ * means a typo in the name of an object or a missing {@code +alias} meta.
+ * Such a call is compiled to {@code Φ.NAME} reference, which this lint
+ * inspects.</p>
+ *
+ * @since 0.0.52
+ */
+final class LtMystery implements Lint {
+
+    /**
+     * Reserved names.
+     * The key is object name, the value is the path to EO file.
+     */
+    private final Map<String, String> reserved;
+
+    /**
+     * Ctor.
+     */
+    LtMystery() {
+        this(new ReservedNames());
+    }
+
+    /**
+     * Ctor.
+     * @param names Reserved names
+     */
+    LtMystery(final Map<String, String> names) {
+        this.reserved = names;
+    }
+
+    @Override
+    public String name() {
+        return "mystery-object";
+    }
+
+    @Override
+    public Collection<Defect> defects(final XML xmir) throws IOException {
+        final Collection<Defect> defects;
+        if (this.reserved.isEmpty()) {
+            defects = new ArrayList<>(0);
+        } else {
+            defects = LtMystery.find(xmir, this.reserved);
+        }
+        return defects;
+    }
+
+    @Override
+    public String motive() throws IOException {
+        return new MotiveFrom("names", this.name()).asString();
+    }
+
+    @Override
+    public Fix fix() {
+        return new FxEmpty();
+    }
+
+    /**
+     * Detect mystery objects in the program.
+     * @param xmir XMIR document
+     * @param reserved Reserved org.eolang names
+     * @return Detected defects
+     */
+    private static Collection<Defect> find(final XML xmir,
+        final Map<String, String> reserved) {
+        final Xnav xnav = new Xnav(xmir.inner());
+        final Set<String> declared = xnav.path("//o[@name]").map(
+            elem -> elem.attribute("name").text().get()
+        ).collect(Collectors.toSet());
+        return xnav.path("//o[@base]").filter(
+            elem -> {
+                final Optional<String> base = elem.attribute("base").text();
+                return base.isPresent()
+                    && LtMystery.simple(base.get());
+            }
+        ).filter(
+            elem -> {
+                final String base = elem.attribute("base").text().get();
+                return !declared.contains(base.substring(2))
+                    && !reserved.containsKey(base.substring(2));
+            }
+        ).map(
+            elem -> new Defect.Default(
+                "mystery-object",
+                Severity.ERROR,
+                new LineOf(elem).value(),
+                String.format(
+                    "Object \"%s\" is not defined in the program and is not part of org.eolang",
+                    elem.attribute("base").text().get().substring(2)
+                )
+            )
+        ).collect(Collectors.toList());
+    }
+
+    /**
+     * Check if the base is a reference to a single object, like
+     * {@code Φ.bar}, and not to a path like {@code Φ.org.eolang.io.stdout}.
+     * @param base Base attribute value
+     * @return True if it's a simple object reference
+     */
+    private static boolean simple(final String base) {
+        return base.matches("^Φ\\.[a-z][a-z0-9_-]*$");
+    }
+}

--- a/src/main/java/org/eolang/lints/LtMystery.java
+++ b/src/main/java/org/eolang/lints/LtMystery.java
@@ -75,12 +75,6 @@ final class LtMystery implements Lint {
         return new FxEmpty();
     }
 
-    /**
-     * Detect mystery objects in the program.
-     * @param xmir XMIR document
-     * @param reserved Reserved org.eolang names
-     * @return Detected defects
-     */
     private static Collection<Defect> find(final XML xmir,
         final Map<String, String> reserved) {
         final Xnav xnav = new Xnav(xmir.inner());
@@ -96,26 +90,12 @@ final class LtMystery implements Lint {
         ).collect(Collectors.toList());
     }
 
-    /**
-     * Is the {@code @base} a bare single-object reference?
-     * @param elem Object element
-     * @return True if it's a simple object reference
-     */
     private static boolean simpleBase(final Xnav elem) {
         final Optional<String> base = elem.attribute("base").text();
         return base.isPresent()
             && LtMystery.simple(base.get());
     }
 
-    /**
-     * Is the referenced object unknown?
-     * The name is the {@code @base} value without the leading two characters,
-     * which are the {@code Φ.} prefix.
-     * @param elem Object element
-     * @param declared Objects declared in the program
-     * @param reserved Reserved org.eolang names
-     * @return True if the object is neither declared nor reserved
-     */
     private static boolean unknown(final Xnav elem,
         final Set<String> declared, final Map<String, String> reserved) {
         final String name = LtMystery.objectName(elem);
@@ -123,22 +103,10 @@ final class LtMystery implements Lint {
             && !reserved.containsKey(name);
     }
 
-    /**
-     * Object name from the {@code @base} attribute.
-     * The name is the value without the leading two characters,
-     * which are the {@code Φ.} prefix.
-     * @param elem Object element
-     * @return Object name
-     */
     private static String objectName(final Xnav elem) {
         return elem.attribute("base").text().get().substring(2);
     }
 
-    /**
-     * Defect for an unknown object.
-     * @param elem Object element
-     * @return Defect
-     */
     private static Defect defect(final Xnav elem) {
         return new Defect.Default(
             "mystery-object",
@@ -151,12 +119,6 @@ final class LtMystery implements Lint {
         );
     }
 
-    /**
-     * Check if the base is a reference to a single object, like
-     * {@code Φ.bar}, and not to a path like {@code Φ.org.eolang.io.stdout}.
-     * @param base Base attribute value
-     * @return True if it's a simple object reference
-     */
     private static boolean simple(final String base) {
         return base.matches("^Φ\\.[a-z][a-z0-9_-]*$");
     }

--- a/src/main/java/org/eolang/lints/LtMystery.java
+++ b/src/main/java/org/eolang/lints/LtMystery.java
@@ -88,28 +88,67 @@ final class LtMystery implements Lint {
             elem -> elem.attribute("name").text().get()
         ).collect(Collectors.toSet());
         return xnav.path("//o[@base]").filter(
-            elem -> {
-                final Optional<String> base = elem.attribute("base").text();
-                return base.isPresent()
-                    && LtMystery.simple(base.get());
-            }
+            LtMystery::simpleBase
         ).filter(
-            elem -> {
-                final String base = elem.attribute("base").text().get();
-                return !declared.contains(base.substring(2))
-                    && !reserved.containsKey(base.substring(2));
-            }
+            elem -> LtMystery.unknown(elem, declared, reserved)
         ).map(
-            elem -> new Defect.Default(
-                "mystery-object",
-                Severity.ERROR,
-                new LineOf(elem).value(),
-                String.format(
-                    "Object \"%s\" is not defined in the program and is not part of org.eolang",
-                    elem.attribute("base").text().get().substring(2)
-                )
-            )
+            LtMystery::defect
         ).collect(Collectors.toList());
+    }
+
+    /**
+     * Is the {@code @base} a bare single-object reference?
+     * @param elem Object element
+     * @return True if it's a simple object reference
+     */
+    private static boolean simpleBase(final Xnav elem) {
+        final Optional<String> base = elem.attribute("base").text();
+        return base.isPresent()
+            && LtMystery.simple(base.get());
+    }
+
+    /**
+     * Is the referenced object unknown?
+     * The name is the {@code @base} value without the leading two characters,
+     * which are the {@code Φ.} prefix.
+     * @param elem Object element
+     * @param declared Objects declared in the program
+     * @param reserved Reserved org.eolang names
+     * @return True if the object is neither declared nor reserved
+     */
+    private static boolean unknown(final Xnav elem,
+        final Set<String> declared, final Map<String, String> reserved) {
+        final String name = LtMystery.objectName(elem);
+        return !declared.contains(name)
+            && !reserved.containsKey(name);
+    }
+
+    /**
+     * Object name from the {@code @base} attribute.
+     * The name is the value without the leading two characters,
+     * which are the {@code Φ.} prefix.
+     * @param elem Object element
+     * @return Object name
+     */
+    private static String objectName(final Xnav elem) {
+        return elem.attribute("base").text().get().substring(2);
+    }
+
+    /**
+     * Defect for an unknown object.
+     * @param elem Object element
+     * @return Defect
+     */
+    private static Defect defect(final Xnav elem) {
+        return new Defect.Default(
+            "mystery-object",
+            Severity.ERROR,
+            new LineOf(elem).value(),
+            String.format(
+                "Object \"%s\" is not defined in the program and is not part of org.eolang",
+                LtMystery.objectName(elem)
+            )
+        );
     }
 
     /**

--- a/src/main/java/org/eolang/lints/MonoLints.java
+++ b/src/main/java/org/eolang/lints/MonoLints.java
@@ -64,7 +64,8 @@ final class MonoLints extends IterableEnvelope<Lint> {
                 new LtAsciiOnly(),
                 new LtReservedName(),
                 new LtSyntaxVersion(),
-                new LtTestNotVerb()
+                new LtTestNotVerb(),
+                new LtMystery()
             );
         } catch (final IOException ex) {
             throw new IllegalStateException(

--- a/src/main/resources/org/eolang/motives/names/mystery-object.md
+++ b/src/main/resources/org/eolang/motives/names/mystery-object.md
@@ -1,0 +1,20 @@
+# Mystery object
+
+Objects, applied in the code, must be defined somewhere in the program,
+be the objects of `org.eolang.*` or be imported via `+alias` meta. Free
+usage of an unknown object is a mystery object — it is almost always a
+typo in the name, since this object is not declared anywhere.
+
+Incorrect:
+
+```eo
+# Foo.
+[] > foo
+  bar 42 > x
+```
+
+Here, `bar` is not defined in the program, not an object from `org.eolang.*`
+and not imported via `+alias`. It will be compiled to `Φ.bar` reference,
+which can't be validated by the parser. This is what we call a mystery
+object, and it should be fixed by adding the definition of `bar`, importing
+it, or using a proper object name.

--- a/src/main/resources/org/eolang/motives/names/mystery-object.md
+++ b/src/main/resources/org/eolang/motives/names/mystery-object.md
@@ -2,7 +2,7 @@
 
 Objects, applied in the code, must be defined somewhere in the program,
 be the objects of `org.eolang.*` or be imported via `+alias` meta. Free
-usage of an unknown object is a mystery object — it is almost always a
+usage of an unknown object is a mystery object—it is almost always a
 typo in the name, since this object is not declared anywhere.
 
 Incorrect:

--- a/src/test/java/org/eolang/lints/LtMysteryTest.java
+++ b/src/test/java/org/eolang/lints/LtMysteryTest.java
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import fixtures.EoProgram;
+import java.io.IOException;
+import java.util.Map;
+import org.cactoos.io.InputOf;
+import org.cactoos.list.ListOf;
+import org.cactoos.map.MapEntry;
+import org.cactoos.map.MapOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link LtMystery}.
+ * @since 0.0.52
+ */
+final class LtMysteryTest {
+
+    @Test
+    void catchesMysteryObject() throws IOException {
+        MatcherAssert.assertThat(
+            "It is expected to catch a mystery object here",
+            new LtMystery(this.canonical()).defects(
+                new EoProgram("org/eolang/lints/mystery-object.eo").parse()
+            ),
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
+    void allowsDeclaredObject() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are not empty, but the object is declared in the program",
+            new LtMystery(this.canonical()).defects(
+                new EoProgram("org/eolang/lints/declared-object.eo").parse()
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void allowsAliasedObject() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are not empty, but the object is imported via +alias",
+            new LtMystery(this.canonical()).defects(
+                new EoProgram("org/eolang/lints/aliased-object.eo").parse()
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void allowsCanonicalObject() throws IOException {
+        MatcherAssert.assertThat(
+            "Defects are not empty, but the object is part of org.eolang",
+            new LtMystery(this.canonical()).defects(
+                new EoProgram("org/eolang/lints/canonical-object.eo").parse()
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void reportsCorrectMessageForMysteryObject() throws IOException {
+        MatcherAssert.assertThat(
+            "The message should mention the mystery object",
+            new ListOf<>(
+                new LtMystery(this.canonical()).defects(
+                    new EoProgram("org/eolang/lints/mystery-object.eo").parse()
+                )
+            ).get(0).text(),
+            Matchers.equalTo(
+                "Object \"bar\" is not defined in the program and is not part of org.eolang"
+            )
+        );
+    }
+
+    @Test
+    void allowsAllObjectsDeclaredInline() throws IOException {
+        final String src = String.format(
+            "[] > foo%n  [a] > bar%n  bar > x"
+        );
+        MatcherAssert.assertThat(
+            "Objects should not be reported, since all of them are declared",
+            new LtMystery(this.canonical()).defects(
+                new EoProgram(src, new InputOf(src)).parse()
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Tag("reserved")
+    @Test
+    void scansMysteryFromHome() throws Exception {
+        MatcherAssert.assertThat(
+            "It is expected to catch a mystery object using reserved names from home",
+            new LtMystery().defects(
+                new EoProgram("org/eolang/lints/mystery-bipki.eo").parse()
+            ),
+            Matchers.hasSize(1)
+        );
+    }
+
+    /**
+     * Dummy reserved names for the tests.
+     * @return Reserved names map
+     */
+    private Map<String, String> canonical() {
+        return new MapOf<>(
+            new MapEntry<>("number", "number.eo"),
+            new MapEntry<>("bytes", "bytes.eo"),
+            new MapEntry<>("string", "string.eo")
+        );
+    }
+}

--- a/src/test/java/org/eolang/lints/LtMysteryTest.java
+++ b/src/test/java/org/eolang/lints/LtMysteryTest.java
@@ -107,10 +107,6 @@ final class LtMysteryTest {
         );
     }
 
-    /**
-     * Dummy reserved names for the tests.
-     * @return Reserved names map
-     */
     private Map<String, String> canonical() {
         return new MapOf<>(
             new MapEntry<>("number", "number.eo"),

--- a/src/test/resources/org/eolang/lints/aliased-object.eo
+++ b/src/test/resources/org/eolang/lints/aliased-object.eo
@@ -1,0 +1,7 @@
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++alias org.eolang.io.stdout
+
+# Foo.
+[] > foo
+  stdout "Hello" > x

--- a/src/test/resources/org/eolang/lints/canonical-object.eo
+++ b/src/test/resources/org/eolang/lints/canonical-object.eo
@@ -1,0 +1,6 @@
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Foo.
+[] > foo
+  42 > x

--- a/src/test/resources/org/eolang/lints/declared-object.eo
+++ b/src/test/resources/org/eolang/lints/declared-object.eo
@@ -1,0 +1,7 @@
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Foo.
+[] > foo
+  [t] > bar
+  bar 42 > x

--- a/src/test/resources/org/eolang/lints/mystery-bipki.eo
+++ b/src/test/resources/org/eolang/lints/mystery-bipki.eo
@@ -1,0 +1,6 @@
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Foo.
+[] > foo
+  bipki 42 > x

--- a/src/test/resources/org/eolang/lints/mystery-object.eo
+++ b/src/test/resources/org/eolang/lints/mystery-object.eo
@@ -1,0 +1,6 @@
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Foo.
+[] > foo
+  bar 42 > x


### PR DESCRIPTION
fix #20

## What

A new Java-based lint `mystery-object` is added. It is registered in
`MonoLints` together with the other hand-coded lints (`ascii-only`,
`reserved-name`). The full set of artifacts:

- `src/main/java/org/eolang/lints/LtMystery.java` — the lint implementation
- `src/main/resources/org/eolang/motives/names/mystery-object.md` — the motive
- `src/test/java/org/eolang/lints/LtMysteryTest.java` — unit tests
- `src/test/resources/org/eolang/lints/*.eo` — EO fixtures used by the tests

## Why

Consider this program:

```eo
[] > foo
  bar 42 > x
```

The object `bar` is neither defined in the program, nor imported via
`+alias`, nor one of the `org.eolang` objects. Such a call is almost always
a typo in the object name. Still, the parser happily compiles it into a
bare `Φ.bar` reference and nobody complains. The program reaches the
compile/run pipeline and fails there with an obscure error, far away from
the actual mistake.

This lint detects exactly that situation and reports it as an `error`
right at the source line.

## How it works

The parser resolves any object application into a `base` attribute. There
are three interesting shapes:

- `Φ.org.eolang.io.stdout` — a *qualified* path (result of `+alias` or a
  fully-qualified name). Always legitimate, never reported.
- `Φ.number`, `Φ.bytes`, etc. — references to prime `org.eolang` objects.
  Legitimate, but only when the name is really one of the reserved top-level
  objects of the home repository.
- `Φ.bar` — a *bare single-name* reference. This is the suspicious case.

The lint walks every `//o[@base]` element and applies the simple-name
pattern `^Φ\.[a-z][a-z0-9_-]*$`. Any element that matches must prove its
right to exist:

1. The name is declared somewhere in the current program, i.e. there is a
   `//o[@name='bar']` node in the same XMIR — a legitimate local object, or
2. The name is present in `ReservedNames` — the CSV of the `org.eolang`
   top-level objects, generated from the home repository on the `reserved`
   build profile.

Everything else is a mystery object and gets an `error` defect.

Aliased objects need no special handling: the parser resolves an alias into
a dotted path (`Φ.org.eolang.io.stdout`), which never matches the simple
one-word pattern, so they are excluded by construction.

## Why not an XSL lint

The decision on "is `NAME` a legitimate `org.eolang` object" depends on the
runtime list from the home repository (`ReservedNames`, backed by
`reserved.csv` generated on the `reserved` Maven profile). XSL transforms
cannot read that runtime data, while a Java lint can — this is the same
reason the existing `reserved-name` lint is implemented in Java.

## Robustness against a missing reserved list

`reserved.csv` exists only when the `reserved` profile is active (CI does
this in a dedicated `reserved.yml` workflow). In the default `mvn test`
run the map is empty. The lint handles this gracefully: with an empty list
it returns no defects. The full behavior matrix is exercised in the
`@Tag("reserved")` integration test (`scansMysteryFromHome`), which runs
against the real home data in CI.

## Tests

- `catchesMysteryObject` — `bar` with no definition is caught
- `reportsCorrectMessageForMysteryObject` — message names the object
- `allowsDeclaredObject` — local `bar` declaration is fine
- `allowsAliasedObject` — `+alias` import is fine
- `allowsCanonicalObject` — `org.eolang` literal (`42`) is fine
- `allowsAllObjectsDeclaredInline` — all inline declarations are fine
- `scansMysteryFromHome` (`@Tag("reserved")`) — integration against the
  real reserved list from home

Both `mvn test` (592 tests) and `mvn clean install -Pqulice` pass.