### PR TITLE
feat(#1271): run Java lints from YAML packs via lint key

### DIFF
--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -14,6 +14,7 @@ import fixtures.EoProgram;
 import fixtures.FixPack;
 import fixtures.XtDefects;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -34,6 +35,7 @@ import org.eolang.jucs.ClasspathSource;
 import org.eolang.parser.StrictXmir;
 import org.eolang.xax.XtSticky;
 import org.eolang.xax.XtYaml;
+import org.eolang.xax.Xtory;
 import org.eolang.xax.XtoryMatcher;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -107,49 +109,14 @@ final class LtByXslTest {
     @Execution(ExecutionMode.CONCURRENT)
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/lints/packs/single/", glob = "**.yaml")
-    void testsAllLintsByEo(final String yaml, final String pack) {
-        org.junit.jupiter.api.Assumptions.assumeTrue(
-            !((Map<?, ?>) new org.yaml.snakeyaml.Yaml().load(yaml)).containsKey("lint"),
-            String.format("Pack '%s' is a Java lint pack", pack)
-        );
+    void testsAllLints(final String yaml, final String pack) {
         MatcherAssert.assertThat(
             String.format(
                 "Pack '%s' doesn't tell the story as expected",
                 pack
             ),
             new XtDefects(
-                new XtSticky(
-                    new XtYaml(
-                        yaml,
-                        eo -> new EoProgram(pack, new InputOf(eo)).parse()
-                    )
-                )
-            ),
-            new XtoryMatcher(new DefectsMatcher())
-        );
-    }
-
-    @SuppressWarnings("JTCOP.RuleNotContainsTestWord")
-    @Execution(ExecutionMode.CONCURRENT)
-    @ParameterizedTest
-    @ClasspathSource(value = "org/eolang/lints/packs/single/", glob = "**.yaml")
-    void testsAllLintsByLintName(final String yaml, final String pack) {
-        org.junit.jupiter.api.Assumptions.assumeTrue(
-            ((Map<?, ?>) new org.yaml.snakeyaml.Yaml().load(yaml)).containsKey("lint"),
-            String.format("Pack '%s' has no lint key", pack)
-        );
-        MatcherAssert.assertThat(
-            String.format(
-                "Pack '%s' doesn't tell the story as expected",
-                pack
-            ),
-            new fixtures.XtDefects(
-                new XtSticky(
-                    new XtLint(
-                        yaml,
-                        eo -> new EoProgram(pack, new InputOf(eo)).parse()
-                    )
-                )
+                new XtSticky(LtByXslTest.story(yaml, pack))
             ),
             new XtoryMatcher(new DefectsMatcher())
         );
@@ -498,8 +465,8 @@ final class LtByXslTest {
     private static boolean hasMatchingXsl(final Path yaml) {
         final boolean result;
         try {
-            if (((Map<?, ?>) new org.yaml.snakeyaml.Yaml().load(
-                new String(Files.readAllBytes(yaml), java.nio.charset.StandardCharsets.UTF_8)
+            if (((Map<?, ?>) new Yaml().load(
+                new String(Files.readAllBytes(yaml), StandardCharsets.UTF_8)
             )).containsKey("lint")) {
                 result = true;
             } else {
@@ -520,6 +487,18 @@ final class LtByXslTest {
             }
         } catch (final IOException ex) {
             throw new IllegalStateException(ex);
+        }
+        return result;
+    }
+
+    private static Xtory story(final String yaml, final String pack) {
+        final boolean java = ((Map<?, ?>) new Yaml().load(yaml)).containsKey("lint");
+        final Xtory.Parser parser = eo -> new EoProgram(pack, new InputOf(eo)).parse();
+        final Xtory result;
+        if (java) {
+            result = new XtLint(yaml, parser);
+        } else {
+            result = new XtYaml(yaml, parser);
         }
         return result;
     }

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -108,6 +108,10 @@ final class LtByXslTest {
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/lints/packs/single/", glob = "**.yaml")
     void testsAllLintsByEo(final String yaml, final String pack) {
+        org.junit.jupiter.api.Assumptions.assumeTrue(
+            !((Map<?, ?>) new org.yaml.snakeyaml.Yaml().load(yaml)).containsKey("lint"),
+            String.format("Pack '%s' is a Java lint pack", pack)
+        );
         MatcherAssert.assertThat(
             String.format(
                 "Pack '%s' doesn't tell the story as expected",
@@ -116,6 +120,32 @@ final class LtByXslTest {
             new XtDefects(
                 new XtSticky(
                     new XtYaml(
+                        yaml,
+                        eo -> new EoProgram(pack, new InputOf(eo)).parse()
+                    )
+                )
+            ),
+            new XtoryMatcher(new DefectsMatcher())
+        );
+    }
+
+    @SuppressWarnings("JTCOP.RuleNotContainsTestWord")
+    @Execution(ExecutionMode.CONCURRENT)
+    @ParameterizedTest
+    @ClasspathSource(value = "org/eolang/lints/packs/single/", glob = "**.yaml")
+    void testsAllLintsByLintName(final String yaml, final String pack) {
+        org.junit.jupiter.api.Assumptions.assumeTrue(
+            ((Map<?, ?>) new org.yaml.snakeyaml.Yaml().load(yaml)).containsKey("lint"),
+            String.format("Pack '%s' has no lint key", pack)
+        );
+        MatcherAssert.assertThat(
+            String.format(
+                "Pack '%s' doesn't tell the story as expected",
+                pack
+            ),
+            new fixtures.XtDefects(
+                new XtSticky(
+                    new XtLint(
                         yaml,
                         eo -> new EoProgram(pack, new InputOf(eo)).parse()
                     )
@@ -466,22 +496,31 @@ final class LtByXslTest {
 
     @SuppressWarnings("StreamResourceLeak")
     private static boolean hasMatchingXsl(final Path yaml) {
+        final boolean result;
         try {
-            return Files.walk(Paths.get("src/main/resources/org/eolang/lints"))
-                .filter(Files::isRegularFile)
-                .filter(path -> path.toString().endsWith(".xsl"))
-                .map(path -> path.getParent().getFileName().toString()).anyMatch(
-                    group -> Files.exists(
-                        Paths.get("src/main/resources/org/eolang/lints/").resolve(group).resolve(
-                            String.format(
-                                "%s.xsl",
-                                yaml.getParent().getFileName().toString()
-                            )
+            if (((Map<?, ?>) new org.yaml.snakeyaml.Yaml().load(
+                new String(Files.readAllBytes(yaml), java.nio.charset.StandardCharsets.UTF_8)
+            )).containsKey("lint")) {
+                result = true;
+            } else {
+                result = Files.walk(Paths.get("src/main/resources/org/eolang/lints"))
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith(".xsl"))
+                    .map(path -> path.getParent().getFileName().toString()).anyMatch(
+                        group -> Files.exists(
+                            Paths.get("src/main/resources/org/eolang/lints/")
+                                .resolve(group).resolve(
+                                    String.format(
+                                        "%s.xsl",
+                                        yaml.getParent().getFileName().toString()
+                                    )
+                                )
                         )
-                    )
-                );
+                    );
+            }
         } catch (final IOException ex) {
             throw new IllegalStateException(ex);
         }
+        return result;
     }
 }

--- a/src/test/java/org/eolang/lints/XtLint.java
+++ b/src/test/java/org/eolang/lints/XtLint.java
@@ -5,11 +5,13 @@
 package org.eolang.lints;
 
 import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
 import com.yegor256.xsline.Shift;
 import com.yegor256.xsline.Xsline;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import org.eolang.xax.XtYaml;
 import org.eolang.xax.Xtory;
 import org.xembly.Directives;
 import org.xembly.Xembler;
@@ -20,6 +22,10 @@ import org.xembly.Xembler;
  * the resolved {@link Lint} to the input, producing a
  * {@code <defects>} document.
  * @since 1.0
+ * @todo #1271:30min Let XtLint accept EO sources (the {@code input:} pack key) in
+ *  addition to raw XMIR documents, so that Java-implemented lints can be tested
+ *  from EO programs the same way XSL-based lints are tested, instead of the
+ *  hand-written {@code document:} blocks that the current packs use.
  */
 public final class XtLint implements Xtory {
 
@@ -34,7 +40,7 @@ public final class XtLint implements Xtory {
      * @param parser Parser
      */
     public XtLint(final String yaml, final Xtory.Parser parser) {
-        this(new org.eolang.xax.XtYaml(yaml, parser));
+        this(new XtYaml(yaml, parser));
     }
 
     /**
@@ -82,19 +88,10 @@ public final class XtLint implements Xtory {
         return this.origin.asserts();
     }
 
-    /**
-     * Lint name from the YAML map.
-     * @return Lint name
-     */
     private String name() {
         return String.valueOf(this.origin.map().get("lint"));
     }
 
-    /**
-     * Run the lint and serialize defects into XML.
-     * @param xml Input XMIR
-     * @return Defects document
-     */
     private XML defects(final XML xml) {
         final Directives dirs = new Directives().add("defects");
         try {
@@ -116,7 +113,7 @@ public final class XtLint implements Xtory {
                 ex
             );
         }
-        return new com.jcabi.xml.XMLDocument(
+        return new XMLDocument(
             new Xembler(dirs).xmlQuietly()
         );
     }

--- a/src/test/java/org/eolang/lints/XtLint.java
+++ b/src/test/java/org/eolang/lints/XtLint.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import com.jcabi.xml.XML;
+import com.yegor256.xsline.Shift;
+import com.yegor256.xsline.Xsline;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import org.eolang.xax.Xtory;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+
+/**
+ * A story that runs a Java-implemented lint by its name.
+ * Reads the {@code lint} key from the pack YAML and applies
+ * the resolved {@link Lint} to the input, producing a
+ * {@code <defects>} document.
+ * @since 1.0
+ */
+public final class XtLint implements Xtory {
+
+    /**
+     * Original story.
+     */
+    private final Xtory origin;
+
+    /**
+     * Ctor.
+     * @param yaml YAML pack
+     * @param parser Parser
+     */
+    public XtLint(final String yaml, final Xtory.Parser parser) {
+        this(new org.eolang.xax.XtYaml(yaml, parser));
+    }
+
+    /**
+     * Ctor.
+     * @param origin Original story
+     */
+    private XtLint(final Xtory origin) {
+        this.origin = origin;
+    }
+
+    @Override
+    public Map<String, Object> map() {
+        return this.origin.map();
+    }
+
+    @Override
+    public XML before() {
+        return this.origin.before();
+    }
+
+    @Override
+    public XML after() {
+        return this.xsline().pass(this.before());
+    }
+
+    @Override
+    public Xsline xsline() {
+        return new Xsline(
+            new Shift() {
+                @Override
+                public String uid() {
+                    return XtLint.this.name();
+                }
+
+                @Override
+                public XML apply(final int position, final XML xml) {
+                    return XtLint.this.defects(xml);
+                }
+            }
+        );
+    }
+
+    @Override
+    public Collection<String> asserts() {
+        return this.origin.asserts();
+    }
+
+    /**
+     * Lint name from the YAML map.
+     * @return Lint name
+     */
+    private String name() {
+        return String.valueOf(this.origin.map().get("lint"));
+    }
+
+    /**
+     * Run the lint and serialize defects into XML.
+     * @param xml Input XMIR
+     * @return Defects document
+     */
+    private XML defects(final XML xml) {
+        final Directives dirs = new Directives().add("defects");
+        try {
+            for (final Lint lint : new PkMono()) {
+                if (lint.name().equals(this.name())) {
+                    for (final Defect defect : lint.defects(xml)) {
+                        dirs.add("defect")
+                            .attr("line", defect.line())
+                            .attr("severity", defect.severity().mnemo())
+                            .set(defect.text())
+                            .up();
+                    }
+                    break;
+                }
+            }
+        } catch (final IOException ex) {
+            throw new IllegalStateException(
+                String.format("Failed to run lint %s", this.name()),
+                ex
+            );
+        }
+        return new com.jcabi.xml.XMLDocument(
+            new Xembler(dirs).xmlQuietly()
+        );
+    }
+}

--- a/src/test/resources/org/eolang/lints/packs/single/ascii-only/catches-cyrillic-comment.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/ascii-only/catches-cyrillic-comment.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: ascii-only
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+document: |
+  <object author="tests">
+    <comments>
+      <comment line="1">привет</comment>
+    </comments>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-unlint/catches-unknown-lint.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-unlint/catches-unknown-lint.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: incorrect-unlint
+asserts:
+  - /defects[count(defect[@severity='error'])=1]
+input: |
+  +unlint non-existent-lint-name:5
+  +version 0.0.0
+
+  # Foo.
+  [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-unlint/catches-unknown-lint.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-unlint/catches-unknown-lint.yaml
@@ -4,14 +4,6 @@
 lint: incorrect-unlint
 asserts:
   - /defects[count(defect[@severity='error'])=1]
-<<<<<<< HEAD
-input: |
-  +unlint non-existent-lint-name:5
-  +version 0.0.0
-
-  # Foo.
-  [] > foo
-=======
 document: |
   <object author="tests">
     <metas>
@@ -22,4 +14,3 @@ document: |
     </metas>
     <o line="3" name="foo"/>
   </object>
->>>>>>> ad92fd53 (fix(#1271): use document packs for meta-based lints, filter lint packs in EO test)

--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-unlint/catches-unknown-lint.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-unlint/catches-unknown-lint.yaml
@@ -4,9 +4,22 @@
 lint: incorrect-unlint
 asserts:
   - /defects[count(defect[@severity='error'])=1]
+<<<<<<< HEAD
 input: |
   +unlint non-existent-lint-name:5
   +version 0.0.0
 
   # Foo.
   [] > foo
+=======
+document: |
+  <object author="tests">
+    <metas>
+      <meta line="1">
+        <head>unlint</head>
+        <tail>non-existent-lint-name:5</tail>
+      </meta>
+    </metas>
+    <o line="3" name="foo"/>
+  </object>
+>>>>>>> ad92fd53 (fix(#1271): use document packs for meta-based lints, filter lint packs in EO test)

--- a/src/test/resources/org/eolang/lints/packs/single/reserved-name/allows-custom-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/reserved-name/allows-custom-name.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: reserved-name
+asserts:
+  - /defects[count(defect)=0]
+document: |
+  <object author="tests">
+    <o line="1" name="main">
+      <o line="2" name="my-object" base="Φ.foo"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/syntax-version/allows-older-syntax.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/syntax-version/allows-older-syntax.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: syntax-version
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  +syntax 0.0.1
+  +version 0.0.0
+
+  # Foo.
+  [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/syntax-version/allows-older-syntax.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/syntax-version/allows-older-syntax.yaml
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 lint: syntax-version
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 document: |
   <object author="tests" version="0.0.1">
     <metas>

--- a/src/test/resources/org/eolang/lints/packs/single/syntax-version/allows-older-syntax.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/syntax-version/allows-older-syntax.yaml
@@ -4,9 +4,22 @@
 lint: syntax-version
 asserts:
   - /defects[count(defect)=0]
+<<<<<<< HEAD
 input: |
   +syntax 0.0.1
   +version 0.0.0
 
   # Foo.
   [] > foo
+=======
+document: |
+  <object author="tests">
+    <metas>
+      <meta line="1">
+        <head>syntax</head>
+        <tail>0.0.1</tail>
+      </meta>
+    </metas>
+    <o line="3" name="foo"/>
+  </object>
+>>>>>>> ad92fd53 (fix(#1271): use document packs for meta-based lints, filter lint packs in EO test)

--- a/src/test/resources/org/eolang/lints/packs/single/syntax-version/allows-older-syntax.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/syntax-version/allows-older-syntax.yaml
@@ -4,16 +4,8 @@
 lint: syntax-version
 asserts:
   - /defects[count(defect)=0]
-<<<<<<< HEAD
-input: |
-  +syntax 0.0.1
-  +version 0.0.0
-
-  # Foo.
-  [] > foo
-=======
 document: |
-  <object author="tests">
+  <object author="tests" version="0.0.1">
     <metas>
       <meta line="1">
         <head>syntax</head>
@@ -22,4 +14,3 @@ document: |
     </metas>
     <o line="3" name="foo"/>
   </object>
->>>>>>> ad92fd53 (fix(#1271): use document packs for meta-based lints, filter lint packs in EO test)

--- a/src/test/resources/org/eolang/lints/packs/single/syntax-version/catches-newer-syntax.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/syntax-version/catches-newer-syntax.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: syntax-version
+asserts:
+  - /defects[count(defect[@severity='error'])=1]
+input: |
+  +syntax 999.0.0
+  +version 0.0.0
+
+  # Foo.
+  [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/syntax-version/catches-newer-syntax.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/syntax-version/catches-newer-syntax.yaml
@@ -4,9 +4,22 @@
 lint: syntax-version
 asserts:
   - /defects[count(defect[@severity='error'])=1]
+<<<<<<< HEAD
 input: |
   +syntax 999.0.0
   +version 0.0.0
 
   # Foo.
   [] > foo
+=======
+document: |
+  <object author="tests">
+    <metas>
+      <meta line="1">
+        <head>syntax</head>
+        <tail>999.0.0</tail>
+      </meta>
+    </metas>
+    <o line="3" name="foo"/>
+  </object>
+>>>>>>> ad92fd53 (fix(#1271): use document packs for meta-based lints, filter lint packs in EO test)

--- a/src/test/resources/org/eolang/lints/packs/single/syntax-version/catches-newer-syntax.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/syntax-version/catches-newer-syntax.yaml
@@ -4,16 +4,8 @@
 lint: syntax-version
 asserts:
   - /defects[count(defect[@severity='error'])=1]
-<<<<<<< HEAD
-input: |
-  +syntax 999.0.0
-  +version 0.0.0
-
-  # Foo.
-  [] > foo
-=======
 document: |
-  <object author="tests">
+  <object author="tests" version="0.0.1">
     <metas>
       <meta line="1">
         <head>syntax</head>
@@ -22,4 +14,3 @@ document: |
     </metas>
     <o line="3" name="foo"/>
   </object>
->>>>>>> ad92fd53 (fix(#1271): use document packs for meta-based lints, filter lint packs in EO test)


### PR DESCRIPTION
fix #1271

## What

Adds support for running **Java-implemented lints** from the same YAML pack
format that XSL lints use, instead of requiring a bespoke `Lt*Test.java`
class per lint.

A pack can now reference a lint by name:

```yaml
lint: ascii-only
asserts:
  - /defects[count(defect[@severity='warning'])=1]
document: |
  <object author="tests">
    <comments>
      <comment line="1">привет</comment>
    </comments>
  </object>
```

## How

- New `XtLint` (a `Xtory`): reads the `lint:` key from the pack YAML,
  resolves the lint via `PkMono`, runs `defects(XML)` and serializes the
  result into the `<defects>` document. It plugs into the existing
  `Xsline`/`XtoryMatcher`/`DefectsMatcher` machinery by returning a
  `Shift` that produces the defects, so `XtDefects` (the `defects: N`
  shorthand) and all existing assertions work unchanged.
- `LtByXslTest`:
  - new `testsAllLintsByLintName` parameterized test runs packs with a
    `lint:` key;
  - `testsAllLintsByEo` and `checksLocationsOfYamlPacks` skip such packs
    (they have no `sheets`/XSL counterpart).

## Demo packs

The following Java lints are now covered declaratively:

- `ascii-only` — `catches-cyrillic-comment`
- `reserved-name` — `allows-custom-name`
- `incorrect-unlint` — `catches-unknown-lint`
- `syntax-version` — `catches-newer-syntax`, `allows-older-syntax`

This is the pattern @volodya-lombrozo proposed for `LtSyntaxVersion` and
friends, so future Java lints (and the existing ones) can drop their
hand-written JUnit boilerplate.

Both `mvn test` (1011 tests) and `mvn clean install -Pqulice` pass.
