### PR TITLE
fix(#639): don't flag self-aliases used in nested formations

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
@@ -14,7 +14,8 @@
       <xsl:variable name="top" select="/object/o/generate-id()"/>
       <xsl:for-each select="//o[generate-id() != $top and @name and @name != 'φ' and @base and @base != '∅' and not(@base='ξ' and @name='xi🌵')]">
         <xsl:variable name="in-recursive" select="some $r in key('referenced-by-name', @name), $f in $r/ancestor::o[@name and not(@base)] satisfies exists(key('referenced-by-name', $f/@name) intersect $f/descendant::o)"/>
-        <xsl:if test="count(key('referenced-by-name', @name))&lt;=1 and not(@name and o[1]/@base = 'Φ.dataized') and not($in-recursive)">
+        <xsl:variable name="self-alias-crosses-formation" select="@base = 'ξ' and (some $r in key('referenced-by-name', @name) satisfies matches($r/@base, '^ξ\.ρ\.'))"/>
+        <xsl:if test="count(key('referenced-by-name', @name))&lt;=1 and not(@name and o[1]/@base = 'Φ.dataized') and not($in-recursive) and not($self-alias-crosses-formation)">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/motives/misc/redundant-object.md
+++ b/src/main/resources/org/eolang/motives/misc/redundant-object.md
@@ -39,9 +39,9 @@ of the recursion its own copy of the subgraph, so the lint skips such objects:
 ```
 
 A `$`-alias is also *not* redundant when its only reference reaches it from
-inside a nested formation. At that point `$` refers to the nested formation
-itself, not to the object where the alias was declared, so inlining the alias
-into the reference would change what it points to:
+inside a nested formation. There, `$` refers to the nested formation itself,
+not to the object where the alias was declared. Inlining the alias into that
+reference would change what it points to:
 
 ```eo
 # Jeff.

--- a/src/main/resources/org/eolang/motives/misc/redundant-object.md
+++ b/src/main/resources/org/eolang/motives/misc/redundant-object.md
@@ -37,3 +37,16 @@ of the recursion its own copy of the subgraph, so the lint skips such objects:
       0
       squared.plus (poly (n.minus 1))
 ```
+
+A `$`-alias is also *not* redundant when its only reference reaches it from
+inside a nested formation. At that point `$` refers to the nested formation
+itself, not to the object where the alias was declared, so inlining the alias
+into the reference would change what it points to:
+
+```eo
+# Jeff.
+[] > jeff
+  $ > self
+  [] > say-hello
+    stdout self > @
+```

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-self-reused-in-nested-formation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-self-reused-in-nested-formation.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/redundant-object.xsl
+defects: 0
+input: |
+  [] > jeff
+    $ > self
+    [] > say-hello
+      stdout self > @


### PR DESCRIPTION
Fixes #639.

## The bug

```eo
[] > jeff
  $ > self
  [] > say-hello
    stdout self > @
```

Here, `self` was introduced on purpose, to make `jeff` itself reusable from
inside `say-hello`. But `redundant-object` flags it:

```text
The object "self" is redundant and may be inlined
```

## Root cause

`redundant-object.xsl` counts, for each named object, how many times it is
referenced (via the `referenced-by-name` key, which matches `@base` values
reached through zero or more `ξ.ρ` hops). If that count is `<= 1`, the
object is flagged as redundant and safe to inline.

The reference to `self` from inside `say-hello` is exactly one such
reference (`ξ.ρ.self`), so the count is `1` and the lint fires. But
inlining is unsafe here: `self`'s body is `$` (`@base="ξ"`), and `ξ` inside
`say-hello` refers to `say-hello` itself, not to `jeff`. So the alias is
not redundant — it exists specifically to let the nested formation reach
back to `jeff`.

## Fix

`src/main/resources/org/eolang/lints/misc/redundant-object.xsl`: add a
`self-alias-crosses-formation` check that suppresses the warning when the
candidate's own `@base = 'ξ'` (i.e. it's a `$`-alias) and at least one of
its usages is reached through a `ξ.ρ.` hop (i.e. from inside a nested
formation). Same-level `$`-aliases (no `ρ` hop needed to reach them) are
still flagged as redundant, since those really can be inlined safely.

## Test

Added `redundant-object/allows-self-reused-in-nested-formation.yaml` with
the exact snippet from the issue, asserting zero defects.

## Test plan

- [x] New pack reproduces the issue on unpatched XSL and passes after the fix
- [x] `LtByXslTest#testsAllLintsByEo` (410 packs) passes
- [x] Full test suite (excluding the pre-existing flaky `deep`-tagged tests) passes

---
_Generated by [Claude Code](https://claude.ai/code/session_013BVHodYc5wvee5SFpGgwTa)_