### PR TITLE
`duplicate-as-attribute`: group `@as` siblings instead of a global key

### DIFF
--- a/src/main/resources/org/eolang/lints/names/duplicate-as-attribute.xsl
+++ b/src/main/resources/org/eolang/lints/names/duplicate-as-attribute.xsl
@@ -8,39 +8,44 @@
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:key name="as-key" match="o[@as]" use="concat(generate-id(..), '|', @as)"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[o[@as]]">
-        <xsl:variable name="pid" select="generate-id()"/>
+      <!--
+      The "[2]" predicate lets us skip, without any grouping at all, every
+      object that has less than two "as" children, which is the majority
+      of them.
+      -->
+      <xsl:for-each select="//o[o[@as][2]]">
+        <xsl:variable name="parent" select="."/>
         <xsl:variable name="oname" select="@name"/>
         <xsl:variable name="line" select="eo:lineno(@line)"/>
-        <xsl:variable name="context" select="eo:defect-context(.)"/>
-        <xsl:for-each select="o[@as][count(key('as-key', concat($pid, '|', @as))) &gt; 1 and generate-id(.) = generate-id(key('as-key', concat($pid, '|', @as))[1])]">
-          <defect>
-            <xsl:attribute name="line">
-              <xsl:value-of select="$line"/>
-            </xsl:attribute>
-            <xsl:if test="$line = '0'">
-              <xsl:attribute name="context">
-                <xsl:value-of select="$context"/>
+        <xsl:for-each-group select="o[@as]" group-by="string(@as)">
+          <xsl:if test="count(current-group()) &gt; 1">
+            <defect>
+              <xsl:attribute name="line">
+                <xsl:value-of select="$line"/>
               </xsl:attribute>
-            </xsl:if>
-            <xsl:attribute name="severity">warning</xsl:attribute>
-            <xsl:text>The </xsl:text>
-            <xsl:choose>
-              <xsl:when test="$oname">
-                <xsl:text>object </xsl:text>
-                <xsl:value-of select="eo:escape($oname)"/>
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:text>anonymous object</xsl:text>
-              </xsl:otherwise>
-            </xsl:choose>
-            <xsl:text> has duplicated @as attribute </xsl:text>
-            <xsl:value-of select="eo:escape(@as)"/>
-          </defect>
-        </xsl:for-each>
+              <xsl:if test="$line = '0'">
+                <xsl:attribute name="context">
+                  <xsl:value-of select="eo:defect-context($parent)"/>
+                </xsl:attribute>
+              </xsl:if>
+              <xsl:attribute name="severity">warning</xsl:attribute>
+              <xsl:text>The </xsl:text>
+              <xsl:choose>
+                <xsl:when test="$oname">
+                  <xsl:text>object </xsl:text>
+                  <xsl:value-of select="eo:escape($oname)"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:text>anonymous object</xsl:text>
+                </xsl:otherwise>
+              </xsl:choose>
+              <xsl:text> has duplicated @as attribute </xsl:text>
+              <xsl:value-of select="eo:escape(@as)"/>
+            </defect>
+          </xsl:if>
+        </xsl:for-each-group>
       </xsl:for-each>
     </defects>
   </xsl:template>

--- a/src/test/resources/org/eolang/lints/packs/single/duplicate-as-attribute/reports-each-duplicate-once.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/duplicate-as-attribute/reports-each-duplicate-once.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/duplicate-as-attribute.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=2]
+  - /defects/defect[contains(text(), '"foo"')]
+  - /defects/defect[contains(text(), '"bar"')]
+document: |
+  <object author="tests">
+    <o base="Φ.t" name="tee" line="3">
+      <o base="Φ.f1" as="foo"/>
+      <o base="Φ.f2" as="bar"/>
+      <o base="Φ.f3" as="foo"/>
+      <o base="Φ.f4" as="bar"/>
+      <o base="Φ.f5" as="foo"/>
+    </o>
+  </object>


### PR DESCRIPTION
Closes #1274.

`duplicate-as-attribute.xsl` built a document-wide `xsl:key` over every
`o[@as]`, keyed by `generate-id()` of the parent, and then spent two `key()`
lookups plus two `generate-id()` calls per `@as` child to decide whether that
child was the first of a duplicate group. All of that indexing was paid even by
documents with no duplicates at all.

Duplicated `@as` attributes are always siblings, so no global index is needed.
`xsl:for-each-group` finds them locally, in a single pass over the children,
with no ids and no keys:

```xml
<xsl:for-each select="//o[o[@as][2]]">
  <xsl:variable name="parent" select="."/>
  ...
  <xsl:for-each-group select="o[@as]" group-by="string(@as)">
    <xsl:if test="count(current-group()) &gt; 1">
```

The `[2]` predicate on the outer selector is the second half of it: it skips,
before any grouping happens, every object that has fewer than two `@as`
children — the majority of them in a real XMIR.

Since `eo:defect-context()` is now called from inside the `xsl:if`, it can only
ever run for an object that really has a duplicate, instead of being bound as a
variable for every candidate parent.

## Measurements

Through `XSLDocument` + `ClasspathSources`, exactly as `LtByXsl` applies it,
best of several runs:

| Input | Before | After |
| --- | --- | --- |
| The 500×500 XMIR from `LtByXslTest` | 1297 ms | 280 ms |
| 171 XMIR files of `eo-runtime`, parsed by `eo-parser` | 398 ms | 186 ms |

## Correctness

The reported defects are unchanged. I ran the old and the new stylesheet over
8000 randomly shaped XMIRs — varying nesting depth, presence of `@name` and
`@line`, and a deliberately tiny alphabet of `@as` values that included the
empty string and values containing `|` (to try to break the concatenated key) —
and they produced byte-identical `<defects>` documents in every case, `@context`
attributes included.

`LtByXslTest` passes: 417 tests, 0 failures.

I also added `reports-each-duplicate-once.yaml`, which pins the behaviour the
grouping has to preserve: an object with three `foo` children and two `bar`
children yields exactly two defects, not five.


---
_Generated by [Claude Code](https://claude.ai/code/session_013RN4eq44VcauNbKJ2LVnX9)_