### PR TITLE
fix(#586): accumulate and validate without() names

### DIFF
--- a/src/main/java/org/eolang/lints/Source.java
+++ b/src/main/java/org/eolang/lints/Source.java
@@ -10,7 +10,10 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import org.cactoos.iterable.Sticky;
 import org.cactoos.iterable.Synced;
 
@@ -41,6 +44,11 @@ public final class Source {
     private final Iterable<Lint> lints;
 
     /**
+     * Disabled lint names.
+     */
+    private final Collection<String> disabled;
+
+    /**
      * Ctor.
      * @param file The absolute path of the XMIR file
      * @throws FileNotFoundException If file isn't found
@@ -67,17 +75,47 @@ public final class Source {
      * @param list The lints
      */
     Source(final XML xml, final Iterable<Lint> list) {
+        this(xml, list, new ArrayList<>(0));
+    }
+
+    /**
+     * Ctor.
+     * @param xml The XMIR
+     * @param list The lints
+     * @param names Disabled lint names
+     */
+    private Source(final XML xml, final Iterable<Lint> list, final Collection<String> names) {
         this.xmir = xml;
         this.lints = list;
+        this.disabled = names;
     }
 
     /**
      * Source with disabled lints.
-     * @param names Lint names
-     * @return Program analysis without specific name
+     * @param first Lint name to disable
+     * @param rest Lint names to disable
+     * @return Program analysis without specific names
      */
-    public Source without(final String... names) {
-        return new org.eolang.lints.Source(this.xmir, new MonoWithout(names));
+    public Source without(final String first, final String... rest) {
+        final Collection<String> names = new ArrayList<>(this.disabled);
+        names.add(first);
+        names.addAll(Arrays.asList(rest));
+        final Set<String> known = new HashSet<>(0);
+        for (final Lint lint : new PkMono()) {
+            known.add(lint.name());
+        }
+        for (final String name : names) {
+            if (!known.contains(name)) {
+                throw new IllegalArgumentException(
+                    String.format("Unknown lint name: %s", name)
+                );
+            }
+        }
+        return new org.eolang.lints.Source(
+            this.xmir,
+            new MonoWithout(names.toArray(new String[0])),
+            names
+        );
     }
 
     /**

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -204,7 +204,7 @@ final class SourceTest {
     void createsSourceWithoutMultipleLints() {
         final Collection<String> disabled = List.of(
             "ascii-only",
-            "object-does-not-match-filename",
+            "sparse-seq",
             "comment-not-capitalized",
             "empty-object",
             "mandatory-home",
@@ -219,7 +219,10 @@ final class SourceTest {
             "Defects for disabled lints are not empty, but should be",
             new Source(
                 new EoProgram("org/eolang/lints/non-ascii-cyrillic.eo").parse()
-            ).without(disabled.toArray(new String[0])).defects().stream()
+            ).without(
+                disabled.iterator().next(),
+                disabled.stream().skip(1).toArray(String[]::new)
+            ).defects().stream()
                 .filter(defect -> disabled.contains(defect.rule()))
                 .collect(Collectors.toList()),
             Matchers.emptyIterable()
@@ -261,6 +264,32 @@ final class SourceTest {
                 .filter(defect -> defect.rule().startsWith("unlint-non-existing-defect"))
                 .collect(Collectors.toList()),
             Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void accumulatesWithoutCalls() {
+        final Collection<Defect> defects = new Source(
+            new EoProgram("org/eolang/lints/non-ascii-cyrillic.eo").parse()
+        ).without("mandatory-home").without("mandatory-version").defects();
+        MatcherAssert.assertThat(
+            String.format(
+                "Disabled lints from both without() calls must stay disabled, got: %s",
+                defects
+            ),
+            defects.stream().map(Defect::rule).collect(Collectors.toList()),
+            Matchers.not(Matchers.hasItems("mandatory-home", "mandatory-version"))
+        );
+    }
+
+    @Test
+    void rejectsUnknownLintName() {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new Source(
+                new EoProgram("org/eolang/lints/foo-without-dot.eo").parse()
+            ).without("no-such-lint"),
+            "Unknown lint name must be rejected"
         );
     }
 


### PR DESCRIPTION
fix #586

## What

Fixes the strange behavior of `Source.without()`:

1. **Accumulation** — chained calls now combine:
   `without("a").without("b")` disables both `a` and `b`, instead of the
   last call silently overriding the previous one.
2. **Validation** — passing a lint name that does not exist now throws
   `IllegalArgumentException` instead of silently doing nothing.
3. **Signature** — `without(String first, String... rest)` requires at
   least one argument, so `without()` with no arguments is impossible.

## How

`Source` now keeps a `disabled` collection of lint names. Each `without()`
call appends to it, so the accumulated set is passed to `MonoWithout`.
Before constructing the new `Source`, every requested name is checked
against the full set of known lint names (from `PkMono`); an unknown name
throws.

Note: the existing test `createsSourceWithoutMultipleLints` referenced the
lint `object-does-not-match-filename`, which no longer exists in the
codebase — the validation rightfully rejects it, so the test now uses a
real lint name (`sparse-seq`) instead.

## Tests

- `accumulatesWithoutCalls` — two chained `without()` calls both take effect
- `rejectsUnknownLintName` — an unknown name throws `IllegalArgumentException`
- existing `without`-related tests updated for the new signature

Both `mvn test` (592 tests) and `mvn clean install -Pqulice` pass.
