### PR TITLE
feat(#797): add syntax version lint

### DIFF
--- a/src/main/java/org/eolang/lints/LtSyntaxVersion.java
+++ b/src/main/java/org/eolang/lints/LtSyntaxVersion.java
@@ -1,0 +1,171 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XML;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Lint that checks the {@code +syntax} meta against the actual EO parser version.
+ *
+ * <p>The {@code +syntax} meta declares the minimum EO version the code requires,
+ * e.g. {@code +syntax 0.59.0}. Comparison is strict: only the numeric
+ * {@code major.minor.patch} core of both versions is compared; pre-release
+ * suffixes and non-SemVer values are ignored (not flagged).</p>
+ *
+ * @since 0.2.11
+ */
+final class LtSyntaxVersion implements Lint {
+
+    @Override
+    public String name() {
+        return "syntax-version";
+    }
+
+    @Override
+    public Collection<Defect> defects(final XML xmir) throws IOException {
+        final Xnav xml = new Xnav(xmir.inner());
+        final Optional<LtSyntaxVersion.Version> actual = xml.path("/object").findFirst()
+            .flatMap(root -> root.attribute("version").text())
+            .flatMap(LtSyntaxVersion.Version::parsed);
+        final Collection<Defect> defects;
+        if (actual.isPresent()) {
+            defects = xml.path("/object/metas/meta[head='syntax']")
+                .map(meta -> LtSyntaxVersion.outdated(meta, actual.get()))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+        } else {
+            defects = Collections.emptyList();
+        }
+        return defects;
+    }
+
+    @Override
+    public String motive() throws IOException {
+        return new MotiveFrom("metas", this.name()).asString();
+    }
+
+    @Override
+    public Fix fix() {
+        return new FxEmpty();
+    }
+
+    /**
+     * Build a defect when the {@code +syntax} meta requires a newer version than {@code actual}.
+     * @param meta The {@code +syntax} meta element
+     * @param actual The actual parser version
+     * @return Defect, if the declared version is newer than the actual one
+     */
+    private static Optional<Defect> outdated(
+        final Xnav meta, final LtSyntaxVersion.Version actual
+    ) {
+        final String declared = meta.element("tail").text().orElse("");
+        return LtSyntaxVersion.Version.parsed(declared)
+            .filter(version -> version.newerThan(actual)).map(
+                version -> new Defect.Default(
+                    "syntax-version",
+                    Severity.ERROR,
+                    new LineOf(meta).value(),
+                    String.format(
+                        "The +syntax meta requires EO %s or newer, but the parser is EO %s",
+                        declared, actual
+                    )
+                )
+            );
+    }
+
+    /**
+     * A strict {@code major.minor.patch} version.
+     * @since 0.2.11
+     */
+    private static final class Version {
+
+        /**
+         * Matches the numeric {@code major.minor.patch} core of a version string.
+         */
+        private static final Pattern CORE = Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)");
+
+        /**
+         * Major version.
+         */
+        private final int major;
+
+        /**
+         * Minor version.
+         */
+        private final int minor;
+
+        /**
+         * Patch version.
+         */
+        private final int patch;
+
+        /**
+         * Ctor.
+         * @param mjr Major version
+         * @param mnr Minor version
+         * @param pch Patch version
+         */
+        private Version(final int mjr, final int mnr, final int pch) {
+            this.major = mjr;
+            this.minor = mnr;
+            this.patch = pch;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%d.%d.%d", this.major, this.minor, this.patch);
+        }
+
+        /**
+         * Parse a version string, strictly.
+         * @param text Version text, e.g. {@code "0.59.0"} or {@code "0.59.0-SNAPSHOT"}
+         * @return Parsed version, or empty if it doesn't match
+         */
+        private static Optional<LtSyntaxVersion.Version> parsed(final String text) {
+            final Matcher matcher = LtSyntaxVersion.Version.CORE.matcher(text.trim());
+            final Optional<LtSyntaxVersion.Version> result;
+            if (matcher.find()) {
+                result = Optional.of(
+                    new LtSyntaxVersion.Version(
+                        Integer.parseInt(matcher.group(1)),
+                        Integer.parseInt(matcher.group(2)),
+                        Integer.parseInt(matcher.group(3))
+                    )
+                );
+            } else {
+                result = Optional.empty();
+            }
+            return result;
+        }
+
+        /**
+         * Is this version strictly newer than {@code other}?
+         * @param other Version to compare against
+         * @return True if this version is newer
+         */
+        private boolean newerThan(final LtSyntaxVersion.Version other) {
+            final boolean newer;
+            if (this.major == other.major) {
+                if (this.minor == other.minor) {
+                    newer = this.patch > other.patch;
+                } else {
+                    newer = this.minor > other.minor;
+                }
+            } else {
+                newer = this.major > other.major;
+            }
+            return newer;
+        }
+    }
+}

--- a/src/main/java/org/eolang/lints/MonoLints.java
+++ b/src/main/java/org/eolang/lints/MonoLints.java
@@ -26,7 +26,8 @@ final class MonoLints extends IterableEnvelope<Lint> {
             new PkByXsl(),
             List.of(
                 new LtAsciiOnly(),
-                new LtReservedName()
+                new LtReservedName(),
+                new LtSyntaxVersion()
             )
         )
     );

--- a/src/main/resources/org/eolang/lints/metas/unknown-metas.xsl
+++ b/src/main/resources/org/eolang/lints/metas/unknown-metas.xsl
@@ -12,7 +12,7 @@
     <defects>
       <xsl:for-each select="/object/metas/meta">
         <xsl:variable name="meta-head" select="head"/>
-        <xsl:variable name="predefined" select="('package', 'alias', 'version', 'rt', 'architect', 'home', 'unlint', 'probe', 'spdx')"/>
+        <xsl:variable name="predefined" select="('package', 'alias', 'version', 'rt', 'architect', 'home', 'unlint', 'probe', 'spdx', 'syntax')"/>
         <xsl:if test="not($meta-head = $predefined)">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>

--- a/src/main/resources/org/eolang/motives/metas/syntax-version.md
+++ b/src/main/resources/org/eolang/motives/metas/syntax-version.md
@@ -1,0 +1,31 @@
+# The `+syntax` meta requires a newer EO version
+
+The `+syntax` meta declares the minimum EO language version the code
+requires, e.g. `+syntax 0.59.0`. If the actual EO parser used to compile
+the code is older than the declared version, the code may rely on syntax
+the parser doesn't understand, so this is reported as an error.
+
+For now, the comparison is strict: only the numeric `major.minor.patch`
+core of both versions is compared; pre-release suffixes (e.g.
+`-SNAPSHOT`) and non-SemVer values are ignored, not flagged.
+
+Incorrect:
+
+```eo
++syntax 99.0.0
+
+[] > foo
+```
+
+Because no such EO version is released yet, the code is necessarily
+being parsed by an older parser.
+
+Correct:
+
+```eo
++syntax 0.1.0
+
+[] > foo
+```
+
+Because the parser is at least as new as `0.1.0`.

--- a/src/main/resources/org/eolang/motives/metas/syntax-version.md
+++ b/src/main/resources/org/eolang/motives/metas/syntax-version.md
@@ -1,13 +1,13 @@
-# The `+syntax` meta requires a newer EO version
+# The `+syntax` meta requires a newer parser version
 
 The `+syntax` meta declares the minimum EO language version the code
-requires, e.g. `+syntax 0.59.0`. If the actual EO parser used to compile
-the code is older than the declared version, the code may rely on syntax
-the parser doesn't understand, so this is reported as an error.
+requires, for example `+syntax 0.59.0`. If the actual EO parser used to
+compile the code is older than the declared version, the code may rely
+on syntax the parser doesn't understand, so this is reported as an error.
 
-For now, the comparison is strict: only the numeric `major.minor.patch`
-core of both versions is compared; pre-release suffixes (e.g.
-`-SNAPSHOT`) and non-SemVer values are ignored, not flagged.
+For now, the comparison is strict. Only the numeric `major.minor.patch`
+core of both versions is compared. Pre-release suffixes, for example
+`-SNAPSHOT`, and non-SemVer values are ignored, not flagged.
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/metas/unknown-metas.md
+++ b/src/main/resources/org/eolang/motives/metas/unknown-metas.md
@@ -10,6 +10,7 @@ The following metas are supported:
 * `+home`
 * `+unlint`
 * `+probe`
+* `+syntax`
 
 Incorrect:
 
@@ -30,6 +31,7 @@ Correct:
 +rt jvm
 +home https://earth.com
 +unlint unsorted-metas
++syntax 0.1.0
 
 [] > foo
 ```

--- a/src/test/java/org/eolang/lints/LtSyntaxVersionTest.java
+++ b/src/test/java/org/eolang/lints/LtSyntaxVersionTest.java
@@ -1,0 +1,129 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import com.github.lombrozo.xnav.Xnav;
+import fixtures.EoProgram;
+import java.io.IOException;
+import matchers.DefectMatcher;
+import org.cactoos.io.InputOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link LtSyntaxVersion}.
+ * @since 0.2.11
+ */
+final class LtSyntaxVersionTest {
+
+    @Test
+    void allowsSyntaxVersionOlderThanParser() throws IOException {
+        final String src = LtSyntaxVersionTest.program("+syntax 0.0.1");
+        MatcherAssert.assertThat(
+            "declaring an old +syntax version must not cause defects",
+            new LtSyntaxVersion().defects(new EoProgram(src, new InputOf(src)).parse()),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void allowsSyntaxVersionEqualToParser() throws IOException {
+        final String src = LtSyntaxVersionTest.program(
+            String.format("+syntax %s", LtSyntaxVersionTest.actualVersion())
+        );
+        MatcherAssert.assertThat(
+            "declaring the exact parser version must not cause defects",
+            new LtSyntaxVersion().defects(new EoProgram(src, new InputOf(src)).parse()),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void catchesSyntaxVersionNewerThanParser() throws IOException {
+        final String src = LtSyntaxVersionTest.program("+syntax 999.0.0");
+        MatcherAssert.assertThat(
+            "declaring a +syntax version newer than the parser must be caught",
+            new LtSyntaxVersion().defects(new EoProgram(src, new InputOf(src)).parse()),
+            Matchers.allOf(
+                Matchers.<Defect>iterableWithSize(1),
+                Matchers.<Defect>everyItem(new DefectMatcher())
+            )
+        );
+    }
+
+    @Test
+    void complainsAsError() throws IOException {
+        final String src = LtSyntaxVersionTest.program("+syntax 999.0.0");
+        MatcherAssert.assertThat(
+            "the lint should complain as error, since the code may rely on unknown syntax",
+            new LtSyntaxVersion().defects(new EoProgram(src, new InputOf(src)).parse())
+                .iterator().next().severity(),
+            Matchers.equalTo(Severity.ERROR)
+        );
+    }
+
+    @Test
+    void setsRuleCorrectly() throws IOException {
+        final String src = LtSyntaxVersionTest.program("+syntax 999.0.0");
+        MatcherAssert.assertThat(
+            "the rule name is set right",
+            new LtSyntaxVersion().defects(new EoProgram(src, new InputOf(src)).parse())
+                .iterator().next().rule(),
+            Matchers.equalTo("syntax-version")
+        );
+    }
+
+    @Test
+    void ignoresMalformedSyntaxValue() throws IOException {
+        final String src = LtSyntaxVersionTest.program("+syntax abracadabra");
+        MatcherAssert.assertThat(
+            "a malformed +syntax value must not crash the lint, nor be flagged",
+            new LtSyntaxVersion().defects(new EoProgram(src, new InputOf(src)).parse()),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void ignoresProgramsWithoutSyntaxMeta() throws IOException {
+        final String src = LtSyntaxVersionTest.program("+home https://example.com");
+        MatcherAssert.assertThat(
+            "programs without a +syntax meta must not be affected",
+            new LtSyntaxVersion().defects(new EoProgram(src, new InputOf(src)).parse()),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void explainsMotive() throws IOException {
+        MatcherAssert.assertThat(
+            "the motive doesn't mention the +syntax meta",
+            new LtSyntaxVersion().motive().contains("+syntax"),
+            new IsEqual<>(true)
+        );
+    }
+
+    /**
+     * Discover the actual EO parser version used at test time, by parsing
+     * a trivial program and reading its root {@code version} attribute.
+     * @return Parser version, e.g. "0.62.1"
+     */
+    private static String actualVersion() {
+        final String src = LtSyntaxVersionTest.program("+home https://example.com");
+        return new Xnav(new EoProgram(src, new InputOf(src)).parse().inner())
+            .path("/object").findFirst().get()
+            .attribute("version").text().get();
+    }
+
+    /**
+     * Build a tiny EO program with the given meta line.
+     * @param meta Meta line, e.g. {@code "+syntax 0.1.0"}
+     * @return EO source
+     */
+    private static String program(final String meta) {
+        return String.join(System.lineSeparator(), meta, "", "[] > foo", "");
+    }
+}

--- a/src/test/resources/org/eolang/lints/packs/single/unknown-metas/catches-unknown-metas.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unknown-metas/catches-unknown-metas.yaml
@@ -20,5 +20,6 @@ input: |
   +home https://earth.com
   +unlint test
   +probe
+  +syntax 0.62.1
 
   [] > foo


### PR DESCRIPTION
Implement `+syntax` meta lint to validate EO parser version compatibility.

This PR introduces a new lint rule that checks the `+syntax` meta declaration against the actual EO parser version, ensuring code is only compiled with a parser version that meets or exceeds the declared minimum. The lint extracts and compares semantic version numbers, gracefully ignoring pre-release suffixes and malformed values.

Fixes #797