### PR TITLE
fix(#1212): resolve catches-package-duplicate PDD puzzle

### DIFF
--- a/src/test/resources/org/eolang/lints/packs/single/duplicate-metas/catches-package-duplicate.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/duplicate-metas/catches-package-duplicate.yaml
@@ -1,21 +1,24 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-# @todo #1172:25min Enable `catches-package-duplicate` after fix in EO parser.
-#  Current EO version fails to parse EO with multiple `+package` metas.
-#  See this for more details: https://github.com/objectionary/eo/issues/6395.
-#  Once it will be fixed and realised, we can enable this test again.
-skip: true
-skip-errors: true
 sheets:
   - /org/eolang/lints/metas/unique-metas.xsl
 asserts:
   - /defects[count(defect[@severity='error'])=1]
   - /defects/defect[@line='2']
-input: |
-  +package test
-  +package sandbox
-
-  # No comments.
-  [] > main
-    (stdout "Hello, world!").print > @
+document: |
+  <object author="tests">
+    <metas>
+      <meta line="1">
+        <head>package</head>
+        <tail>test</tail>
+        <part>test</part>
+      </meta>
+      <meta line="2">
+        <head>package</head>
+        <tail>sandbox</tail>
+        <part>sandbox</part>
+      </meta>
+    </metas>
+    <o name="main"/>
+  </object>


### PR DESCRIPTION
## Summary

- Closes #1212.
- `catches-package-duplicate.yaml` was disabled (`skip: true`) waiting on a fix in the
  EO parser for multiple `+package` metas (objectionary/eo#6395). I confirmed the crash
  still reproduces against the currently pinned `eo-parser` 0.62.1: parsing EO source
  with two `+package` lines throws inside `add-default-package.xsl`
  (`A sequence of more than one item ... is not allowed as the first argument of
  fn:string()`), so relying on `input:` (raw EO source) is not viable yet.
- The pack targets `unique-metas.xsl`, which only cares about `/object/metas/meta`
  nodes and doesn't need the EO parser at all. Switched the fixture from `input:`
  (raw EO text) to `document:` (raw XMIR), supplying two `package` metas directly —
  the same pattern already used by `prints-context-when-lines-empty.yaml` in the same
  pack directory. This exercises the lint without hitting the parser bug.
- Removed the resolved `@todo #1172` comment and the `skip`/`skip-errors` flags.

## Test plan

- [x] `mvn -q test -Dtest=LtByXslTest` passes, including the now-enabled
      `catches-package-duplicate` pack.
- [x] Full `mvn -q test` suite passes.
- [x] `yamllint` on the changed file reports no issues.

---
_Generated by [Claude Code](https://claude.ai/code/session_017bnyhFFc62bRZXYBMaXZTW)_