### PR TITLE
feat(#155): add too-deep-object lint

### DIFF
--- a/src/main/resources/org/eolang/lints/design/too-deep-object.xsl
+++ b/src/main/resources/org/eolang/lints/design/too-deep-object.xsl
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="too-deep-object">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[count(ancestor::o[not(@base='Φ.tuple') and not(@base='Φ.bytes') and not(@base='Φ.number') and not(@base='Φ.string')]) &gt; 12 and not(o[count(ancestor::o[not(@base='Φ.tuple') and not(@base='Φ.bytes') and not(@base='Φ.number') and not(@base='Φ.string')]) &gt; 12])]">
+        <defect>
+          <xsl:variable name="line" select="eo:lineno(@line)"/>
+          <xsl:attribute name="line">
+            <xsl:value-of select="$line"/>
+          </xsl:attribute>
+          <xsl:if test="$line = '0'">
+            <xsl:attribute name="context">
+              <xsl:value-of select="eo:defect-context(.)"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:attribute name="severity">warning</xsl:attribute>
+          <xsl:text>The object </xsl:text>
+          <xsl:value-of select="eo:escape(@base)"/>
+          <xsl:text> is nested too deep: </xsl:text>
+          <xsl:value-of select="count(ancestor::o)"/>
+          <xsl:text> levels of nesting, while the maximum is 12</xsl:text>
+        </defect>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/design/too-deep-object.md
+++ b/src/main/resources/org/eolang/motives/design/too-deep-object.md
@@ -1,0 +1,29 @@
+# Too deep object
+
+Objects nested deeper than twelve levels are hard to read and to debug.
+The nesting level of an object is the number of its ancestor objects.
+If it exceeds twelve, a warning is raised.
+
+Incorrect:
+
+```eo
+# Foo.
+[] > foo
+  a > x
+    b
+      c
+        d
+          e
+            f
+              g
+                h
+                  i
+                    j
+                      k
+                        l
+                          m
+```
+
+Here, `m` is nested thirteen levels deep, which is hard to follow.
+It should be refactored by extracting some of the nested objects into
+their own top-level objects.

--- a/src/test/resources/org/eolang/lints/packs/single/too-deep-object/allows-normal-nesting.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/too-deep-object/allows-normal-nesting.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/too-deep-object.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # Foo.
+
+  [] > foo
+    a > x
+      b
+        c
+          d
+            e
+              f
+                g

--- a/src/test/resources/org/eolang/lints/packs/single/too-deep-object/catches-too-deep-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/too-deep-object/catches-too-deep-object.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/too-deep-object.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='16']
+input: |
+  # Foo.
+
+  [] > foo
+    a > x
+      b
+        c
+          d
+            e
+              f
+                g
+                  h
+                    i
+                      j
+                        k
+                          l
+                            m


### PR DESCRIPTION
fix #155

## What

A new `design/too-deep-object` lint that warns when an object is nested
deeper than twelve levels.

## How it works

The lint counts the ancestors of every object in XMIR:

```
depth = count(ancestor::o)
```

If the depth exceeds 12, the object is reported as a `warning`.

Synthetic nodes introduced by the parser are excluded from the count:
`Φ.tuple` (tuples written as `*`), `Φ.bytes`, `Φ.number` and `Φ.string`
(literals). Without this, even the canonical example
(`src/test/resources/org/eolang/lints/canonical.eo`, which is only about
12 source levels deep) would be flagged, because the parser wraps every
literal and tuple in extra levels of nesting.

Only the deepest offending objects are reported (not every descendant),
so a single deep chain yields a single defect.

## Why

Deeply nested objects are hard to read and debug. The issue proposes a
threshold of 12, which this lint follows.

## Tests

- `catches-too-deep-object` — a 14-level chain is flagged
- `allows-normal-nesting` — a 7-level chain (from the issue) is clean

Both `mvn test` (592 tests) and `mvn clean install -Pqulice` pass.
