### PR TITLE
fix(#640): recognize chained-dot usage of $-aliased attributes

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
@@ -15,7 +15,8 @@
       <xsl:for-each select="//o[generate-id() != $top and @name and @name != 'φ' and @base and @base != '∅' and not(@base='ξ' and @name='xi🌵')]">
         <xsl:variable name="in-recursive" select="some $r in key('referenced-by-name', @name), $f in $r/ancestor::o[@name and not(@base)] satisfies exists(key('referenced-by-name', $f/@name) intersect $f/descendant::o)"/>
         <xsl:variable name="self-alias-crosses-formation" select="@base = 'ξ' and (some $r in key('referenced-by-name', @name) satisfies matches($r/@base, '^ξ\.ρ\.'))"/>
-        <xsl:if test="count(key('referenced-by-name', @name))&lt;=1 and not(@name and o[1]/@base = 'Φ.dataized') and not($in-recursive) and not($self-alias-crosses-formation)">
+        <xsl:variable name="self-used-via-chained-dot" select="@base = 'ξ' and exists(//o[matches(@base, concat('^\.', @name, '(?:\.[\w-]+)*$'))])"/>
+        <xsl:if test="count(key('referenced-by-name', @name))&lt;=1 and not(@name and o[1]/@base = 'Φ.dataized') and not($in-recursive) and not($self-alias-crosses-formation) and not($self-used-via-chained-dot)">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
+++ b/src/main/resources/org/eolang/lints/misc/redundant-object.xsl
@@ -15,7 +15,8 @@
       <xsl:for-each select="//o[generate-id() != $top and @name and @name != 'φ' and @base and @base != '∅' and not(@base='ξ' and @name='xi🌵')]">
         <xsl:variable name="in-recursive" select="some $r in key('referenced-by-name', @name), $f in $r/ancestor::o[@name and not(@base)] satisfies exists(key('referenced-by-name', $f/@name) intersect $f/descendant::o)"/>
         <xsl:variable name="self-alias-crosses-formation" select="@base = 'ξ' and (some $r in key('referenced-by-name', @name) satisfies matches($r/@base, '^ξ\.ρ\.'))"/>
-        <xsl:variable name="self-used-via-chained-dot" select="@base = 'ξ' and exists(//o[matches(@base, concat('^\.', @name, '(?:\.[\w-]+)*$'))])"/>
+        <xsl:variable name="candidate-name" select="@name"/>
+        <xsl:variable name="self-used-via-chained-dot" select="@base = 'ξ' and exists(//o[matches(@base, concat('^\.', $candidate-name, '(?:\.[\w-]+)*$'))])"/>
         <xsl:if test="count(key('referenced-by-name', @name))&lt;=1 and not(@name and o[1]/@base = 'Φ.dataized') and not($in-recursive) and not($self-alias-crosses-formation) and not($self-used-via-chained-dot)">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-self-used-via-chained-dot.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-self-used-via-chained-dot.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/redundant-object.xsl
+defects: 0
+input: |
+  # Bytes as input.
+  [bts] > bytes-as-input
+    # Read `size` amount of bytes from `bts`.
+    [size] > read
+      ((input-block bts --).read size).self > @
+      # Bytes-as-input block.
+      [data buffer] > input-block
+        buffer > @
+        $ > self

--- a/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-self-used-via-chained-dot.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/redundant-object/allows-self-used-via-chained-dot.yaml
@@ -5,12 +5,9 @@ sheets:
   - /org/eolang/lints/misc/redundant-object.xsl
 defects: 0
 input: |
-  # Bytes as input.
   [bts] > bytes-as-input
-    # Read `size` amount of bytes from `bts`.
     [size] > read
       ((input-block bts --).read size).self > @
-      # Bytes-as-input block.
       [data buffer] > input-block
         buffer > @
         $ > self


### PR DESCRIPTION
Fixes #640.

## The bug

`redundant-object` flags a `$`-aliased attribute (e.g. `$ > self`) as redundant when its only usage in the program is a trailing dot-attribute access on the result of an unrelated call chain, such as:

```eo
[bts] > bytes-as-input
  [size] > read
    ((input-block bts --).read size).self > @

    [data buffer] > input-block
      buffer > @
      $ > self
```

Here `self` (declared via `$ > self`) is used through `.self` at the end of the `((input-block bts --).read size).self` chain. The lint's `referenced-by-name` key only indexes usages whose `@base` starts with `ξ(.ρ)*.` or `Φ.pkg.`, so this chained-dot access is invisible to it, the usage count stays at `<= 1`, and the lint incorrectly reports `self` as redundant — even though `self` cannot actually be inlined (`(...).$` is not valid EO).

## Fix

`src/main/resources/org/eolang/lints/misc/redundant-object.xsl`: add a `self-used-via-chained-dot` check that looks for any `o[@base]` in the document matching `^\.NAME(?:\.[\w-]+)*$`, and skip the warning for `$`-aliased candidates (`@base = 'ξ'`) when such a usage exists. This mirrors the existing `self-alias-crosses-formation` guard already in the file.

## Test

New pack `redundant-object/allows-self-used-via-chained-dot.yaml` reproduces the exact example from the issue and asserts zero defects. The full `LtByXslTest#testsAllLintsByEo` suite (438 tests) and the complete `mvn test` run pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELh6FCEHCn5UN8GYxAYqr7)_