### PR TITLE
fix(#602): split HomeNames by SRP

### DIFF
--- a/src/main/groovy/org/eolang/lints/HomeNames.groovy
+++ b/src/main/groovy/org/eolang/lints/HomeNames.groovy
@@ -4,47 +4,19 @@
  */
 package org.eolang.lints
 
-import com.github.lombrozo.xnav.Xnav
-import com.jcabi.xml.XML
 import com.yegor256.tojos.MnCsv
 import com.yegor256.tojos.TjCached
 import com.yegor256.tojos.TjDefault
 import com.yegor256.tojos.TjSynchronized
 import com.yegor256.tojos.Tojos
-import java.nio.file.FileSystem
-import java.nio.file.FileSystems
-import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.function.Predicate
-import java.util.regex.Pattern
-import java.util.stream.Stream
-import org.cactoos.io.InputOf
-import org.cactoos.io.UncheckedInput
-import org.cactoos.list.ListOf
-import org.cactoos.text.TextOf
-import org.eolang.parser.EoSyntax
 
 /**
- * Home object names in the CSV file.
+ * Home object names placed into the CSV file.
  * @since 0.0.49
- * @todo #465:45min Refactor HomeNames.
- *  Currently, the class does two things: 1) Object name parsing, and 2) CSV placing.
- *  Let's refactor it to make it aligned with <a href="https://en.wikipedia.org/wiki/Single-responsibility_principle">SRP</a>.
- *  Probably one new class will be required (for name parsing), together with proper
- *  naming of this one (for placing them into CSV).
  */
 final class HomeNames {
-
-/**
- * Home objects regex.
- */
-  private static final Pattern HOME_OBJECTS = Pattern.compile(".*/downloaded/home/objects")
-
-  /**
-   * Non-unix file separators.
-   */
-  private static final Pattern NON_UNIX = Pattern.compile("\\\\")
 
   /**
    * Reserved store.
@@ -52,7 +24,7 @@ final class HomeNames {
   private final Tojos placed
 
   /**
-   * Home objects location
+   * Home objects location.
    */
   private final String location
 
@@ -66,7 +38,7 @@ final class HomeNames {
 
   /**
    * Ctor.
-   * @param Home objects location
+   * @param hloc Home objects location
    */
   HomeNames(final String hloc) {
     this("target/classes/reserved.csv", hloc)
@@ -97,115 +69,17 @@ final class HomeNames {
    */
   HomeNames(final Tojos tjs, final String hloc) {
     this.placed = tjs
-    this.location = hloc;
+    this.location = hloc
   }
 
   /**
    * Place them into CSV file.
-   * Here, we are receiving names from either JAR or normal file depending, where the source of home
-   * objects is located. When `lints` used as a dependency, home repo is accessed from JAR, while,
-   * in local tests, we use read as normal file on disk.
-   * Both methods: {@link HomeNames#namesInJar} and {@link HomeNames#namesInFile} depend on
-   * the same directory, which we pass in the ctor, the only difference in the term of access - for
-   * JAR we need to "mount" the file system using {@link FileSystem}.
    */
   void placeCsv() {
-    final List<Map<String, String>> names = new ListOf<>()
-    final URL resource = Thread.currentThread().contextClassLoader.getResource(this.location)
-    final Predicate<Path> sources = p -> {
-      final String file = p.toString().replace("\\", "/")
-      return file.endsWith(".eo")
-        && file.contains(
-        Path.of(this.location)
-          .resolve("objects")
-          .toString().replace("\\", "/")
-      )
-    }
-    if ("jar" == resource.protocol) {
-      final URI uri = URI.create(
-        "jar:file:${resource.file.substring(5, resource.file.indexOf('!'))}",
-      )
-      try (
-        FileSystem mount = FileSystems.newFileSystem(uri, Collections.emptyMap())
-        Stream<Path> paths = Files.walk(mount.getPath(this.location))
-      ) {
-        paths.filter(sources)
-          .forEach(eo -> names.add(namesInJar(eo)))
-      } catch (final IOException exception) {
-        throw new IllegalStateException(
-          "Failed to read home objects from JAR", exception
-        )
-      }
-    } else {
-      try (Stream<Path> paths = Files.walk(Paths.get(resource.toURI()))) {
-        paths.filter(sources)
-          .forEach(eo -> names.add(namesInFile(eo)))
-      } catch (final IOException exception) {
-        throw new IllegalStateException("Failed to walk through files", exception)
-      } catch (final URISyntaxException exception) {
-        throw new IllegalStateException("URI syntax is broken", exception)
-      }
-    }
-    names.stream()
+    new HomeObjects(this.location).read().stream()
       .flatMap(map -> map.entrySet().stream())
       .forEach(
         entry -> this.placed.add(entry.key).set("path", entry.value)
       )
-  }
-
-  /**
-   * Names in EO file.
-   * @param path Path to EO file
-   * @return Map of names, the key is object name, the value us path
-   */
-  private static Map<String, String> namesInFile(final Path path) {
-    final XML parsed
-    try {
-      parsed = new EoSyntax(new UncheckedInput(new InputOf(path.toFile())))
-        .parsed()
-    } catch (final IOException exception) {
-      throw new IllegalStateException("Failed to parse EO source in \"${path}\"", exception)
-    }
-    return namesInXmir(parsed, path)
-  }
-
-  /**
-   * Names in EO file from JAR.
-   * @param path Path to EO file in JAR
-   * @return Map of names, the key is object name, the value us path
-   * @checkstyle IllegalCatchCheck (15 lines)
-   */
-  @SuppressWarnings("PMD.AvoidCatchingGenericException")
-  private static Map<String, String> namesInJar(final Path path) {
-    final XML parsed
-    try (InputStream input = Files.newInputStream(path)) {
-      parsed = new EoSyntax(new TextOf(input).asString()).parsed()
-    } catch (final Exception exception) {
-      throw new IllegalStateException("Failed to parse EO source in \"${path}\"", exception)
-    }
-    return namesInXmir(parsed, path)
-  }
-
-  /**
-   * High-level object names in XMIR.
-   * @param xmir XMIR
-   * @param path EO source file path
-   * @return Map of object names in XMIR
-   */
-  private static Map<String, String> namesInXmir(final XML xmir, final Path path) {
-    final Map<String, String> names = new HashMap<>(64)
-    new Xnav(xmir.inner()).path("/object/o/@name")
-      .map(oname -> oname.text().get())
-      .forEach(
-        oname ->
-          names[oname] = HOME_OBJECTS.matcher(
-            NON_UNIX.matcher(path.toString()).replaceAll("/")
-          )
-            .replaceFirst("")
-            .substring(1)
-            .replace("/", ".")
-            .replace("\"", ".")
-      )
-    return names
   }
 }

--- a/src/main/groovy/org/eolang/lints/HomeObjects.groovy
+++ b/src/main/groovy/org/eolang/lints/HomeObjects.groovy
@@ -1,0 +1,155 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints
+
+import com.github.lombrozo.xnav.Xnav
+import com.jcabi.xml.XML
+import java.nio.file.FileSystem
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.function.Predicate
+import java.util.regex.Pattern
+import java.util.stream.Stream
+import org.cactoos.io.InputOf
+import org.cactoos.io.UncheckedInput
+import org.cactoos.list.ListOf
+import org.cactoos.text.TextOf
+import org.eolang.parser.EoSyntax
+
+/**
+ * Object names parsed from the home repository.
+ * @since 0.0.49
+ */
+final class HomeObjects {
+
+  /**
+   * Home objects regex.
+   */
+  private static final Pattern HOME_OBJECTS = Pattern.compile(".*/downloaded/home/objects")
+
+  /**
+   * Non-unix file separators.
+   */
+  private static final Pattern NON_UNIX = Pattern.compile("\\\\")
+
+  /**
+   * Home objects location.
+   */
+  private final String location
+
+  /**
+   * Ctor.
+   * @param hloc Home objects location
+   */
+  HomeObjects(final String hloc) {
+    this.location = hloc
+  }
+
+  /**
+   * Object names from the home repository, keyed by object name,
+   * the value is the relative path to the EO file.
+   * Here, we are receiving names from either JAR or normal file depending, where the source of home
+   * objects is located. When `lints` used as a dependency, home repo is accessed from JAR, while,
+   * in local tests, we use read as normal file on disk.
+   * @return Object names
+   */
+  List<Map<String, String>> read() {
+    final List<Map<String, String>> names = new ListOf<>()
+    final URL resource = Thread.currentThread().contextClassLoader.getResource(this.location)
+    final Predicate<Path> sources = p -> {
+      final String file = p.toString().replace("\\", "/")
+      return file.endsWith(".eo")
+        && file.contains(
+        Path.of(this.location)
+          .resolve("objects")
+          .toString().replace("\\", "/")
+      )
+    }
+    if ("jar" == resource.protocol) {
+      final URI uri = URI.create(
+        "jar:file:${resource.file.substring(5, resource.file.indexOf('!'))}",
+      )
+      try (
+        FileSystem mount = FileSystems.newFileSystem(uri, Collections.emptyMap())
+        Stream<Path> paths = Files.walk(mount.getPath(this.location))
+      ) {
+        paths.filter(sources)
+          .forEach(eo -> names.add(HomeObjects.namesInJar(eo)))
+      } catch (final IOException exception) {
+        throw new IllegalStateException(
+          "Failed to read home objects from JAR", exception
+        )
+      }
+    } else {
+      try (Stream<Path> paths = Files.walk(Paths.get(resource.toURI()))) {
+        paths.filter(sources)
+          .forEach(eo -> names.add(HomeObjects.namesInFile(eo)))
+      } catch (final IOException exception) {
+        throw new IllegalStateException("Failed to walk through files", exception)
+      } catch (final URISyntaxException exception) {
+        throw new IllegalStateException("URI syntax is broken", exception)
+      }
+    }
+    return names
+  }
+
+  /**
+   * Names in EO file.
+   * @param path Path to EO file
+   * @return Map of names, the key is object name, the value is path
+   */
+  private static Map<String, String> namesInFile(final Path path) {
+    final XML parsed
+    try {
+      parsed = new EoSyntax(new UncheckedInput(new InputOf(path.toFile())))
+        .parsed()
+    } catch (final IOException exception) {
+      throw new IllegalStateException("Failed to parse EO source in \"${path}\"", exception)
+    }
+    return HomeObjects.namesInXmir(parsed, path)
+  }
+
+  /**
+   * Names in EO file from JAR.
+   * @param path Path to EO file in JAR
+   * @return Map of names, the key is object name, the value is path
+   * @checkstyle IllegalCatchCheck (15 lines)
+   */
+  @SuppressWarnings("PMD.AvoidCatchingGenericException")
+  private static Map<String, String> namesInJar(final Path path) {
+    final XML parsed
+    try (InputStream input = Files.newInputStream(path)) {
+      parsed = new EoSyntax(new TextOf(input).asString()).parsed()
+    } catch (final Exception exception) {
+      throw new IllegalStateException("Failed to parse EO source in \"${path}\"", exception)
+    }
+    return HomeObjects.namesInXmir(parsed, path)
+  }
+
+  /**
+   * High-level object names in XMIR.
+   * @param xmir XMIR
+   * @param path EO source file path
+   * @return Map of object names in XMIR
+   */
+  private static Map<String, String> namesInXmir(final XML xmir, final Path path) {
+    final Map<String, String> names = new HashMap<>(64)
+    new Xnav(xmir.inner()).path("/object/o/@name")
+      .map(oname -> oname.text().get())
+      .forEach(
+        oname ->
+          names[oname] = HOME_OBJECTS.matcher(
+            NON_UNIX.matcher(path.toString()).replaceAll("/")
+          )
+            .replaceFirst("")
+            .substring(1)
+            .replace("/", ".")
+            .replace("\"", ".")
+      )
+    return names
+  }
+}


### PR DESCRIPTION
fix #602

## What

Refactors `HomeNames` per the `@todo #465:45min` puzzle: the class did
two things — parsing object names from the home repository, and placing
them into the CSV file. It now follows the Single Responsibility
Principle.

## Changes

- New class `HomeObjects` — parses object names from the home repository
  (walking JAR or filesystem, parsing each EO file via `EoSyntax`, reading
  top-level object names from XMIR). Its `read()` returns
  `List<Map<String, String>>`.
- `HomeNames` — now only places the parsed names into the CSV (`Tojos`).
  `placeCsv()` delegates to `HomeObjects.read()` and writes the entries.

The public contract is unchanged: `new HomeNames(...).placeCsv()` still
produces the same `reserved.csv`. `ReserveNames.groovy` and
`HomeNamesTest` are untouched.

## Verification

- `mvn test-compile` — compiles
- `mvn clean -Pqulice` — clean
- `mvn clean install -Pqulice` — 590 tests pass; the two `@Tag("reserved")`
  `HomeNamesTest` cases run in CI where the home repo is present.
