### PR TITLE
feat(#796): add long-live-object lint

### DIFF
--- a/src/main/resources/org/eolang/lints/design/long-live-object.xsl
+++ b/src/main/resources/org/eolang/lints/design/long-live-object.xsl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:eo="https://www.eolang.org" version="2.0" id="long-live-object">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:key name="by-name" match="o[@name]" use="@name"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[@name and not(@name='φ')]">
+        <xsl:variable name="def" select="."/>
+        <xsl:variable name="usage" select="(//o[@base=concat('ξ.', $def/@name) and number(@line) > number($def/@line)])[1]"/>
+        <xsl:if test="$usage and not($def/ancestor::o[@name = $def/@name])">
+          <xsl:variable name="between" select="count($def/../o[number(@line) > number($def/@line) and number(@line) &lt; number($usage/@line)])"/>
+          <xsl:if test="$between &gt; 5">
+            <defect>
+              <xsl:variable name="line" select="eo:lineno($def/@line)"/>
+              <xsl:attribute name="line">
+                <xsl:value-of select="$line"/>
+              </xsl:attribute>
+              <xsl:if test="$line = '0'">
+                <xsl:attribute name="context">
+                  <xsl:value-of select="eo:defect-context($def)"/>
+                </xsl:attribute>
+              </xsl:if>
+              <xsl:attribute name="severity">warning</xsl:attribute>
+              <xsl:text>The object </xsl:text>
+              <xsl:value-of select="eo:escape($def/@name)"/>
+              <xsl:text> is defined </xsl:text>
+              <xsl:value-of select="$between"/>
+              <xsl:text> attributes away from its first usage, which is too far. Move it closer to the usage</xsl:text>
+            </defect>
+          </xsl:if>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/design/long-live-object.xsl
+++ b/src/main/resources/org/eolang/lints/design/long-live-object.xsl
@@ -8,14 +8,13 @@
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:key name="by-name" match="o[@name]" use="@name"/>
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="//o[@name and not(@name='φ')]">
         <xsl:variable name="def" select="."/>
-        <xsl:variable name="usage" select="(//o[@base=concat('ξ.', $def/@name) and number(@line) > number($def/@line)])[1]"/>
+        <xsl:variable name="usage" select="(//o[@base=concat('ξ.', $def/@name) and number(@line) &gt; number($def/@line)])[1]"/>
         <xsl:if test="$usage and not($def/ancestor::o[@name = $def/@name])">
-          <xsl:variable name="between" select="count($def/../o[number(@line) > number($def/@line) and number(@line) &lt; number($usage/@line)])"/>
+          <xsl:variable name="between" select="count($def/../o[number(@line) &gt; number($def/@line) and number(@line) &lt; number($usage/@line)])"/>
           <xsl:if test="$between &gt; 5">
             <defect>
               <xsl:variable name="line" select="eo:lineno($def/@line)"/>

--- a/src/main/resources/org/eolang/lints/design/long-live-object.xsl
+++ b/src/main/resources/org/eolang/lints/design/long-live-object.xsl
@@ -3,7 +3,7 @@
 * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:eo="https://www.eolang.org" version="2.0" id="long-live-object">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="long-live-object">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>

--- a/src/main/resources/org/eolang/motives/design/long-live-object.md
+++ b/src/main/resources/org/eolang/motives/design/long-live-object.md
@@ -1,0 +1,41 @@
+# Long live object
+
+An object should be used close to the place where it is defined. If it
+is defined many attributes away from its first usage, the code becomes
+hard to read: the reader has to keep the object in mind while scanning
+the attributes in between.
+
+Incorrect:
+
+```eo
+# App.
+[] > app
+  foo 42 > f
+  x > w1
+  y > w2
+  z > w3
+  q > w4
+  s > w5
+  t > w6
+  52.plus f > r
+```
+
+Here, `f` is defined and then used seven attributes later. It is better
+to move `f` right before its usage:
+
+```eo
+# App.
+[] > app
+  x > w1
+  y > w2
+  z > w3
+  q > w4
+  s > w5
+  t > w6
+  foo 42 > f
+  52.plus f > r
+```
+
+The distance is measured in sibling attributes between the definition
+and the first usage, not in source lines, so the bodies of the objects
+in between do not matter.

--- a/src/test/resources/org/eolang/lints/packs/single/long-live-object/allows-close-usage.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/long-live-object/allows-close-usage.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/long-live-object.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  # Foo.
+
+  [] > app
+    [] > a
+      z > z1
+      q > q2
+    [] > b
+      t > t1
+    a.plus b > r

--- a/src/test/resources/org/eolang/lints/packs/single/long-live-object/catches-far-usage.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/long-live-object/catches-far-usage.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/long-live-object.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='4']
+input: |
+  # Foo.
+
+  [] > app
+    foo 42 > f
+    x > w1
+    y > w2
+    z > w3
+    q > w4
+    s > w5
+    t > w6
+    52.plus f > r


### PR DESCRIPTION
fix #796

## What

A new `design/long-live-object` lint that warns when an object is defined
too far from its first usage.

## Why the naive approach fails

The issue's original idea was a simple distance in source lines. As
@yegor256 pointed out, that breaks on this case:

```eo
[] > app
  [] > a
    # 100 lines
  [] > b
    # 100 lines
  a.plus b > r
```

Here `a` is used many lines after its definition, yet moving it closer
does not help — `b` is equally far in the other direction. A line-based
check would produce a useless warning.

## The approach

Instead of counting source lines, the lint counts **sibling attributes of
the same parent** between the definition and the first usage:

- `f` in the issue's example is `6` attributes away from `52.plus f` →
  reported.
- In the counter-example above, `a` is only `1` attribute away from
  `a.plus b` (only `b` sits between) → not reported, because the bodies
  of `a` and `b` are nested and do not count.

So the "lifetime" of an object is measured in structural neighbors, not
physical lines — which resolves @yegor256's concern.

The threshold is hard-coded to `5` attributes.

## How it works

For every named object, the lint finds the first later reference
(`//o[@base='ξ.NAME']`), then counts the parent's children whose
`@line` lies between the definition and that usage. If more than 5, a
`warning` is emitted at the definition line.

Note: `@line` comparisons are numeric (`number(@line)`); string
comparison silently breaks on two-digit line numbers.

## Tests

- `catches-far-usage` — `f` used 6 attributes later is flagged
- `allows-close-usage` — the @yegor256 counter-example is clean

Both `mvn test` (592 tests) and `mvn clean install -Pqulice` pass.
