### PR TITLE
feat(#592): enable redundant-object in benchmarks

### DIFF
--- a/src/test/java/benchmarks/SourceBench.java
+++ b/src/test/java/benchmarks/SourceBench.java
@@ -40,15 +40,10 @@ public class SourceBench {
      * Benchmark for XMIR scanning.
      * Scans XMIR.
      * @param state State
-     * @todo #376:60min Enable redundant object in the single XMIR scope benchmarks.
-     *  As for now, the lint is too slow, especially on L, XL and XXL-sized XMIRs.
-     *  This happens mostly because of multiple XPath `//o` selects in the XSL. Once,
-     *  the lint will be optimized, we can enable the lint in the benchmarks.
      */
     @Benchmark
     public final void scansXmir(final BenchmarkState state) {
-        new Source(state.xmir).without("redundant-object")
-            .defects();
+        new Source(state.xmir).defects();
     }
 
     /**


### PR DESCRIPTION
fix #592

## What

Enables the `redundant-object` lint in the single-XMIR-scope benchmark
(`SourceBench.scansXmir`), resolving the `@todo #376:60min` puzzle.

## Why

The puzzle asked to re-enable `redundant-object` in the benchmarks once
the lint is optimized. The optimization landed in commit `501273ee`
(`perf(#975): optimize redundant-object lint with XSLT key index`), which
replaced the repeated XPath `//o` selects with an `xsl:key` index. This
change removes the `.without("redundant-object")` workaround so the
benchmark measures the real, optimized behavior.

## Verification

`mvn jmh:benchmark` passes. Results (AverageTime, ms/op):
S 1.3, M 8.8, L 30.2, XL 38.6, XXL 183.2. The lint still triggers a
`MeasuredXsl` warning on the largest (XXL) inputs in warmup, which is
expected for big XMIRs and is not a failure.
