### PR TITLE
docs(#318): explain the ⌴ space marker in unsorted-metas defects

### DIFF
--- a/src/main/resources/org/eolang/motives/metas/unsorted-metas.md
+++ b/src/main/resources/org/eolang/motives/metas/unsorted-metas.md
@@ -19,3 +19,9 @@ Correct:
 
 [] > foo
 ```
+
+In the defect message, the meta is quoted with every space replaced by
+`⌴` (U+2314): `The "alias⌴stdout⌴org.eolang.io.stdout" meta is out of
+order`. This is not a stray character. Every lint marks spaces this way
+in quoted text, so a leading, trailing, or repeated space is never
+mistaken for a printing artifact.


### PR DESCRIPTION
## Summary

Closes #318.

`unsorted-metas` (and every other lint, via the shared `eo:escape`
XSLT function) renders quoted text in defect messages with spaces
replaced by `⌴` (U+2314). That is by design — it exists so a leading,
trailing, or repeated space in the quoted text isn't mistaken for a
rendering artifact — but the motive doc never explained it, which is
exactly what confused the reporter in this issue and in the discussion
that followed.

This documents the convention right where the confusion happened, in
`src/main/resources/org/eolang/motives/metas/unsorted-metas.md`.

## Test plan

- [x] `vale` (Google/Microsoft/proselint styles from `.vale.ini`) passes
      on the changed file
- [x] `markdownlint-cli2` passes on the changed file
- [x] Docs-only change; no `.xsl`/Java files touched

---
_Generated by [Claude Code](https://claude.ai/code/session_014xJywzcWM1d5JSdcjCTibF)_