### PR TITLE
feat(#1045): add same-package-alias lint

### DIFF
--- a/src/main/resources/org/eolang/lints/aliases/same-package-alias.xsl
+++ b/src/main/resources/org/eolang/lints/aliases/same-package-alias.xsl
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="same-package-alias" version="2.0">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:variable name="pkg" select="/object/metas/meta[head='package'][1]/tail"/>
+      <xsl:for-each select="/object/metas/meta[head='alias' and count(part)=2]">
+        <xsl:variable name="local" select="part[1]"/>
+        <xsl:variable name="fqn" select="replace(part[2], '^Φ\.', '')"/>
+        <xsl:if test="$pkg != '' and $fqn = concat($pkg, '.', $local)">
+          <xsl:element name="defect">
+            <xsl:variable name="line" select="eo:lineno(@line)"/>
+            <xsl:attribute name="line">
+              <xsl:value-of select="$line"/>
+            </xsl:attribute>
+            <xsl:if test="$line = '0'">
+              <xsl:attribute name="context">
+                <xsl:value-of select="eo:defect-context(.)"/>
+              </xsl:attribute>
+            </xsl:if>
+            <xsl:attribute name="severity">
+              <xsl:text>error</xsl:text>
+            </xsl:attribute>
+            <xsl:text>The alias </xsl:text>
+            <xsl:value-of select="eo:escape($fqn)"/>
+            <xsl:text> is redundant, because it refers to an object in the same package (</xsl:text>
+            <xsl:value-of select="eo:escape($pkg)"/>
+            <xsl:text>) as the current file</xsl:text>
+          </xsl:element>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/aliases/same-package-alias.md
+++ b/src/main/resources/org/eolang/motives/aliases/same-package-alias.md
@@ -1,0 +1,39 @@
+# Same-package alias
+
+An `+alias` meta that points to an object in the same package as the
+current file's `+package` meta is redundant. The compiler resolves a
+bare reference to an object of the same package on its own, so such
+an alias only adds noise.
+
+Incorrect:
+
+```eo
++package org.eolang.txt
++alias org.eolang.txt.sprintf
+
+# Foo.
+[x] > foo
+  sprintf x > @
+```
+
+Correct:
+
+```eo
++package org.eolang.txt
+
+# Foo.
+[x] > foo
+  sprintf x > @
+```
+
+An alias that points to a different package, or one that renames the
+object to a new local name, is not redundant and is left alone:
+
+```eo
++package org.eolang.txt
++alias sp org.eolang.txt.sprintf
+
+# Foo.
+[x] > foo
+  sp x > @
+```

--- a/src/test/resources/org/eolang/lints/packs/single/same-package-alias/allows-alias-when-no-package-meta.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/same-package-alias/allows-alias-when-no-package-meta.yaml
@@ -8,6 +8,5 @@ asserts:
 input: |
   +alias org.eolang.txt.sprintf
 
-  # Foo.
   [x] > foo
     sprintf x > @

--- a/src/test/resources/org/eolang/lints/packs/single/same-package-alias/allows-alias-when-no-package-meta.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/same-package-alias/allows-alias-when-no-package-meta.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/aliases/same-package-alias.xsl
+asserts:
+  - /defects[count(defect[@severity='error'])=0]
+input: |
+  +alias org.eolang.txt.sprintf
+
+  # Foo.
+  [x] > foo
+    sprintf x > @

--- a/src/test/resources/org/eolang/lints/packs/single/same-package-alias/allows-cross-package-alias.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/same-package-alias/allows-cross-package-alias.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/aliases/same-package-alias.xsl
+asserts:
+  - /defects[count(defect[@severity='error'])=0]
+input: |
+  +package org.eolang.txt
+  +alias org.eolang.io.stdout
+
+  # Foo.
+  [x] > foo
+    stdout x > @

--- a/src/test/resources/org/eolang/lints/packs/single/same-package-alias/allows-cross-package-alias.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/same-package-alias/allows-cross-package-alias.yaml
@@ -9,6 +9,5 @@ input: |
   +package org.eolang.txt
   +alias org.eolang.io.stdout
 
-  # Foo.
   [x] > foo
     stdout x > @

--- a/src/test/resources/org/eolang/lints/packs/single/same-package-alias/allows-renamed-same-package-alias.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/same-package-alias/allows-renamed-same-package-alias.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/aliases/same-package-alias.xsl
+asserts:
+  - /defects[count(defect[@severity='error'])=0]
+input: |
+  +package org.eolang.txt
+  +alias sp org.eolang.txt.sprintf
+
+  # Foo.
+  [x] > foo
+    sp x > @

--- a/src/test/resources/org/eolang/lints/packs/single/same-package-alias/allows-renamed-same-package-alias.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/same-package-alias/allows-renamed-same-package-alias.yaml
@@ -9,6 +9,5 @@ input: |
   +package org.eolang.txt
   +alias sp org.eolang.txt.sprintf
 
-  # Foo.
   [x] > foo
     sp x > @

--- a/src/test/resources/org/eolang/lints/packs/single/same-package-alias/catches-same-package-alias.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/same-package-alias/catches-same-package-alias.yaml
@@ -10,6 +10,5 @@ input: |
   +package org.eolang.txt
   +alias org.eolang.txt.sprintf
 
-  # Foo.
   [x] > foo
     sprintf x > @

--- a/src/test/resources/org/eolang/lints/packs/single/same-package-alias/catches-same-package-alias.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/same-package-alias/catches-same-package-alias.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/aliases/same-package-alias.xsl
+asserts:
+  - /defects[count(defect[@severity='error'])=1]
+  - /defects/defect[@line='2']
+input: |
+  +package org.eolang.txt
+  +alias org.eolang.txt.sprintf
+
+  # Foo.
+  [x] > foo
+    sprintf x > @

--- a/src/test/resources/org/eolang/lints/packs/single/same-package-alias/prints-context-when-lines-empty.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/same-package-alias/prints-context-when-lines-empty.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/aliases/same-package-alias.xsl
+asserts:
+  - /defects[count(defect[@context and @severity='error'])=1]
+document: |
+  <object author="tests">
+    <metas>
+      <meta>
+         <head>package</head>
+         <tail>org.eolang.txt</tail>
+         <part>org.eolang.txt</part>
+      </meta>
+      <meta>
+         <head>alias</head>
+         <tail>sprintf Φ.org.eolang.txt.sprintf</tail>
+         <part>sprintf</part>
+         <part>Φ.org.eolang.txt.sprintf</part>
+      </meta>
+    </metas>
+    <o name="foo"/>
+  </object>


### PR DESCRIPTION
Closes #1045.

Adds a new lint `same-package-alias` that catches an `+alias` meta whose
target object lives in the same package as the file's own `+package`
meta. Since the compiler auto-homes a bare reference to an object in the
same package, such an alias is redundant (see objectionary/eo#5527,
which removed all the existing ones by hand).

The parser expands a bare `+alias org.eolang.txt.sprintf` into the
two-part meta form `sprintf Φ.org.eolang.txt.sprintf`. The lint flags a
meta when the alias's fully-qualified target (with the `Φ.` prefix
stripped) equals `<package>.<local-name>`. A renamed alias
(`+alias sp org.eolang.txt.sprintf`) or a cross-package alias is left
alone, since neither is redundant.

## What's included

- `src/main/resources/org/eolang/lints/aliases/same-package-alias.xsl` — the lint
- `src/main/resources/org/eolang/motives/aliases/same-package-alias.md` — motive doc
- Five pack tests: catches the redundant case, allows a cross-package
  alias, allows a renamed same-package alias, allows an alias when no
  `+package` meta is present, and checks the `context` attribute is
  printed when line numbers are absent

## Testing

- `mvn test -Dtest=LtByXslTest,PkMonoTest` — 431 tests, 0 failures
- Full `mvn test -Dgroups='!deep & !benchmark'` — 0 failures, 0 errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01WwFnKcNakcpzPWb6HTQFPu)_