### PR TITLE
fix(#520): replace new ArrayList<>(0) with new ArrayList<>()

### DIFF
--- a/src/main/java/org/eolang/lints/LtAsciiOnly.java
+++ b/src/main/java/org/eolang/lints/LtAsciiOnly.java
@@ -20,17 +20,13 @@ import java.util.stream.Collectors;
  *  For now we just reusing object line number (via @line), which is not correct
  *  for specifying on which line of the program comment is located. This issue
  *  can be solved after <a href="https://github.com/objectionary/eo/issues/3536">this one</a>.
- * @todo #402:15min Replace the creation of new ArrayList<>(0) with the creation of
- *  ArrayList<>() without a constructor argument in whole project. Add ignore warning
- *  ConditionalRegexpMultilineCheck from Checkstyle (it doesn't seem to be possible at the moment
- *  <a href="https://github.com/yegor256/qulice/issues/1328">issue 1328</a>)
  * @checkstyle UnnecessaryParenthesesCheck (30 lines)
  */
 final class LtAsciiOnly implements Lint {
 
     @Override
     public Collection<Defect> defects(final XML xmir) throws IOException {
-        final Collection<Defect> defects = new ArrayList<>(0);
+        final Collection<Defect> defects = new ArrayList<>();
         final Xnav xml = new Xnav(xmir.inner());
         final List<Xnav> comments = xml.path("/object/comments/comment")
             .collect(Collectors.toList());

--- a/src/main/java/org/eolang/lints/LtAsciiOnly.java
+++ b/src/main/java/org/eolang/lints/LtAsciiOnly.java
@@ -26,6 +26,7 @@ final class LtAsciiOnly implements Lint {
 
     @Override
     public Collection<Defect> defects(final XML xmir) throws IOException {
+        // @checkstyle ConditionalRegexpMultilineCheck (1 line)
         final Collection<Defect> defects = new ArrayList<>();
         final Xnav xml = new Xnav(xmir.inner());
         final List<Xnav> comments = xml.path("/object/comments/comment")

--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -129,6 +129,7 @@ final class LtByXsl implements Lint {
 
     @Override
     public Collection<Defect> defects(final XML xmir) {
+        // @checkstyle ConditionalRegexpMultilineCheck (1 line)
         final Collection<Defect> defects = new ArrayList<>();
         for (final XML defect : LtByXsl.findDefects(this.sheet.value().transform(xmir))) {
             final Xnav xml = new Xnav(defect.inner());

--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -129,7 +129,7 @@ final class LtByXsl implements Lint {
 
     @Override
     public Collection<Defect> defects(final XML xmir) {
-        final Collection<Defect> defects = new ArrayList<>(0);
+        final Collection<Defect> defects = new ArrayList<>();
         for (final XML defect : LtByXsl.findDefects(this.sheet.value().transform(xmir))) {
             final Xnav xml = new Xnav(defect.inner());
             final Optional<String> sever = xml.attribute("severity").text();

--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -40,6 +40,7 @@ final class LtUnlint implements Lint {
 
     @Override
     public Collection<Defect> defects(final XML xmir) throws IOException {
+        // @checkstyle ConditionalRegexpMultilineCheck (1 line)
         final Collection<Defect> defects = new ArrayList<>();
         final String lname = this.origin.name();
         final Collection<Defect> found = this.origin.defects(xmir);

--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -40,7 +40,7 @@ final class LtUnlint implements Lint {
 
     @Override
     public Collection<Defect> defects(final XML xmir) throws IOException {
-        final Collection<Defect> defects = new ArrayList<>(0);
+        final Collection<Defect> defects = new ArrayList<>();
         final String lname = this.origin.name();
         final Collection<Defect> found = this.origin.defects(xmir);
         final List<Integer> problematic = found.stream()

--- a/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
+++ b/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
@@ -64,7 +64,7 @@ final class LtUnlintNonExistingDefect implements Lint {
             .collect(Collectors.toList());
         final Collection<Defect> messages;
         if (unlints.isEmpty()) {
-            messages = new ArrayList<>(0);
+            messages = new ArrayList<>();
         } else {
             messages = unlints.stream().filter(
                 new DefectMissing(this.existing(unlints, xmir), this.excluded)::apply

--- a/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
+++ b/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
@@ -64,6 +64,7 @@ final class LtUnlintNonExistingDefect implements Lint {
             .collect(Collectors.toList());
         final Collection<Defect> messages;
         if (unlints.isEmpty()) {
+            // @checkstyle ConditionalRegexpMultilineCheck (1 line)
             messages = new ArrayList<>();
         } else {
             messages = unlints.stream().filter(

--- a/src/main/java/org/eolang/lints/Source.java
+++ b/src/main/java/org/eolang/lints/Source.java
@@ -103,7 +103,7 @@ public final class Source {
      */
     public Collection<Defect> defects() {
         try {
-            final Collection<Defect> messages = new ArrayList<>(0);
+            final Collection<Defect> messages = new ArrayList<>();
             for (final Lint lint : this.lints) {
                 messages.addAll(new ScopedDefects(lint.defects(this.xmir), "S"));
             }

--- a/src/main/java/org/eolang/lints/Source.java
+++ b/src/main/java/org/eolang/lints/Source.java
@@ -103,6 +103,7 @@ public final class Source {
      */
     public Collection<Defect> defects() {
         try {
+            // @checkstyle ConditionalRegexpMultilineCheck (1 line)
             final Collection<Defect> messages = new ArrayList<>();
             for (final Lint lint : this.lints) {
                 messages.addAll(new ScopedDefects(lint.defects(this.xmir), "S"));

--- a/src/test/java/matchers/DefectMatcher.java
+++ b/src/test/java/matchers/DefectMatcher.java
@@ -21,7 +21,7 @@ public final class DefectMatcher extends BaseMatcher<Defect> {
     /**
      * Synthetic matcher that is built when input arrives.
      */
-    private final List<Matcher<?>> matchers = new ArrayList<>(0);
+    private final List<Matcher<?>> matchers = new ArrayList<>();
 
     @Override
     public boolean matches(final Object input) {

--- a/src/test/java/matchers/DefectMatcher.java
+++ b/src/test/java/matchers/DefectMatcher.java
@@ -21,6 +21,7 @@ public final class DefectMatcher extends BaseMatcher<Defect> {
     /**
      * Synthetic matcher that is built when input arrives.
      */
+    // @checkstyle ConditionalRegexpMultilineCheck (1 line)
     private final List<Matcher<?>> matchers = new ArrayList<>();
 
     @Override

--- a/src/test/java/matchers/DefectsMatcher.java
+++ b/src/test/java/matchers/DefectsMatcher.java
@@ -27,7 +27,7 @@ public final class DefectsMatcher extends BaseMatcher<XML> {
 
     @Override
     public boolean matches(final Object xml) {
-        final Collection<Defect> defects = new ArrayList<>(0);
+        final Collection<Defect> defects = new ArrayList<>();
         for (final XML defect : ((XML) xml).nodes("/defects/defect")) {
             defects.add(
                 new Defect.Default(

--- a/src/test/java/matchers/DefectsMatcher.java
+++ b/src/test/java/matchers/DefectsMatcher.java
@@ -27,6 +27,7 @@ public final class DefectsMatcher extends BaseMatcher<XML> {
 
     @Override
     public boolean matches(final Object xml) {
+        // @checkstyle ConditionalRegexpMultilineCheck (1 line)
         final Collection<Defect> defects = new ArrayList<>();
         for (final XML defect : ((XML) xml).nodes("/defects/defect")) {
             defects.add(

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -373,6 +373,7 @@ final class SourceTest {
     }
 
     private static Map<Map<SourceSize, Collection<Defect>>, String> benchmarkResults() {
+        // @checkstyle ConditionalRegexpMultilineCheck (1 line)
         final List<Map<SourceSize, Collection<Defect>>> results = new ArrayList<>();
         final StringBuilder sum = new StringBuilder();
         for (final SourceSize source : SourceSize.values()) {

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -373,7 +373,7 @@ final class SourceTest {
     }
 
     private static Map<Map<SourceSize, Collection<Defect>>, String> benchmarkResults() {
-        final List<Map<SourceSize, Collection<Defect>>> results = new ArrayList<>(0);
+        final List<Map<SourceSize, Collection<Defect>>> results = new ArrayList<>();
         final StringBuilder sum = new StringBuilder();
         for (final SourceSize source : SourceSize.values()) {
             final long before = System.currentTimeMillis();


### PR DESCRIPTION
Closes #520

## Summary

- Replaces `new ArrayList<>(0)` with `new ArrayList<>()` across all 8 occurrences in the project (5 in `src/main`, 3 in `src/test`). The explicit initial-capacity argument `0` is redundant: `ArrayList` already starts with an empty backing array and grows on the first `add`.
- Removes the now-resolved `@todo #402:15min ...` puzzle comment from `LtAsciiOnly.java`.
- Qulice's Checkstyle config enforces the opposite via a custom `ConditionalRegexpMultilineCheck` rule (flags a no-size-argument `ArrayList<>()`). Rather than leaving it unsuppressed (which fails CI) or reverting the fix, each call site gets a `@checkstyle ConditionalRegexpMultilineCheck (1 line)` suppression comment — the same in-code suppression style already used elsewhere in this codebase (e.g. `LtAsciiOnly`'s `UnnecessaryParenthesesCheck`, `FxByXsl`'s `ConstructorsCodeFreeCheck`). This resolves the puzzle's suppression concern, which had blocked a prior attempt (#858).

## Test plan

- [x] `mvn compile` — builds cleanly
- [x] `mvn -Pqulice com.qulice:qulice-maven-plugin:check` — 0 violations
- [x] `mvn test` — full suite passes
- [x] Full CI suite — all 23 checks green