### PR TITLE
feat(#1284): benchmark unlint-non-existing-defect with +unlint metas

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,42 +124,44 @@ Here is the result of linting XMIRs:
 <!-- benchmark_begin -->
 ```text
 Input: com/sun/jna/PointerType.class (S source)
-Lint time: 10s (10054 ms)
+Lint time: 6s (6315 ms)
 
 Input: com/sun/jna/Memory.class (M source)
-Lint time: 7s (7167 ms)
+Lint time: 2s (2251 ms)
 
 Input: com/sun/jna/Pointer.class (L source)
-Lint time: 9s (8715 ms)
+Lint time: 4s (3776 ms)
 
 Input: com/sun/jna/Structure.class (XL source)
-Lint time: 11s (10952 ms)
+Lint time: 5s (5443 ms)
 
 Input: org/apache/hadoop/hdfs/server/namenode/FSNamesystem.class (XXL source)
-Lint time: 38s (37742 ms)
+Lint time: 26s (25826 ms)
+
+Input: org/eolang/lints/unlint-ascii-only.eo (UNLINT source)
+Lint time: 296ms (296 ms)
 
 
-
-unlint-non-existing-defect (XXL) (14513 ms)
-application-without-as-attributes (XXL) (3157 ms)
-unlint-non-existing-defect (XL) (2790 ms)
-unlint-non-existing-defect (L) (1559 ms)
-object-has-data (XXL) (1413 ms)
-unlint-non-existing-defect (M) (1256 ms)
-empty-object (XXL) (1065 ms)
-duplicate-as-attribute (XXL) (797 ms)
-redundant-object (XXL) (686 ms)
-reserved-name (XXL) (611 ms)
-application-without-as-attributes (XL) (597 ms)
-line-is-absent (XXL) (569 ms)
-incorrect-bytes-format (XXL) (548 ms)
-application-without-as-attributes (M) (507 ms)
-compound-name (XXL) (469 ms)
-bytes-without-data (XXL) (376 ms)
+application-without-as-attributes (XXL) (5405 ms)
+object-has-data (XXL) (2065 ms)
+duplicate-as-attribute (XXL) (1929 ms)
+empty-object (XXL) (1596 ms)
+redundant-object (XXL) (1233 ms)
+incorrect-bytes-format (XXL) (1226 ms)
+application-without-as-attributes (XL) (1025 ms)
+line-is-absent (XXL) (927 ms)
+reserved-name (XXL) (880 ms)
+application-without-as-attributes (L) (845 ms)
+compound-name (XXL) (755 ms)
+duplicate-as-attribute (XL) (687 ms)
+application-without-as-attributes (M) (558 ms)
+anonymous-formation (XXL) (471 ms)
+object-has-data (L) (448 ms)
+compound-name (S) (437 ms)
 ```
 
 The results were calculated in [this GHA job][benchmark-gha]
-on 2026-07-30 at 05:24,
+on 2026-08-30 at 22:38,
 on Linux with 4 CPUs.
 <!-- benchmark_end -->
 

--- a/src/test/java/benchmarks/SourceBench.java
+++ b/src/test/java/benchmarks/SourceBench.java
@@ -4,6 +4,7 @@
  */
 package benchmarks;
 
+import fixtures.EoProgram;
 import java.util.concurrent.TimeUnit;
 import org.eolang.lints.Source;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -44,5 +45,16 @@ public class SourceBench {
     @Benchmark
     public final void scansXmir(final BenchmarkState state) {
         new Source(state.xmir()).defects();
+    }
+
+    /**
+     * Benchmark for XMIR scanning with {@code +unlint} metas present.
+     * Scans XMIR.
+     */
+    @Benchmark
+    public final void scansXmirWithUnlints() {
+        new Source(
+            new EoProgram("org/eolang/lints/unlint-ascii-only.eo").parse()
+        ).defects();
     }
 }

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -322,7 +322,7 @@ final class SourceTest {
     @Timeout(600L)
     @SuppressWarnings("PMD.UnitTestContainsTooManyAsserts")
     void benchmarksLintPerformance() throws IOException {
-        final Map<Map<SourceSize, Collection<Defect>>, String> result =
+        final Map<Map<String, Collection<Defect>>, String> result =
             SourceTest.benchmarkResults();
         MatcherAssert.assertThat(
             "All benchmark sources must produce at least one defect",
@@ -372,34 +372,49 @@ final class SourceTest {
         return lines >= src.minAllowed() && lines <= src.maxAllowed();
     }
 
-    private static Map<Map<SourceSize, Collection<Defect>>, String> benchmarkResults() {
+    private static Map<Map<String, Collection<Defect>>, String> benchmarkResults() {
         // @checkstyle ConditionalRegexpMultilineCheck (1 line)
-        final List<Map<SourceSize, Collection<Defect>>> results = new ArrayList<>();
+        final List<Map<String, Collection<Defect>>> results = new ArrayList<>();
         final StringBuilder sum = new StringBuilder();
         for (final SourceSize source : SourceSize.values()) {
-            final long before = System.currentTimeMillis();
-            final Collection<Defect> defects = new SourceTest.BcSource(
-                new Unchecked<>(new BytecodeClass(source.name(), source.java())).value(),
-                source.type()
-            ).defects();
-            final long msec = System.currentTimeMillis() - before;
-            results.add(new MapOf<>(source, defects));
-            sum.append(
-                String.join(
-                    System.lineSeparator(),
-                    String.format(
-                        "Input: %s (%s source)", source.java(), source.type()
-                    ),
-                    Logger.format(
-                        "Lint time: %[ms]s (%d ms)",
-                        msec, msec
-                    )
-                )
-            ).append(System.lineSeparator()).append(System.lineSeparator());
+            SourceTest.benchmark(
+                sum,
+                results,
+                source.type(),
+                source.java(),
+                new Unchecked<>(new BytecodeClass(source.name(), source.java())).value()
+            );
         }
+        SourceTest.benchmark(
+            sum,
+            results,
+            "UNLINT",
+            "org/eolang/lints/unlint-ascii-only.eo",
+            new EoProgram("org/eolang/lints/unlint-ascii-only.eo").parse()
+        );
         return results.stream().collect(
             Collectors.toMap(run -> run, run -> sum.toString())
         );
+    }
+
+    private static void benchmark(
+        final StringBuilder sum,
+        final List<Map<String, Collection<Defect>>> results,
+        final String marker,
+        final String java,
+        final XML xmir
+    ) {
+        final long before = System.currentTimeMillis();
+        final Collection<Defect> defects = new SourceTest.BcSource(xmir, marker).defects();
+        final long msec = System.currentTimeMillis() - before;
+        results.add(new MapOf<>(marker, defects));
+        sum.append(
+            String.join(
+                System.lineSeparator(),
+                String.format("Input: %s (%s source)", java, marker),
+                Logger.format("Lint time: %[ms]s (%d ms)", msec, msec)
+            )
+        ).append(System.lineSeparator()).append(System.lineSeparator());
     }
 
     /**


### PR DESCRIPTION
fix #1284

## What

Adds a JMH benchmark that measures `LtUnlintNonExistingDefect` on an XMIR that actually contains `+unlint` metas.

## Why

The existing `scansXmir` benchmark is driven by real-world bytecode-derived XMIR (`com.sun.jna.*`, `org.apache.hadoop...FSNamesystem`), none of which contains a single `+unlint` meta. So it only measures the "no `+unlint` at all" fast path of `LtUnlintNonExistingDefect`.

#1233 changed the other path too: when `+unlint` metas are present, the lint now filters `this.lints` down to the referenced names before computing `existing()`. Until now there was no fixture exercising that path, so a regression there would go unnoticed by the benchmark.

## How

New benchmark method `scansXmirWithUnlints` in `SourceBench`, which parses the existing fixture `unlint-ascii-only.eo` (it has `+unlint ascii-only` and a non-ASCII comment that produces a real defect) and runs the full lint set on it.

Measured result (JMH, average time):

```
SourceBench.scansXmirWithUnlints  N/A  avgt  3  9.097 ± 31.283  ms/op
```

This gives a timing signal for the `+unlint` code path, so future changes to `LtUnlintNonExistingDefect` (faster, same or slower) become visible.

Both `mvn test` (606 tests) and `mvn clean install -Pqulice` pass.
