### PR TITLE
fix(#536): increase download timeout to 60s

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -652,6 +652,7 @@
                   <outputDirectory>${project.build.directory}/downloaded</outputDirectory>
                   <outputFileName>home.zip</outputFileName>
                   <skipCache>true</skipCache>
+                  <readTimeOut>60000</readTimeOut>
                 </configuration>
               </execution>
             </executions>
@@ -830,6 +831,7 @@
               <url>https://opennlp.sourceforge.net/models-1.5/en-pos-perceptron.bin</url>
               <outputFileName>en-pos-perceptron.bin</outputFileName>
               <outputDirectory>${project.build.directory}/classes</outputDirectory>
+              <readTimeOut>60000</readTimeOut>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
fix #536

## What

Increases the file download timeout for `download-maven-plugin` in both
wget executions.

## Why

The plugin's `readTimeOut` defaults to 3000 ms, which frequently caused
CI crashes when downloading `home.zip` (the `download-home` execution)
and `en-pos-perceptron.bin` (the `download-model` execution). Bumping it
to 60 seconds removes these flaky failures.

## Changes

Added `<readTimeOut>60000</readTimeOut>` to:
- `pom.xml` — the `download-home` execution (objectionary/home archive);
- `pom.xml` — the `download-model` execution (OpenNLP POS model).

`mvn clean install -Pqulice` passes (590 tests).
