### PR TITLE
test(#108): cover nested @ with phi-is-not-first

### DIFF
--- a/src/test/resources/org/eolang/lints/packs/single/phi-is-not-first/catches-nested-at.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/phi-is-not-first/catches-nested-at.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/phi-is-not-first.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='3']
+input: |
+  [] > foo
+    hello > x
+      bar > @


### PR DESCRIPTION
fix #108

## What

A regression test for the exact case from the issue: a nested `@`
attribute (`bar > @` inside a child object) is covered by the existing
`names/phi-is-not-first` lint.

## Why

The parser lifts a nested `@` up to the top level of its parent, where it
becomes a `φ` sibling that is never first (the container always precedes
it). The `phi-is-not-first` lint checks exactly that, so the confusing
code from the issue is already reported. The claim was made in
https://github.com/objectionary/lints/issues/108#issuecomment-5244086746,
but was not backed by a test. This pack locks the behavior in, so a future
regression in the lint or in the parser would be caught by CI.

## Changes

- `src/test/resources/org/eolang/lints/packs/single/phi-is-not-first/catches-nested-at.yaml` — the new regression pack

Both `mvn test` (591 tests) and `mvn clean install -Pqulice` pass.
