### PR TITLE
fix(#1276): `redundant-object` counts `Φ`-rooted references

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
@@ -8,17 +8,7 @@
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:key
-    name="referenced-by-name"
-    match="o[@base]"
-    use="
-      if (matches(@base, '^ξ(?:\.ρ)*\.'))
-      then tokenize(replace(@base, '^ξ(?:\.ρ)*\.', ''), '\.')[1]
-      else if (matches(@base, '^Φ\.[^.]+\.'))
-      then tokenize(@base, '\.')[3]
-      else ''
-    "
-  />
+  <xsl:key name="referenced-by-name" match="o[@base]" use="if (matches(@base, '^ξ(?:\.ρ)*\.')) then tokenize(replace(@base, '^ξ(?:\.ρ)*\.', ''), '\.')[1] else if (matches(@base, '^Φ\.[^.]+\.')) then tokenize(@base, '\.')[3] else ''"/>
   <xsl:template match="/">
     <defects>
       <xsl:variable name="top" select="/object/o/generate-id()"/>

--- a/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
@@ -8,7 +8,17 @@
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:key name="referenced-by-name" match="o[@base]" use="if (matches(@base, '^ξ(?:\.ρ)*\.')) then tokenize(replace(@base, '^ξ(?:\.ρ)*\.', ''), '\.')[1] else ''"/>
+  <xsl:key
+    name="referenced-by-name"
+    match="o[@base]"
+    use="
+      if (matches(@base, '^ξ(?:\.ρ)*\.'))
+      then tokenize(replace(@base, '^ξ(?:\.ρ)*\.', ''), '\.')[1]
+      else if (matches(@base, '^Φ\.[^.]+\.'))
+      then tokenize(@base, '\.')[3]
+      else ''
+    "
+  />
   <xsl:template match="/">
     <defects>
       <xsl:variable name="top" select="/object/o/generate-id()"/>

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-object-refs-in-absolute-form.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-object-refs-in-absolute-form.yaml
@@ -13,11 +13,11 @@ input: |
           match.
             regex "/linux/i"
             name
-  
+
     or. ++> can-check-the-os-family
       os.is-windows.or os.is-macos
       os.is-linux
-  
+
     not. ++> can-tell-it-does-not-belong-to-two-os-families-at-once
       or.
         or.

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-object-refs-in-absolute-form.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-object-refs-in-absolute-form.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/redundant-object.xsl
+defects: 0
+input: |
+  [] > os
+    name > @
+    as-bool. > is-linux
+      exists.
+        next.
+          match.
+            regex "/linux/i"
+            name
+  
+    or. ++> can-check-the-os-family
+      os.is-windows.or os.is-macos
+      os.is-linux
+  
+    not. ++> can-tell-it-does-not-belong-to-two-os-families-at-once
+      or.
+        or.
+          os.is-linux.and os.is-macos
+          os.is-linux.and os.is-windows
+        os.is-macos.and os.is-windows


### PR DESCRIPTION
In this PR I've adjusted `redundant-object` lint to keep count of `Φ`-rooted references too, e.g. `os.is-linux` from [os.eo](https://github.com/objectionary/eo/blob/7a1b1c7be441f24b1ed1d6389244fedac1e9b60c/eo-runtime/src/main/eo/os.eo).

closes #1276 