### PR TITLE
fix(#1243): enforce prefixes per test kind in bad-test-name

### DIFF
--- a/src/main/resources/org/eolang/lints/tests/bad-test-name.xsl
+++ b/src/main/resources/org/eolang/lints/tests/bad-test-name.xsl
@@ -3,17 +3,23 @@
 * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="bad-test-name" version="2.0">
-  <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="bad-test-name" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/test-name.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="/object//o[starts-with(@name, '+')]">
-        <xsl:variable name="regexp" select="'^(can|cannot|accepts|rejects|stops-on)-'"/>
-        <xsl:if test="not(matches(eo:escape-plus(@name), $regexp))">
+      <xsl:for-each select="/object//o[eo:test-name(@name)]">
+        <!--
+        A truthy test asserts that something works, thus it is a positive one,
+        while a throwing test asserts that something fails, thus it is a
+        negative one. Each kind has its own set of allowed prefixes.
+        -->
+        <xsl:variable name="positive" as="xs:boolean" select="starts-with(@name, '+')"/>
+        <xsl:variable name="regexp" as="xs:string" select="if ($positive) then '^(can|accepts)-' else '^(cannot|rejects|stops-on)-'"/>
+        <xsl:if test="not(matches(substring(@name, 2), $regexp))">
           <defect>
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">
@@ -25,10 +31,12 @@
               </xsl:attribute>
             </xsl:if>
             <xsl:attribute name="severity">warning</xsl:attribute>
-            <xsl:text>The name of the test object </xsl:text>
-            <xsl:value-of select="eo:escape(@name)"/>
+            <xsl:text>The name of the </xsl:text>
+            <xsl:value-of select="if ($positive) then 'positive' else 'negative'"/>
+            <xsl:text> test object </xsl:text>
+            <xsl:value-of select="eo:escape(substring(@name, 2))"/>
             <xsl:text> must start with one of the prefixes </xsl:text>
-            <xsl:value-of select="eo:escape('can-, cannot-, accepts-, rejects-, stops-on-')"/>
+            <xsl:value-of select="eo:escape(if ($positive) then 'can-, accepts-' else 'cannot-, rejects-, stops-on-')"/>
           </defect>
         </xsl:if>
       </xsl:for-each>

--- a/src/main/resources/org/eolang/motives/tests/bad-test-name.md
+++ b/src/main/resources/org/eolang/motives/tests/bad-test-name.md
@@ -1,14 +1,26 @@
 # Bad test name
 
 Every unit test object must be named to describe the behavior it verifies,
-starting with one of these prefixes: `can-`, `cannot-`, `accepts-`,
-`rejects-`, or `stops-on-`.
+with a prefix that matches the kind of the test.
+
+A positive test, declared with `+>`, asserts that the object under test does
+something. Its name must start with `can-` or `accepts-`.
+
+A negative test, declared with `->`, asserts that the object under test
+refuses to do something. Its name must start with `cannot-`, `rejects-`, or
+`stops-on-`.
 
 Incorrect:
 
 ```eo
 [] > foo
   [] +> it-works
+    42 > @
+
+  [] +> stops-on-zero
+    42 > @
+
+  [] -> can-divide-by-zero
     42 > @
 ```
 
@@ -17,5 +29,11 @@ Correct:
 ```eo
 [] > foo
   [] +> can-add-two-numbers
+    42 > @
+
+  [] +> accepts-negative-numbers
+    42 > @
+
+  [] -> stops-on-zero
     42 > @
 ```

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-all-negative-prefixes-in-positive-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-all-negative-prefixes-in-positive-tests.yaml
@@ -4,17 +4,13 @@
 sheets:
   - /org/eolang/lints/tests/bad-test-name.xsl
 asserts:
-  - /defects[count(defect[@severity='warning'])=0]
+  - /defects[count(defect[@severity='warning'])=3]
 input: |
   [] > foo
     [] > bar
 
-    [] +> can-do-something
+    [] +> cannot-do-something
 
-    [] +> accepts-input
+    [] +> rejects-input
 
-    [] -> cannot-do-something
-
-    [] -> rejects-input
-
-    [] -> stops-on-error
+    [] +> stops-on-error

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-bad-name-in-negative-test.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-bad-name-in-negative-test.yaml
@@ -4,17 +4,9 @@
 sheets:
   - /org/eolang/lints/tests/bad-test-name.xsl
 asserts:
-  - /defects[count(defect[@severity='warning'])=0]
+  - /defects[count(defect[@severity='warning'])=1]
 input: |
   [] > foo
     [] > bar
 
-    [] +> can-do-something
-
-    [] +> accepts-input
-
-    [] -> cannot-do-something
-
-    [] -> rejects-input
-
-    [] -> stops-on-error
+    [] -> throws-on-empty

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-negative-prefix-in-positive-test.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-negative-prefix-in-positive-test.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/bad-test-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[contains(text(),'positive')]
+input: |
+  [] > foo
+    eq. +> stops-on-zero
+      recovered
+        42.div 0
+        "oops"
+      "oops"

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-positive-prefix-in-negative-test.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-positive-prefix-in-negative-test.yaml
@@ -4,17 +4,12 @@
 sheets:
   - /org/eolang/lints/tests/bad-test-name.xsl
 asserts:
-  - /defects[count(defect[@severity='warning'])=0]
+  - /defects[count(defect[@severity='warning'])=2]
+  - /defects/defect[contains(text(),'negative')]
 input: |
   [] > foo
     [] > bar
 
-    [] +> can-do-something
+    [] -> can-divide-by-zero
 
-    [] +> accepts-input
-
-    [] -> cannot-do-something
-
-    [] -> rejects-input
-
-    [] -> stops-on-error
+    [] -> accepts-empty-input


### PR DESCRIPTION
Closes #1243.

## Problem

`bad-test-name` accepted the same five prefixes (`can-`, `cannot-`, `accepts-`, `rejects-`, `stops-on-`) for every test, and it only inspected truthy tests (`@name` starting with `+`). So the example from the issue passed silently, even though the name claims the object fails while the test asserts that it works:

```eo
[] > foo
  eq. +> stops-on-zero
    recovered
      42.div 0
      "oops"
    "oops"
```

Throwing tests (`@name` starting with `-`) weren't checked at all.

## Fix

The allowed prefixes now depend on the kind of the test, as `Suffix.attribute` in `eo-parser` marks it:

| Kind | EO syntax | `@name` in XMIR | Allowed prefixes |
| --- | --- | --- | --- |
| positive | `+>` | `+the-name` | `can-`, `accepts-` |
| negative | `->` | `-the-name` | `cannot-`, `rejects-`, `stops-on-` |

`bad-test-name.xsl` iterates over `eo:test-name(@name)` instead of `starts-with(@name, '+')`, so throwing tests are linted too, and it picks the regexp and the list of prefixes reported in the defect message from the kind of the test. The message also names the kind now, e.g.:

```
The name of the positive test object "stops-on-zero" must start with one of the prefixes "can-,⌴accepts-"
```

## Tests

`allows-all-prefixes.yaml` was updated — the three negative prefixes moved to `->` tests, where they now belong. Four packs added:

- `catches-negative-prefix-in-positive-test.yaml` — the exact snippet from the issue
- `catches-all-negative-prefixes-in-positive-tests.yaml` — `+> cannot-…`, `+> rejects-…`, `+> stops-on-…`
- `catches-positive-prefix-in-negative-test.yaml` — `-> can-…`, `-> accepts-…`
- `catches-bad-name-in-negative-test.yaml` — `-> throws-on-empty`

The motive in `bad-test-name.md` documents both sets of prefixes.

`mvn test` passes (590 tests, 0 failures), as does `mvn test -Pdeep -Dtest=LtByXslTest#validatesEoPacksForErrors`, which confirms the new EO packs parse without errors. `xcop`, `vale` and `yamllint` are clean on the touched files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HaeFS4H5nK5HJtGyisEZKq)_