### PR TITLE
fix(#1295): catch bare ξ/ρ renames in anemic-getter

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/anemic-getter.xsl
+++ b/src/main/resources/org/eolang/lints/misc/anemic-getter.xsl
@@ -9,17 +9,37 @@
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
   <!--
-  A named object whose whole body is a reference to a sibling attribute of
-  the same formation is an "anemic getter". For example, "title > t" inside
-  a "[title] > book" formation just renames "title" without adding anything.
-  Such renaming is redundant, since the original attribute may be used
-  directly, so we complain about it here.
+  A named object whose whole body is a reference to something the code can
+  already reach, unchanged, right where the object sits is an "anemic getter".
+  Two shapes of body qualify: a sibling attribute of the same formation, as in
+  "title > t" inside a "[title] > book" formation, and a bare chain of "ξ" and
+  "ρ" hops, as in "^ > f" or "$ > f", which "^" and "$" already say. Such
+  renaming is redundant, since the original may be used directly, so we
+  complain about it here. A reference that reaches past the hops for an
+  attribute, such as "^.bar", names something other than the hop itself, so it
+  is not a rename and stays out of scope.
   -->
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[@name and @name!='φ' and @base and matches(@base, '^ξ\.[^.]+$') and not(o)]">
+      <xsl:for-each select="//o[@name and @name!='φ' and not(@base='ξ' and @name='xi🌵') and @base and starts-with(@base, 'ξ') and not(o)]">
         <xsl:variable name="ref" select="substring-after(@base, 'ξ.')"/>
-        <xsl:if test="../o[@name=$ref]">
+        <xsl:variable name="target">
+          <xsl:choose>
+            <!-- "$", the formation itself -->
+            <xsl:when test="@base='ξ'">
+              <xsl:text>$</xsl:text>
+            </xsl:when>
+            <!-- "^", "^.^", and so on: one "^" per "ρ" hop -->
+            <xsl:when test="matches(@base, '^ξ(\.ρ)+$')">
+              <xsl:value-of select="replace($ref, 'ρ', '^')"/>
+            </xsl:when>
+            <!-- a sibling attribute of the same formation -->
+            <xsl:when test="matches(@base, '^ξ\.[^.]+$') and ../o[@name=$ref]">
+              <xsl:value-of select="$ref"/>
+            </xsl:when>
+          </xsl:choose>
+        </xsl:variable>
+        <xsl:if test="$target != ''">
           <defect>
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">
@@ -34,9 +54,9 @@
             <xsl:text>The object </xsl:text>
             <xsl:value-of select="eo:escape(@name)"/>
             <xsl:text> is a redundant getter, it just renames </xsl:text>
-            <xsl:value-of select="eo:escape($ref)"/>
+            <xsl:value-of select="eo:escape(string($target))"/>
             <xsl:text> without adding anything, use </xsl:text>
-            <xsl:value-of select="eo:escape($ref)"/>
+            <xsl:value-of select="eo:escape(string($target))"/>
             <xsl:text> directly instead</xsl:text>
           </defect>
         </xsl:if>

--- a/src/main/resources/org/eolang/motives/misc/anemic-getter.md
+++ b/src/main/resources/org/eolang/motives/misc/anemic-getter.md
@@ -1,8 +1,9 @@
 # Anemic Getter
 
-A named object that does nothing but give access to a sibling attribute of the
-same formation is an "anemic getter." Such renaming is redundant, since the
-original attribute may be used directly, with no extra name added.
+A named object that does nothing but give access to something the code can
+already reach at the place where the object sits is an "anemic getter."
+Such renaming is redundant, since the original may be used directly, with no
+extra name added.
 
 Incorrect:
 
@@ -33,3 +34,28 @@ sibling attribute, not only void ones:
 ```
 
 Here `y` is an anemic getter for `x` and should be removed.
+
+The parent object and the formation itself are reachable by `^` and `$`, so
+renaming them is just as redundant:
+
+```eo
+# Foo.
+[] > foo
+  ^ > f
+  $ > s
+```
+
+Here `f` is an anemic getter for `^`, and `s` is one for `$`. Write `^` and
+`$` where `f` and `s` were used, and drop both. A longer chain of hops, such
+as `^.^`, is no different.
+
+A reference that goes past the hops for an attribute, though, is not a
+rename, and we leave it alone:
+
+```eo
+# Foo.
+[] > foo
+  ^.bar > f
+```
+
+Here `f` is not a second name for `^`, but a name for an attribute of it.

--- a/src/test/resources/org/eolang/lints/packs/single/anemic-getter/allows-rho-application.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anemic-getter/allows-rho-application.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/anemic-getter.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [] > foo
+    ^.plus 1 > f

--- a/src/test/resources/org/eolang/lints/packs/single/anemic-getter/allows-rho-attribute.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anemic-getter/allows-rho-attribute.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/anemic-getter.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [] > foo
+    ^.bar > f

--- a/src/test/resources/org/eolang/lints/packs/single/anemic-getter/allows-synthetic-xi.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anemic-getter/allows-synthetic-xi.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/anemic-getter.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+document: |
+  <object author="tests">
+    <o name="foo">
+      <o base="ξ" name="xi🌵"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/anemic-getter/catches-double-rho-rename.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anemic-getter/catches-double-rho-rename.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/anemic-getter.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='3']
+input: |
+  [] > foo
+    [] > inner
+      ^.^ > f

--- a/src/test/resources/org/eolang/lints/packs/single/anemic-getter/catches-rho-rename.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anemic-getter/catches-rho-rename.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/anemic-getter.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='2']
+input: |
+  [] > foo
+    ^ > f

--- a/src/test/resources/org/eolang/lints/packs/single/anemic-getter/catches-xi-rename.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anemic-getter/catches-xi-rename.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/anemic-getter.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='2']
+input: |
+  [] > foo
+    $ > f


### PR DESCRIPTION
Closes #1295.

## The bug

```
[] > foo
  ^ > f
```

`f` is an anemic getter of `^`, but the lint said nothing.

The parser turns `^ > f` into `<o name="f" base="ξ.ρ"/>`. That base *did* match
the lint's `^ξ\.[^.]+$` filter, so the object reached the body of the
`xsl:for-each` — but `$ref` then became `ρ`, and the `../o[@name=$ref]` guard
looked for a sibling named `ρ`, which never exists. So the `xsl:if` never fired.

## The fix

The lint now recognizes the whole family of bare hop chains alongside the
sibling case, and names the hop in EO syntax in the defect message:

| EO | XMIR base | before | after |
| --- | --- | --- | --- |
| `x > y` (`x` is a sibling) | `ξ.x` | caught | caught |
| `^ > f` | `ξ.ρ` | silent | caught, renames `^` |
| `^.^ > f` | `ξ.ρ.ρ` | silent | caught, renames `^.^` |
| `$ > f` | `ξ` | silent | caught, renames `$` |
| `^.bar > f` | `ξ.ρ.bar` | silent | silent (out of scope) |

Each hop chain is the same redundancy the lint exists to catch: the hop is
already reachable by its own symbol right where the getter sits, so the second
name adds nothing.

Deliberately left alone:

- `^.bar > f` (base `ξ.ρ.bar`) — this reaches *past* the hops for an attribute
  of the parent, so `f` is a name for something other than the hop itself, not
  a rename of it. `redundant-attachment` already reasons about such references.
- `^ > @` — the `@name!='φ'` guard already covers decoration.
- `<o base="ξ" name="xi🌵"/>` — the parser synthesizes this marker, so the `ξ`
  branch excludes it, the same way `redundant-object` and friends do.

The per-branch logic moved out of the `for-each` predicate into an
`xsl:choose` that computes the rename target, which is `''` when the body is
not a rename at all.

## Tests

Six new packs under `packs/single/anemic-getter/`: `catches-rho-rename`,
`catches-double-rho-rename`, `catches-xi-rename`, `allows-rho-attribute`,
`allows-rho-application`, and `allows-synthetic-xi`.

`mvn test` is green — 614 tests, 0 failures, 0 errors, 2 skipped. `xcop`,
`markdownlint`, `yamllint`, and `vale` (against the updated motive) all pass
locally too.

The motive gained a section on `^` and `$`, and on why `^.bar` is not a rename.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RwCDozUQGr5K6PFbVDTgDh)_