### PR TITLE
feat(#1207): add excessive-visibility lint

### DIFF
--- a/src/main/resources/org/eolang/lints/design/excessive-visibility.xsl
+++ b/src/main/resources/org/eolang/lints/design/excessive-visibility.xsl
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="excessive-visibility" version="2.0">
+  <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/test-name.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[eo:abstract(.) and @name]">
+        <xsl:variable name="tests" select="o[eo:test-name(@name)]"/>
+        <xsl:if test="exists($tests)">
+          <xsl:for-each select="o[@name and @base and @base != '∅' and @name != 'φ' and not(@local) and not(eo:test-name(@name))]">
+            <xsl:variable name="method" select="@name"/>
+            <!--
+            A test refers to a sibling method either by calling it on
+            itself, which the parser resolves into a "ξ.ρ."-prefixed chain
+            of self-references, or by chaining a dotted call onto some
+            other expression, e.g. "(phrase "x").multi-words", which the
+            parser resolves into a "."-prefixed postfix base.
+            -->
+            <xsl:variable name="used" select="$tests//o[@base and matches(@base, concat('^(ξ(\.ρ)+\.|\.)', $method, '(\.|$)'))]"/>
+            <xsl:if test="empty($used)">
+              <xsl:element name="defect">
+                <xsl:variable name="line" select="eo:lineno(@line)"/>
+                <xsl:attribute name="line">
+                  <xsl:value-of select="$line"/>
+                </xsl:attribute>
+                <xsl:if test="$line = '0'">
+                  <xsl:attribute name="context">
+                    <xsl:value-of select="eo:defect-context(.)"/>
+                  </xsl:attribute>
+                </xsl:if>
+                <xsl:attribute name="severity">
+                  <xsl:text>warning</xsl:text>
+                </xsl:attribute>
+                <xsl:attribute name="experimental">
+                  <xsl:text>true</xsl:text>
+                </xsl:attribute>
+                <xsl:text>The method </xsl:text>
+                <xsl:value-of select="eo:escape($method)"/>
+                <xsl:text> is public, but no unit test refers to it; obfuscate it with &gt;&gt; instead of &gt;</xsl:text>
+              </xsl:element>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/design/excessive-visibility.xsl
+++ b/src/main/resources/org/eolang/lints/design/excessive-visibility.xsl
@@ -3,7 +3,7 @@
 * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="excessive-visibility" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="excessive-visibility" version="2.0">
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>

--- a/src/main/resources/org/eolang/motives/design/excessive-visibility.md
+++ b/src/main/resources/org/eolang/motives/design/excessive-visibility.md
@@ -1,6 +1,6 @@
 # Excessive visibility
 
-A method that no unit test refers to is not really part of the object's
+A method that no unit test refers to is not part of the object's
 public interface: nothing outside the object depends on it being callable
 from outside. Such a method should be declared private (obfuscated with
 `>>`) instead of public (`>`), so its scope matches how it is actually used.

--- a/src/main/resources/org/eolang/motives/design/excessive-visibility.md
+++ b/src/main/resources/org/eolang/motives/design/excessive-visibility.md
@@ -1,0 +1,29 @@
+# Excessive visibility
+
+A method that no unit test refers to is not really part of the object's
+public interface: nothing outside the object depends on it being callable
+from outside. Such a method should be declared private (obfuscated with
+`>>`) instead of public (`>`), so its scope matches how it is actually used.
+
+Incorrect:
+
+```eo
+[t] > phrase
+  pos.gte 0 > multi-words
+  t.index-of " " > pos
+
+  [] +> checks-phrase
+    (phrase "Object Thinking").multi-words > @
+```
+
+Here, `pos` is never referred to by `checks-phrase` or by any other test, so
+it should be private:
+
+```eo
+[t] > phrase
+  pos.gte 0 > multi-words
+  t.index-of " " >> pos
+
+  [] +> checks-phrase
+    (phrase "Object Thinking").multi-words > @
+```

--- a/src/test/resources/org/eolang/lints/packs/single/excessive-visibility/allows-already-private-method.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/excessive-visibility/allows-already-private-method.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/excessive-visibility.xsl
+defects: 0
+input: |
+  [t] > phrase
+    pos.gte 0 > multi-words
+    t.index-of " " >> pos
+
+    [] +> checks-phrase
+      (phrase "Object Thinking").multi-words > @

--- a/src/test/resources/org/eolang/lints/packs/single/excessive-visibility/allows-decoratee-attribute.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/excessive-visibility/allows-decoratee-attribute.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/excessive-visibility.xsl
+defects: 0
+input: |
+  [n] > counter
+    n.plus 1 > @
+
+    [] +> checks-counter
+      (counter 1).eq 2 > @

--- a/src/test/resources/org/eolang/lints/packs/single/excessive-visibility/allows-method-used-directly-by-test.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/excessive-visibility/allows-method-used-directly-by-test.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/excessive-visibility.xsl
+defects: 0
+input: |
+  [t] > phrase
+    t.index-of " " > pos
+
+    [] +> checks-phrase
+      pos > @

--- a/src/test/resources/org/eolang/lints/packs/single/excessive-visibility/allows-method-used-via-qualified-call.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/excessive-visibility/allows-method-used-via-qualified-call.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/excessive-visibility.xsl
+defects: 0
+input: |
+  [t] > phrase
+    t.index-of " " > pos
+
+    [] +> checks-phrase
+      (phrase "Object Thinking").pos > @

--- a/src/test/resources/org/eolang/lints/packs/single/excessive-visibility/allows-object-without-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/excessive-visibility/allows-object-without-tests.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/excessive-visibility.xsl
+defects: 0
+input: |
+  [t] > phrase
+    pos.gte 0 > multi-words
+    t.index-of " " > pos

--- a/src/test/resources/org/eolang/lints/packs/single/excessive-visibility/catches-unused-method.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/excessive-visibility/catches-unused-method.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/excessive-visibility.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='3']
+  - /defects/defect[contains(text(), 'pos')]
+input: |
+  [t] > phrase
+    pos.gte 0 > multi-words
+    t.index-of " " > pos
+
+    [] +> checks-phrase
+      (phrase "Object Thinking").multi-words > @


### PR DESCRIPTION
fix #1207

## What

A new XSL-based lint `excessive-visibility` is added:

- `src/main/resources/org/eolang/lints/design/excessive-visibility.xsl` — the lint
- `src/main/resources/org/eolang/motives/design/excessive-visibility.md` — the motive
- `src/test/resources/org/eolang/lints/packs/single/excessive-visibility/*.yaml` — test packs

## Why

Consider this object:

```eo
[t] > phrase
  pos.gte 0 > multi-words
  t.index-of " " > pos

  [] +> checks-phrase
    (phrase "Object Thinking").multi-words > @
```

Here, `pos` is never referred to by any test, so it isn't really part of the
object's public interface. It should be declared private instead:

```eo
[t] > phrase
  pos.gte 0 > multi-words
  t.index-of " " >> pos

  [] +> checks-phrase
    (phrase "Object Thinking").multi-words > @
```

## How it works

For every abstract (named) formation that contains at least one unit test
(a nested attribute whose name starts with `+` or `-`, per the parser's own
test-attribute marker), the lint looks at each of its other direct, public,
non-void attributes (no `@local`, i.e. not already declared with `>>`, and
not `φ`). A method counts as "used by a test" when a test refers to it
either:

- by calling it on itself, which the parser resolves into a
  `ξ.ρ...ρ.<name>`-prefixed chain of self-references, or
- by chaining a dotted call onto some other expression, e.g.
  `(phrase "x").multi-words`, which the parser resolves into a
  `.<name>`-prefixed postfix base.

A public method that no test refers to either way is flagged, with a
message suggesting `>>` instead of `>`.

Objects without any unit tests at all are skipped entirely, to avoid
flagging every public attribute of code that simply isn't unit-tested yet —
this lint is only about attributes whose *tested* surface doesn't match
their declared visibility.

The self/postfix reference patterns were verified against the actual XMIR
produced by the current `eo-parser` (0.62.1) for both the self-call and the
chained-call cases, rather than assumed.

## Tests

- `catches-unused-method` — a public method untouched by the object's test
  is caught
- `allows-method-used-directly-by-test` — a bare self-call from the test
  clears the method
- `allows-method-used-via-qualified-call` — a dotted call onto a fresh
  instance clears the method
- `allows-object-without-tests` — no defects when the formation has no
  tests at all
- `allows-already-private-method` — a method already declared with `>>` is
  never a candidate
- `allows-decoratee-attribute` — the `@` decoratee itself is never flagged

`mvn test` (all `LtByXslTest` packs, 437 tests) and `mvn -Pqulice verify`
both pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GJEhUWEihLeSuKoHCyPX3w)_