### PR TITLE
many-void-attributes counts rho toward the five-void cap

### DIFF
--- a/src/main/resources/org/eolang/lints/errors/many-void-attributes.xsl
+++ b/src/main/resources/org/eolang/lints/errors/many-void-attributes.xsl
@@ -9,9 +9,14 @@
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:variable name="max" select="5"/>
+  <!--
+  A void named "ρ" is the receiver, not an argument: every formation has one
+  whether or not the head spells it out, so counting it toward the cap
+  rewards leaving it implicit (objectionary/lints#1299).
+  -->
   <xsl:template match="/">
     <defects>
-      <xsl:for-each-group select="//o[@name and @base='∅' and not(o)]" group-by="generate-id(..)">
+      <xsl:for-each-group select="//o[@name and @name!='ρ' and @base='∅' and not(o)]" group-by="generate-id(..)">
         <xsl:if test="count(current-group()) &gt; $max">
           <xsl:for-each select="current-group()[1]/..">
             <xsl:element name="defect">

--- a/src/main/resources/org/eolang/motives/errors/many-void-attributes.md
+++ b/src/main/resources/org/eolang/motives/errors/many-void-attributes.md
@@ -15,3 +15,11 @@ Correct:
 [a b c d e] > with-ok
   something > @
 ```
+
+A void named `ρ` is the receiver, not an argument, so it does not count
+toward the cap:
+
+```eo
+[^ a b c d e] > with-ok
+  something > @
+```

--- a/src/test/resources/org/eolang/lints/packs/single/many-void-attributes/allows-rho-void-past-the-cap.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/many-void-attributes/allows-rho-void-past-the-cap.yaml
@@ -3,6 +3,10 @@
 ---
 # objectionary/lints#1299: a void named "ρ" is the receiver, not an
 # argument, so it must not count toward the five-void cap.
+# The released XMIR.xsd does not allow "ρ" as the name of an attribute
+# yet, see objectionary/eo#7500, so this document cannot be validated
+# against it.
+ignore-schema: true
 sheets:
   - /org/eolang/lints/errors/many-void-attributes.xsl
 asserts:

--- a/src/test/resources/org/eolang/lints/packs/single/many-void-attributes/allows-rho-void-past-the-cap.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/many-void-attributes/allows-rho-void-past-the-cap.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# objectionary/lints#1299: a void named "ρ" is the receiver, not an
+# argument, so it must not count toward the five-void cap.
+sheets:
+  - /org/eolang/lints/errors/many-void-attributes.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+document: |
+  <object author="tests">
+    <o name="matched">
+       <o base="∅" name="ρ"/>
+       <o base="∅" name="a"/>
+       <o base="∅" name="b"/>
+       <o base="∅" name="c"/>
+       <o base="∅" name="d"/>
+       <o base="∅" name="e"/>
+       <o base="Φ.boom" name="φ"/>
+    </o>
+  </object>


### PR DESCRIPTION
Fixes #1299. `many-void-attributes` counts a void named `ρ` toward the
five-void cap, but `ρ` is the receiver, not an argument: every formation
has one whether or not the head spells it out. Counting it means the real
cap is four for a formation that declares its receiver and five for one
that leaves it implicit, which rewards leaving it out.

Excluded a void named `ρ` from the count. Added a regression pack with
five real voids plus a named receiver, asserting zero defects.
