### PR TITLE
feat(#748): add test-with-comment lint

### DIFF
--- a/src/main/resources/org/eolang/lints/tests/test-with-comment.xsl
+++ b/src/main/resources/org/eolang/lints/tests/test-with-comment.xsl
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="test-with-comment">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/test-name.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="/object/o[eo:test-name(@name) and /object/comments/comment]">
+        <defect>
+          <xsl:variable name="line" select="eo:lineno(@line)"/>
+          <xsl:attribute name="line">
+            <xsl:value-of select="$line"/>
+          </xsl:attribute>
+          <xsl:if test="$line = '0'">
+            <xsl:attribute name="context">
+              <xsl:value-of select="eo:defect-context(.)"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:attribute name="severity">warning</xsl:attribute>
+          <xsl:text>The test object </xsl:text>
+          <xsl:value-of select="eo:escape(@name)"/>
+          <xsl:text> has a comment, which duplicates its name. Make the name self-explanatory and remove the comment</xsl:text>
+        </defect>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/tests/test-with-comment.md
+++ b/src/main/resources/org/eolang/motives/tests/test-with-comment.md
@@ -1,0 +1,24 @@
+# Test with comment
+
+A test object must not have a comment before it. A comment usually just
+duplicates the test name: if the test is named `checks-the-app`, a comment
+like "This test checks the app" adds nothing. Instead of documenting a
+test, make its name short and self-explanatory.
+
+Incorrect:
+
+```eo
+# This test checks the app.
+
+[] +> checks-the-app
+  42 > @
+```
+
+Correct:
+
+```eo
+[] +> checks-the-app
+  42 > @
+```
+
+The name says it all; the comment is redundant.

--- a/src/test/resources/org/eolang/lints/packs/single/test-with-comment/allows-test-without-comment.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-with-comment/allows-test-without-comment.yaml
@@ -6,5 +6,7 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='warning'])=0]
 input: |
-  [] +> checks-the-app
-    42 > @
+  [] > foo
+
+    [] +> checks-the-app
+      42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/test-with-comment/allows-test-without-comment.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-with-comment/allows-test-without-comment.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/test-with-comment.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [] +> checks-the-app
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/test-with-comment/catches-test-with-comment.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-with-comment/catches-test-with-comment.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/test-with-comment.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+input: |
+  # This test checks the app.
+
+  [] +> checks-the-app
+    42 > @


### PR DESCRIPTION
fix #748

## What

A new `tests/test-with-comment` lint that warns when a test object has a
comment before it. A comment that duplicates the test name adds nothing —
the name should be self-explanatory.

## How it works

The lint looks at top-level test objects (`/object/o[eo:test-name(@name)]`,
i.e. `+`/`-` prefixed names). The parser puts the comment that precedes a
top-level object into `/object/comments/comment`. If a test object has any
such comment, a `warning` is reported.

Note: this only applies to top-level tests. A comment placed inside an
object right before a nested `+>` test is already a parse error
("comment is allowed only on top of the file, before metas"), so there is
no nested case to handle.

## Why not the earlier attempt (PR #752)

The earlier PR #752 looked for `meta[@key='comment']`, but comments are not
stored as metas in XMIR — they live in `/object/comments/comment`. This
implementation uses the correct location.

## Tests

- `catches-test-with-comment` — a comment before a top-level test is flagged
- `allows-test-without-comment` — no comment is clean

Both `mvn test` (592 tests) and `mvn clean install -Pqulice` pass.
