### PR TITLE
fix(#769): reduce source test timeouts

### DIFF
--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -62,15 +62,11 @@ import org.objectweb.asm.Opcodes;
 /**
  * Test for {@link Source}.
  * @since 0.0.1
- * @todo #767:60min Decrease timeouts for source linting.
- *  As for now, most lints are too slow, we need to optimize them first, so they
- *  run in milliseconds, not seconds/minutes. It should decrease our build time too.
- *  After that, we need to decrease our test timeouts. Don't forget to remove this puzzle.
  */
 @ExtendWith(MktmpResolver.class)
 final class SourceTest {
 
-    @Timeout(unit = TimeUnit.SECONDS, value = 60L)
+    @Timeout(unit = TimeUnit.SECONDS, value = 30L)
     @Test
     void returnsEmptyListOfDefects() {
         MatcherAssert.assertThat(
@@ -164,7 +160,7 @@ final class SourceTest {
      *  `+unlint redundant-attachment`.
      */
     @Test
-    @Timeout(60L)
+    @Timeout(30L)
     void acceptsCanonicalCode() {
         final XML xmir = new EoProgram(
             "org/eolang/lints/canonical.eo"


### PR DESCRIPTION
fix #769

## What

Reduces the source linting test timeouts, resolving the `@todo #767:60min`
puzzle.

## Why

The puzzle asked to optimize the lints so they run in milliseconds (not
seconds/minutes) and then lower the test timeouts. The lints have since
been optimized (e.g. `perf(#975): optimize redundant-object lint with XSLT
key index` and #1135), and the CI builds have been fast and green for
weeks (recent `mvn` runs complete in 4-8 minutes). The original timeout
failures reported in #863 are no longer reproducible.

## Changes

In `SourceTest.java`:
- `returnsEmptyListOfDefects`: `@Timeout(60)` → `@Timeout(30)` (runs in ~1s)
- `acceptsCanonicalCode`: `@Timeout(60)` → `@Timeout(30)` (whole class runs
  in ~9s)
- removed the `@todo #767` puzzle text

The `@Timeout(600)` benchmark is left untouched (it runs under
`@Tag("benchmark")`, not in regular builds).

Both `mvn test` (590 tests) and `mvn clean install -Pqulice` pass.
