### PR TITLE
fix(#1261): stop redundant-attachment from contradicting anonymous-formation

### DIFF
--- a/src/main/resources/org/eolang/funcs/outer-refs.xsl
+++ b/src/main/resources/org/eolang/funcs/outer-refs.xsl
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="outer-refs" version="2.0">
+  <!--
+  The name a "ξ.ρ."-based reference resolves to, with the "ξ" and the
+  chain of "ρ" hops that lead out of the formation stripped away.
+  -->
+  <xsl:function name="eo:base-to-name" as="xs:string">
+    <xsl:param name="base" as="xs:string"/>
+    <xsl:value-of select="replace($base, '^ξ(\.ρ)+\.', '')"/>
+  </xsl:function>
+  <!--
+  The objects a formation reads from the scope that encloses it: every
+  "ξ.ρ."-based reference in its body that neither its own voids nor its own
+  bound attributes cover. When this is empty, the formation stands on its
+  own and makes sense without a name and without an enclosing scope. Both
+  "anonymous-formation" and "redundant-attachment" judge a formation by
+  this very set, from opposite sides, so they share it here.
+  -->
+  <xsl:function name="eo:outer-refs" as="element()*">
+    <xsl:param name="formation" as="element()"/>
+    <xsl:variable name="allowed" as="xs:string*">
+      <xsl:for-each select="$formation/o[@base='∅']">
+        <xsl:sequence select="concat('ξ(\.ρ)+\.', @name, '(?:\.\w+)?')"/>
+      </xsl:for-each>
+    </xsl:variable>
+    <xsl:for-each select="$formation//o[starts-with(@base, 'ξ.ρ.') and not(some $pattern in $allowed satisfies matches(@base, $pattern))]">
+      <xsl:variable name="name" select="eo:base-to-name(@base)"/>
+      <xsl:if test="not($formation/o[@name = $name])">
+        <xsl:sequence select="."/>
+      </xsl:if>
+    </xsl:for-each>
+  </xsl:function>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/misc/redundant-attachment.xsl
+++ b/src/main/resources/org/eolang/lints/misc/redundant-attachment.xsl
@@ -3,17 +3,35 @@
 * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="redundant-attachment" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="redundant-attachment" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:import href="/org/eolang/funcs/outer-refs.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:key name="referenced-by-auto-name" match="o[@base]" use="if (matches(@base, '^ξ(?:\.ρ)*\.')) then tokenize(replace(@base, '^ξ(?:\.ρ)*\.', ''), '\.')[1] else ''"/>
+  <!--
+  The ".as-bytes" wrapper the parser builds around a nameless "!" const
+  argument, such as the "m!" in "m.plus m!". Its auto-name comes from the
+  parser, not from a "&gt;&gt;" in the source, so there is no suffix to delete
+  and the warning could not be acted upon.
+  -->
+  <xsl:function name="eo:const-wrapper" as="xs:boolean">
+    <xsl:param name="object" as="element()"/>
+    <xsl:sequence select="$object/@base='.as-bytes' and exists($object/o[@base='Φ.dataized'])"/>
+  </xsl:function>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[@name and matches(@name, '^a🌵[0-9]+-[0-9]+$')]">
+      <xsl:for-each select="//o[@name and matches(@name, '^a🌵[0-9]+-[0-9]+$') and not(eo:const-wrapper(.))]">
         <xsl:variable name="refs" select="key('referenced-by-auto-name', @name)"/>
         <xsl:variable name="external" select="$refs except descendant::o"/>
-        <xsl:if test="count($refs)=0 or (count($refs)=1 and count($external)=1 and not($external[1]/o) and $external[1]/@as)">
+        <!--
+        Only an object whose body stays within itself can afford to lose the
+        name: dropping the name inlines the object at the single place that
+        refers to it, and a "ξ.ρ."-based reference reaching past its own voids
+        into the enclosing scope would then be flagged by the
+        "anonymous-formation" lint instead. See #1261.
+        -->
+        <xsl:if test="empty(eo:outer-refs(.)) and (count($refs)=0 or (count($refs)=1 and count($external)=1 and not($external[1]/o) and $external[1]/@as))">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/lints/names/anonymous-formation.xsl
+++ b/src/main/resources/org/eolang/lints/names/anonymous-formation.xsl
@@ -3,51 +3,34 @@
 * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:eo="https://www.eolang.org" id="anonymous-formation" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="anonymous-formation" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/outer-refs.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:function name="eo:matches-any-void" as="xs:boolean">
-    <xsl:param name="text" as="xs:string"/>
-    <xsl:param name="patterns" as="xs:string*"/>
-    <xsl:sequence select="some $pattern in $patterns satisfies matches($text, $pattern)"/>
-  </xsl:function>
-  <xsl:function name="eo:base-to-name" as="xs:string">
-    <xsl:param name="base" as="xs:string"/>
-    <xsl:value-of select="replace($base, '^ξ(\.ρ)+\.', '')"/>
-  </xsl:function>
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="//o[not(@name) and not(@base) and not(eo:has-data(.) and parent::o[@base='Φ.bytes'])]">
-        <xsl:variable name="allowed" as="xs:string*">
-          <xsl:for-each select="o[@base='∅']">
-            <xsl:sequence select="concat('ξ(\.ρ)+\.', @name, '(?:\.\w+)?')"/>
-          </xsl:for-each>
-        </xsl:variable>
-        <xsl:variable name="anonymous" select="."/>
-        <xsl:for-each select=".//o[starts-with(@base, 'ξ.ρ.') and not(eo:matches-any-void(@base, $allowed))]">
-          <xsl:variable name="bname" select="eo:base-to-name(@base)"/>
-          <xsl:if test="not($anonymous/o[@name = $bname])">
-            <defect>
-              <xsl:variable name="line" select="eo:lineno(@line)"/>
-              <xsl:attribute name="line">
-                <xsl:value-of select="$line"/>
+        <xsl:for-each select="eo:outer-refs(.)">
+          <defect>
+            <xsl:variable name="line" select="eo:lineno(@line)"/>
+            <xsl:attribute name="line">
+              <xsl:value-of select="$line"/>
+            </xsl:attribute>
+            <xsl:if test="$line = '0'">
+              <xsl:attribute name="context">
+                <xsl:value-of select="eo:defect-context(.)"/>
               </xsl:attribute>
-              <xsl:if test="$line = '0'">
-                <xsl:attribute name="context">
-                  <xsl:value-of select="eo:defect-context(.)"/>
-                </xsl:attribute>
-              </xsl:if>
-              <xsl:attribute name="severity">
-                <xsl:text>warning</xsl:text>
-              </xsl:attribute>
-              <xsl:text>It is not recommended to have anonymous formation accessing undefined object </xsl:text>
-              <xsl:value-of select="eo:escape(eo:base-to-name(@base))"/>
-              <xsl:text> inside the formation</xsl:text>
-            </defect>
-          </xsl:if>
+            </xsl:if>
+            <xsl:attribute name="severity">
+              <xsl:text>warning</xsl:text>
+            </xsl:attribute>
+            <xsl:text>It is not recommended to have anonymous formation accessing undefined object </xsl:text>
+            <xsl:value-of select="eo:escape(eo:base-to-name(@base))"/>
+            <xsl:text> inside the formation</xsl:text>
+          </defect>
         </xsl:for-each>
       </xsl:for-each>
     </defects>

--- a/src/main/resources/org/eolang/motives/misc/redundant-attachment.md
+++ b/src/main/resources/org/eolang/motives/misc/redundant-attachment.md
@@ -44,3 +44,21 @@ or by being called from another part of the same object:
     n.plus 1 > @
   helper 5 > @
 ```
+
+The name is not redundant either when the body reads objects from the scope
+that encloses it, over and above its own voids. Such an object cannot become
+anonymous, because `anonymous-formation` forbids an anonymous formation from
+reaching outside itself. Here `func` comes from `mapped`, not from `[item idx]`,
+so the `>>` stays:
+
+```eo
+[sequence func] > mapped
+  sequence.mapped > @
+    func item > [item idx] >>
+```
+
+An auto-generated name that the parser invents on its own, rather than for a
+`>>` written in the source, is left alone too. The `!` const suffix on a
+nameless argument is such a case: `m.plus m!` makes the parser wrap `m` into
+a named `.as-bytes` over `Φ.dataized`, and no `>>` exists in the source to
+be removed.

--- a/src/main/resources/org/eolang/motives/misc/redundant-attachment.md
+++ b/src/main/resources/org/eolang/motives/misc/redundant-attachment.md
@@ -46,10 +46,10 @@ or by being called from another part of the same object:
 ```
 
 The name is not redundant either when the body reads objects from the scope
-that encloses it, over and above its own voids. Such an object cannot become
+that encloses it, beyond its own voids. Such an object cannot become
 anonymous, because `anonymous-formation` forbids an anonymous formation from
-reaching outside itself. Here `func` comes from `mapped`, not from `[item idx]`,
-so the `>>` stays:
+reaching outside itself. Here `func` comes from `mapped`, not from
+`[item idx]`, so the `>>` stays:
 
 ```eo
 [sequence func] > mapped
@@ -57,8 +57,8 @@ so the `>>` stays:
     func item > [item idx] >>
 ```
 
-An auto-generated name that the parser invents on its own, rather than for a
-`>>` written in the source, is left alone too. The `!` const suffix on a
-nameless argument is such a case: `m.plus m!` makes the parser wrap `m` into
-a named `.as-bytes` over `Φ.dataized`, and no `>>` exists in the source to
-be removed.
+A generated name that the parser invents on its own, rather than for a `>>`
+written in the source, is left alone too. The `!` suffix on a nameless
+argument is such a case: `m.plus m!` makes the parser wrap `m` into a named
+`.as-bytes` over `Φ.dataized`, and no `>>` exists in the source to be
+removed.

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -151,18 +151,6 @@ final class SourceTest {
         );
     }
 
-    /**
-     * Accepts canonical code.
-     * @todo #1101:30min Decide whether canonical.eo should drop the `>>` on
-     *  nested formations like `[i] >>`/`[i1] >>`, or whether
-     *  `redundant-attachment` should gain a documented exception for
-     *  formations that capture outer scope via `^`/`ρ`. The `>>` there is not
-     *  structurally required (parsing and scope resolution work identically
-     *  without it, verified empirically), but it may still be idiomatic for
-     *  closures over outer state. Raise this with the EO language/parser
-     *  maintainers; for now the lint is suppressed on canonical.eo via
-     *  `+unlint redundant-attachment`.
-     */
     @Test
     @Timeout(60L)
     void acceptsCanonicalCode() {

--- a/src/test/resources/org/eolang/lints/canonical.eo
+++ b/src/test/resources/org/eolang/lints/canonical.eo
@@ -6,13 +6,12 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint missed-obfuscation
 +unlint unit-test-missing
-+unlint redundant-attachment
 
 # Times table, which is a canonical example of EO program.
 [start] > canonical
   malloc.for > @
     start
-    [x] >>
+    [x]
       seq > @
         *
           x.put 2

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-attachment/allows-const-wrapper-auto-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-attachment/allows-const-wrapper-auto-name.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/redundant-attachment.xsl
+defects: 0
+input: |
+  [] > foo
+    [m] > bar
+      m.plus m! > @

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-attachment/allows-formation-reading-enclosing-scope.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-attachment/allows-formation-reading-enclosing-scope.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/redundant-attachment.xsl
+defects: 0
+input: |
+  [sequence func] > mapped
+    sequence.mapped > @
+      func item > [item idx] >>

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-attachment/allows-nested-formation-reading-enclosing-scope.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-attachment/allows-nested-formation-reading-enclosing-scope.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/redundant-attachment.xsl
+defects: 0
+input: |
+  [] > app
+    "Hello" > t
+    malloc.of > @
+      64
+      [m] >>
+        io.stdout > @
+          t


### PR DESCRIPTION
Closes #1261.

## The deadlock

`misc/redundant-attachment.xsl:16` flagged every `a🌵N-M` auto-name with no
referrer, asking for the `>>` to go. `names/anonymous-formation.xsl:30` flagged
every unnamed formation reaching into `ξ.ρ.*`, asking for the name back. A
formation that reads its enclosing scope satisfied neither form:

```eo
func item > [item idx] >>   # redundant-attachment: "doesn't need to be named"
func item > [item idx]      # anonymous-formation: "accessing undefined object func"
```

## The fix

The set of objects a formation reads from outside itself — every `ξ.ρ.`-based
reference in its body that neither its own `∅` voids nor its own bound
attributes cover — is now a shared function, `eo:outer-refs`, in the new
`funcs/outer-refs.xsl`. Both lints judge a formation by that same set, from
opposite sides, so they can no longer drift apart:

- `anonymous-formation` iterates it (behaviour unchanged — the inline
  `eo:matches-any-void`/`eo:base-to-name` pair and the nested loop it drove
  collapse into one `for-each`).
- `redundant-attachment` guards on it being empty, which is the qualifier
  `redundant-attachment.md` and #1101 always implied but the XSL never checked:
  a name is removable only when "the body doesn't refer to any objects outside
  it".

The issue's second note is fixed too. The rule fired where the source has no
`>>` at all: `m.plus m!` makes the parser synthesise
`<o name="a🌵N-M" base=".as-bytes">` over `Φ.dataized` for the nameless const
argument, and no suffix existed to delete. `eo:const-wrapper` now recognises
that wrapper and leaves it alone.

## Consequences

`canonical.eo` no longer needs `+unlint redundant-attachment`, which resolves
the `@todo #1101:30min` on `SourceTest.acceptsCanonicalCode` in favour of the
documented exception: the `[i]`/`[i1]` closures over `^.x` keep their `>>`,
and the self-contained `[x]` drops the one it never needed. Verified that
`[x]`'s subtree reaches no further out than `ξ.ρ.x` (its own void), so
inlining it changes nothing it references.

## Tests

Three new packs under `packs/single/redundant-attachment/`, covering the
`mapped.eo` shape, a nested formation reading an outer `t`, and the `m!` const
wrapper. Existing packs for both lints keep their expectations unchanged.

Full suite green (594 tests, 0 failures), plus `qulice`, `xcop`, `reuse` and
`yamllint` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hw5qR8Jk8bJN2EsjPdMWSK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hw5qR8Jk8bJN2EsjPdMWSK)_