### PR TITLE
fix(#1279): exempt home objects from mandatory-package lint

### DIFF
--- a/src/main/resources/org/eolang/funcs/home-object.xsl
+++ b/src/main/resources/org/eolang/funcs/home-object.xsl
@@ -13,16 +13,7 @@
   with the home repository; both lints share it from here so it never goes
   stale in two places at once.
   -->
-  <xsl:variable name="eo:home-objects" as="xs:string*">
-    <xsl:sequence select="(
-      'bool', 'buffer', 'bytes', 'chunk', 'clock', 'console', 'dataized',
-      'directory', 'e', 'eol', 'false', 'file', 'getenv', 'i16', 'i32', 'i64',
-      'i8', 'input', 'malloc', 'map', 'mktemp', 'nan', 'ninf', 'nop', 'number',
-      'os', 'output', 'path', 'pi', 'pinf', 'posix', 'range', 'recovered',
-      'seq', 'set', 'socket', 'stderr', 'stdin', 'stdout', 'string', 'switch',
-      'true', 'tuple', 'u16', 'u32', 'u64', 'u8', 'uri', 'while', 'win32'
-      )"/>
-  </xsl:variable>
+  <xsl:variable name="eo:home-objects" as="xs:string*" select="('bool', 'buffer', 'bytes', 'chunk', 'clock', 'console', 'dataized', 'directory', 'e', 'eol', 'false', 'file', 'getenv', 'i16', 'i32', 'i64', 'i8', 'input', 'malloc', 'map', 'mktemp', 'nan', 'ninf', 'nop', 'number', 'os', 'output', 'path', 'pi', 'pinf', 'posix', 'range', 'recovered', 'seq', 'set', 'socket', 'stderr', 'stdin', 'stdout', 'string', 'switch', 'true', 'tuple', 'u16', 'u32', 'u64', 'u8', 'uri', 'while', 'win32')"/>
   <xsl:variable name="eo:home-repo" as="xs:string" select="'https://github.com/objectionary/eo'"/>
   <xsl:function name="eo:home-object" as="xs:boolean">
     <xsl:param name="name" as="xs:string?"/>

--- a/src/main/resources/org/eolang/funcs/home-object.xsl
+++ b/src/main/resources/org/eolang/funcs/home-object.xsl
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="home-object" version="2.0">
+  <!--
+  Names of the root objects that live directly under "eo-runtime/src/main/eo"
+  in the "objectionary/eo" repository. These objects belong to "org.eolang"
+  by design: the transpiler emits "package org.eolang" for them itself, so
+  neither "+package" (mandatory-package) nor "+package org.eolang"
+  (prohibited-package) should be flagged on them. Keep this list in sync
+  with the home repository; both lints share it from here so it never goes
+  stale in two places at once.
+  -->
+  <xsl:variable name="eo:home-objects" as="xs:string*">
+    <xsl:sequence select="(
+      'bool', 'buffer', 'bytes', 'chunk', 'clock', 'console', 'dataized',
+      'directory', 'e', 'eol', 'false', 'file', 'getenv', 'i16', 'i32', 'i64',
+      'i8', 'input', 'malloc', 'map', 'mktemp', 'nan', 'ninf', 'nop', 'number',
+      'os', 'output', 'path', 'pi', 'pinf', 'posix', 'range', 'recovered',
+      'seq', 'set', 'socket', 'stderr', 'stdin', 'stdout', 'string', 'switch',
+      'true', 'tuple', 'u16', 'u32', 'u64', 'u8', 'uri', 'while', 'win32'
+      )"/>
+  </xsl:variable>
+  <xsl:variable name="eo:home-repo" as="xs:string" select="'https://github.com/objectionary/eo'"/>
+  <xsl:function name="eo:home-object" as="xs:boolean">
+    <xsl:param name="name" as="xs:string?"/>
+    <xsl:param name="metas" as="element()*"/>
+    <xsl:sequence select="$name = $eo:home-objects and $metas[head = 'home' and tail = $eo:home-repo]"/>
+  </xsl:function>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/metas/mandatory-package.xsl
+++ b/src/main/resources/org/eolang/lints/metas/mandatory-package.xsl
@@ -5,10 +5,11 @@
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="mandatory-package" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/home-object.xsl"/>
   <xsl:output encoding="UTF-8"/>
   <xsl:template match="/">
     <defects>
-      <xsl:if test="count(/object/metas/meta[head ='package'])=0">
+      <xsl:if test="count(/object/metas/meta[head ='package'])=0 and not(eo:home-object(/object/o[1]/@name, /object/metas/meta))">
         <xsl:element name="defect">
           <xsl:attribute name="line">
             <xsl:value-of select="eo:lineno(@line)"/>

--- a/src/main/resources/org/eolang/lints/metas/prohibited-package.xsl
+++ b/src/main/resources/org/eolang/lints/metas/prohibited-package.xsl
@@ -6,39 +6,15 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="prohibited-package" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:import href="/org/eolang/funcs/home-object.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:variable name="white-list">
-    <a>as-phi</a>
-    <a>bytes</a>
-    <a>cti</a>
-    <a>dataized</a>
-    <a>error</a>
-    <a>false</a>
-    <a>go</a>
-    <a>i16</a>
-    <a>i32</a>
-    <a>i64</a>
-    <a>malloc</a>
-    <a>nan</a>
-    <a>negative-infinity</a>
-    <a>number</a>
-    <a>positive-infinity</a>
-    <a>rust</a>
-    <a>seq</a>
-    <a>string</a>
-    <a>switch</a>
-    <a>true</a>
-    <a>try</a>
-    <a>tuple</a>
-    <a>while</a>
-  </xsl:variable>
   <xsl:variable name="name" select="/object/o[1]/@name"/>
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="/object/metas/meta">
         <xsl:variable name="meta-head" select="head"/>
         <xsl:variable name="meta-tail" select="tail"/>
-        <xsl:if test="$meta-head='package' and $meta-tail='org.eolang' and not($white-list/a=$name)">
+        <xsl:if test="$meta-head='package' and $meta-tail='org.eolang' and not(eo:home-object($name, /object/metas/meta))">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/single/mandatory-package/catches-home-name-without-home-meta.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/mandatory-package/catches-home-name-without-home-meta.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/mandatory-package.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+input: |
+  [] > win32

--- a/src/test/resources/org/eolang/lints/packs/single/mandatory-package/skips-home-objects.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/mandatory-package/skips-home-objects.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/mandatory-package.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  +home https://github.com/objectionary/eo
+
+  [] > win32

--- a/src/test/resources/org/eolang/lints/packs/single/prohibited-package/catches-home-name-without-home-meta.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/prohibited-package/catches-home-name-without-home-meta.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/prohibited-package.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+input: |
+  +package org.eolang
+
+  [] > win32

--- a/src/test/resources/org/eolang/lints/packs/single/prohibited-package/catches-stale-whitelist-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/prohibited-package/catches-stale-whitelist-name.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/prohibited-package.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+input: |
+  +home https://github.com/objectionary/eo
+  +package org.eolang
+
+  [] > cti

--- a/src/test/resources/org/eolang/lints/packs/single/prohibited-package/skips-new-home-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/prohibited-package/skips-new-home-object.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/prohibited-package.xsl
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  +home https://github.com/objectionary/eo
+  +package org.eolang
+
+  [] > win32


### PR DESCRIPTION
Consolidate home object definitions and fix package lint rules to correctly exempt standard library objects.

This PR creates a shared `home-object.xsl` utility that defines the canonical list of EO standard library root objects, and updates both `mandatory-package` and `prohibited-package` lints to use this list. This prevents false positives when linting objects from the home repository that are exempt from package requirements.

Fixes #1279