### PR TITLE
feat(#1317): add identity-object lint

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/identity-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/identity-object.xsl
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="identity-object" version="2.0">
+  <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[eo:abstract(.) and count(o) = 2 and o[1][@base='∅'][@name][not(o)] and o[2][@name='φ'][not(@const)][not(o)][@base=concat('ξ.', o[1]/@name)] and not(@line = o[1]/@line and @line = o[2]/@line and @pos = o[1]/@pos and @pos = o[2]/@pos)]">
+        <xsl:element name="defect">
+          <xsl:variable name="line" select="eo:lineno(@line)"/>
+          <xsl:attribute name="line">
+            <xsl:value-of select="$line"/>
+          </xsl:attribute>
+          <xsl:if test="$line = '0'">
+            <xsl:attribute name="context">
+              <xsl:value-of select="eo:defect-context(.)"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:attribute name="severity">
+            <xsl:text>warning</xsl:text>
+          </xsl:attribute>
+          <xsl:attribute name="experimental">true</xsl:attribute>
+          <xsl:text>The </xsl:text>
+          <xsl:choose>
+            <xsl:when test="@name">
+              <xsl:text>formation </xsl:text>
+              <xsl:value-of select="eo:escape(@name)"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:text>anonymous formation</xsl:text>
+            </xsl:otherwise>
+          </xsl:choose>
+          <xsl:text> is a hand-written identity object and may be replaced with the "I" glyph</xsl:text>
+        </xsl:element>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/misc/identity-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/identity-object.xsl
@@ -11,7 +11,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[eo:abstract(.) and count(o) = 2 and o[1][@base='∅'][@name][not(o)] and o[2][@name='φ'][not(@const)][not(o)][@base=concat('ξ.', o[1]/@name)] and not(@line = o[1]/@line and @line = o[2]/@line and @pos = o[1]/@pos and @pos = o[2]/@pos)]">
+      <xsl:for-each select="//o[eo:abstract(.) and count(o) = 2 and o[1]/@base='∅' and o[1]/@name and not(o[1]/o) and o[2]/@name='φ' and not(o[2]/@const) and not(o[2]/o) and o[2]/@base=concat('ξ.', o[1]/@name) and not(@line = o[1]/@line and @line = o[2]/@line and @pos = o[1]/@pos and @pos = o[2]/@pos)]">
         <xsl:element name="defect">
           <xsl:variable name="line" select="eo:lineno(@line)"/>
           <xsl:attribute name="line">
@@ -36,7 +36,7 @@
               <xsl:text>anonymous formation</xsl:text>
             </xsl:otherwise>
           </xsl:choose>
-          <xsl:text> is a hand-written identity object and may be replaced with the "I" glyph</xsl:text>
+          <xsl:text> is a handwritten identity object and may be replaced with the "I" glyph</xsl:text>
         </xsl:element>
       </xsl:for-each>
     </defects>

--- a/src/main/resources/org/eolang/motives/misc/identity-object.md
+++ b/src/main/resources/org/eolang/motives/misc/identity-object.md
@@ -1,0 +1,21 @@
+# Identity object
+
+The language has a glyph for the identity object, `I`, which is
+`[x] > (φ ↦ x)`. Writing that formation out by hand instead of using
+the glyph is discouraged.
+
+Incorrect:
+
+```eo
+[] > jeff
+  [value] > pass
+    value > @
+  foo pass > @
+```
+
+Correct:
+
+```eo
+[] > jeff
+  foo I > @
+```

--- a/src/main/resources/org/eolang/motives/misc/identity-object.md
+++ b/src/main/resources/org/eolang/motives/misc/identity-object.md
@@ -1,8 +1,8 @@
 # Identity object
 
-The language has a glyph for the identity object, `I`, which is
+The language has a symbol for the identity object, `I`, which is
 `[x] > (φ ↦ x)`. Writing that formation out by hand instead of using
-the glyph is discouraged.
+the symbol is discouraged.
 
 Incorrect:
 

--- a/src/test/resources/org/eolang/lints/packs/single/identity-object/allows-desugared-glyph.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/identity-object/allows-desugared-glyph.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/identity-object.xsl
+defects: 0
+document: |
+  <object author="tests">
+    <o line="3" pos="7" name="i">
+      <o line="3" pos="7" base="∅" name="x"/>
+      <o line="3" pos="7" base="ξ.x" name="φ"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/identity-object/allows-phi-applied-to-something.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/identity-object/allows-phi-applied-to-something.yaml
@@ -9,7 +9,7 @@ document: |
     <o line="1" pos="1" name="applies">
       <o line="1" pos="2" base="∅" name="x"/>
       <o line="1" pos="3" base="ξ.x" name="φ">
-        <o line="1" pos="4" base="Q.number"/>
+        <o line="1" pos="4" base="Φ.number"/>
       </o>
     </o>
   </object>

--- a/src/test/resources/org/eolang/lints/packs/single/identity-object/allows-phi-applied-to-something.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/identity-object/allows-phi-applied-to-something.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/identity-object.xsl
+defects: 0
+document: |
+  <object author="tests">
+    <o line="1" pos="1" name="applies">
+      <o line="1" pos="2" base="∅" name="x"/>
+      <o line="1" pos="3" base="ξ.x" name="φ">
+        <o line="1" pos="4" base="Q.number"/>
+      </o>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/identity-object/allows-phi-to-wrong-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/identity-object/allows-phi-to-wrong-name.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/identity-object.xsl
+defects: 0
+document: |
+  <object author="tests">
+    <o line="1" pos="1" name="wrong-ref">
+      <o line="1" pos="2" base="∅" name="x"/>
+      <o line="1" pos="3" base="ξ.y" name="φ"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/identity-object/allows-two-voids.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/identity-object/allows-two-voids.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/identity-object.xsl
+defects: 0
+document: |
+  <object author="tests">
+    <o line="1" pos="1" name="two-voids">
+      <o line="1" pos="2" base="∅" name="a"/>
+      <o line="1" pos="3" base="∅" name="b"/>
+      <o line="1" pos="4" base="ξ.a" name="φ"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/identity-object/catches-anonymous-identity.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/identity-object/catches-anonymous-identity.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/identity-object.xsl
+asserts:
+  - /defects[count(defect[@severity='warning' and @experimental])=1]
+  - /defects/defect[contains(text(), 'anonymous formation')]
+document: |
+  <object author="tests">
+    <o line="1" pos="1" name="uses-anon-identity">
+      <o line="2" pos="1" base="Φ.foo">
+        <o line="3" pos="1">
+          <o line="3" pos="2" base="∅" name="x"/>
+          <o line="3" pos="3" base="ξ.x" name="φ"/>
+        </o>
+      </o>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/identity-object/catches-hand-written-identity.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/identity-object/catches-hand-written-identity.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/identity-object.xsl
+asserts:
+  - /defects[count(defect[@severity='warning' and @experimental])=1]
+  - /defects/defect[contains(text(), '"pass"')]
+document: |
+  <object author="tests">
+    <o line="1" pos="1" name="pass">
+      <o line="1" pos="2" base="∅" name="value"/>
+      <o line="1" pos="3" base="ξ.value" name="φ"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/identity-object/prints-context-when-lines-empty.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/identity-object/prints-context-when-lines-empty.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/identity-object.xsl
+asserts:
+  - /defects[count(defect[@context and @severity='warning'])=1]
+document: |
+  <object author="tests">
+    <o name="pass">
+      <o base="∅" name="value"/>
+      <o base="ξ.value" name="φ"/>
+    </o>
+  </object>


### PR DESCRIPTION
## Summary

- Adds a new `identity-object` lint that flags a handwritten identity formation (`[x] > (φ ↦ x)`) that could be replaced with the `I` glyph.
- A formation is only matched when it binds exactly one void and decorates that same void via `ξ`; the glyph's own desugared shape is told apart by its formation, void and `φ` all sharing the same `@line`/`@pos`, since all three come from the single glyph character (per the heuristic proposed in the issue).
- Adds the lint's motive doc and a YAML test pack covering the catching case, the desugared-glyph false positive, the three near-miss shapes called out in the issue (two voids, `φ` applied to something, `φ` reaching a name that isn't its own void), an anonymous-formation case, and a line-0/context case.

Closes #1317

## Test plan

- [x] `mvn test -Dtest=LtByXslTest#testsAllLintsByEo` — all 427 YAML packs pass, including the new `identity-object` pack
- [x] `mvn test` — full test suite passes
- [x] `mvn verify -DskipTests` — qulice static analysis passes
- [x] `xcop`, `yamllint`, `reuse lint`, `typos`, `markdownlint-cli2`, `vale` — all pass on the new files (no errors)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KicXH9j9HV3JxU57JHJr33)_