### PR TITLE
feat(#407): add test-without-assert lint

### DIFF
--- a/src/main/resources/org/eolang/lints/tests/test-without-assert.xsl
+++ b/src/main/resources/org/eolang/lints/tests/test-without-assert.xsl
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="test-without-assert">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/test-name.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="/object//o[eo:test-name(@name) and o[@name='φ' and (@base='Φ.number' or @base='Φ.string' or @base='Φ.bytes' or @base='Φ.bool')]]">
+        <defect>
+          <xsl:variable name="line" select="eo:lineno(@line)"/>
+          <xsl:attribute name="line">
+            <xsl:value-of select="$line"/>
+          </xsl:attribute>
+          <xsl:if test="$line = '0'">
+            <xsl:attribute name="context">
+              <xsl:value-of select="eo:defect-context(.)"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:attribute name="severity">warning</xsl:attribute>
+          <xsl:text>The test object </xsl:text>
+          <xsl:value-of select="eo:escape(@name)"/>
+          <xsl:text> does not have any assertions</xsl:text>
+        </defect>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/tests/test-without-assert.md
+++ b/src/main/resources/org/eolang/motives/tests/test-without-assert.md
@@ -1,0 +1,31 @@
+# Test without assert
+
+A unit test that does not assert anything tests nothing. Such a test is
+useless: it will pass no matter what, so it cannot catch a regression.
+
+Incorrect:
+
+```eo
++tests
+
+# Test.
+[] > checks-something
+  52 > @
+```
+
+Here the test object `checks-something` is just a number literal — there
+is no comparison, no assertion, nothing to verify.
+
+Correct:
+
+```eo
++tests
+
+# Test.
+[] > checks-something
+  eq. > @
+    42
+    42
+```
+
+Now the test asserts that `eq 42 42` is true.

--- a/src/main/resources/org/eolang/motives/tests/test-without-assert.md
+++ b/src/main/resources/org/eolang/motives/tests/test-without-assert.md
@@ -13,7 +13,7 @@ Incorrect:
   52 > @
 ```
 
-Here the test object `checks-something` is just a number literal — there
+Here the test object `checks-something` is just a number literal—there
 is no comparison, no assertion, nothing to verify.
 
 Correct:

--- a/src/test/resources/org/eolang/lints/packs/single/test-without-assert/allows-side-effect-test.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-without-assert/allows-side-effect-test.yaml
@@ -7,6 +7,7 @@ asserts:
   - /defects[count(defect[@severity='warning'])=0]
 input: |
   [] > foo
+
     [] +> prints-hello-world
       stdout > @
         "Hello, world"

--- a/src/test/resources/org/eolang/lints/packs/single/test-without-assert/allows-side-effect-test.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-without-assert/allows-side-effect-test.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/test-without-assert.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [] > foo
+    [] +> prints-hello-world
+      stdout > @
+        "Hello, world"

--- a/src/test/resources/org/eolang/lints/packs/single/test-without-assert/allows-test-with-assert.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-without-assert/allows-test-with-assert.yaml
@@ -7,6 +7,7 @@ asserts:
   - /defects[count(defect[@severity='warning'])=0]
 input: |
   [] > foo
+
     [] +> checks-something
       eq. > @
         42

--- a/src/test/resources/org/eolang/lints/packs/single/test-without-assert/allows-test-with-assert.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-without-assert/allows-test-with-assert.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/test-without-assert.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [] > foo
+    [] +> checks-something
+      eq. > @
+        42
+        42

--- a/src/test/resources/org/eolang/lints/packs/single/test-without-assert/catches-test-without-assert.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-without-assert/catches-test-without-assert.yaml
@@ -7,5 +7,6 @@ asserts:
   - /defects[count(defect[@severity='warning'])=1]
 input: |
   [] > foo
+
     [] +> checks-something
       52 > @

--- a/src/test/resources/org/eolang/lints/packs/single/test-without-assert/catches-test-without-assert.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-without-assert/catches-test-without-assert.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/test-without-assert.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+input: |
+  [] > foo
+    [] +> checks-something
+      52 > @


### PR DESCRIPTION
fix #407

## What

A new `tests/test-without-assert` lint that reports unit tests whose `@`
attribute is just a literal — i.e. tests that assert nothing.

## Why

A test like this:

```eo
[] +> checks-something
  52 > @
```

passes no matter what the code does, so it can never catch a regression.
It tests nothing.

## How it works

The lint walks test objects (`eo:test-name`, i.e. `+`/`-` prefixed names)
and checks their `φ` (`@`) attribute. If `φ` is one of the literal bases
(`Φ.number`, `Φ.string`, `Φ.bytes`, `Φ.bool`), there is no assertion and
the test is reported as a `warning`.

The heuristic answers @yegor256's question about the formal definition of
an "assertion": the simplest provable case is a bare literal — a test that
just returns a value with no comparison, no application, no side effect.
Tests that call anything (an `eq`, a `stdout`, any application) have a
non-literal `φ` and are left alone. This keeps the check conservative:
no false positives, at the cost of only catching the clearest offenders.

## Tests

- `catches-test-without-assert` — `52 > @` is flagged
- `allows-test-with-assert` — `eq. > @` is clean
- `allows-side-effect-test` — `stdout > @` is clean (conservative)

Both `mvn test` (593 tests) and `mvn clean install -Pqulice` pass.
