### PR TITLE
fix(#1270): drop dead mode="dups" template in duplicate-aliases

### DIFF
--- a/src/main/resources/org/eolang/lints/aliases/duplicate-aliases.xsl
+++ b/src/main/resources/org/eolang/lints/aliases/duplicate-aliases.xsl
@@ -34,22 +34,4 @@
       </xsl:for-each>
     </defects>
   </xsl:template>
-  <xsl:template match="meta" mode="dups">
-    <xsl:for-each select="/object/metas/meta[head='alias']">
-      <xsl:variable name="x" select="."/>
-      <xsl:if test="preceding-sibling::o/@name = $x/@name">
-        <error>
-          <xsl:attribute name="line">
-            <xsl:value-of select="if (@line) then @line else '0'"/>
-          </xsl:attribute>
-          <xsl:attribute name="severity">
-            <xsl:text>error</xsl:text>
-          </xsl:attribute>
-          <xsl:text>The name </xsl:text>
-          <xsl:value-of select="eo:escape(@name)"/>
-          <xsl:text> is already in use</xsl:text>
-        </error>
-      </xsl:if>
-    </xsl:for-each>
-  </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
Closes #1270.

The `mode="dups"` template in `src/main/resources/org/eolang/lints/aliases/duplicate-aliases.xsl` was dead code:

* Nothing invoked it — there is no `<xsl:apply-templates ... mode="dups"/>` in the stylesheet, and no other stylesheet imports `duplicate-aliases.xsl` (the only other `mode="dups"` in the repo is in `critical/duplicate-names.xsl`, which is a separate, self-contained stylesheet that does apply its own).
* It was a copy-paste leftover from `duplicate-names.xsl`: it matched `meta` yet tested `preceding-sibling::o/@name`, so it could not have produced anything even had it been invoked.
* It emitted `<error>` rather than the `<defect>` element that `LtByXsl` and the packs expect, so "fixing" the invocation later would have broken the `/defects/defect` contract.

The working logic stays untouched in the default `match="/"` template. All three `xsl:import`s are still used by it (`eo:lineno`, `eo:escape`, `eo:defect-context`), so they remain.

No behaviour change — pure removal of 18 unreachable lines.

## Verification

`mvn test` — 606 tests, 0 failures, 0 errors (including all 416 `LtByXslTest` pack assertions, among them the two `duplicate-aliases` packs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Axukgt3yd3R6V1cfWA446

---
_Generated by [Claude Code](https://claude.ai/code/session_017Axukgt3yd3R6V1cfWA446)_