### PR TITLE
feat(#787): add sprintf-constant-args lint

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/sprintf-constant-args.xsl
+++ b/src/main/resources/org/eolang/lints/misc/sprintf-constant-args.xsl
@@ -3,7 +3,7 @@
 * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:eo="https://www.eolang.org" version="2.0" id="sprintf-constant-args">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="sprintf-constant-args">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>

--- a/src/main/resources/org/eolang/lints/misc/sprintf-constant-args.xsl
+++ b/src/main/resources/org/eolang/lints/misc/sprintf-constant-args.xsl
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:eo="https://www.eolang.org" version="2.0" id="sprintf-constant-args">
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <!-- Collect the actual argument nodes of a "*"-built tuple, in order -->
+  <xsl:template match="o" mode="constant-args" as="element()*">
+    <xsl:if test="@base='Φ.tuple' and count(o) &gt;= 2">
+      <xsl:apply-templates select="o[1]" mode="constant-args"/>
+      <xsl:sequence select="o[2]"/>
+    </xsl:if>
+  </xsl:template>
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[@base='Φ.txt.sprintf'][count(o)=2][o[2][@base='Φ.tuple']]">
+        <xsl:variable name="text" select="o[1][@base='Φ.string']/o[1][@base='Φ.bytes']/o/text()"/>
+        <xsl:if test="$text">
+          <xsl:variable name="formatters">
+            <xsl:variable name="txt" select="translate($text, '-', '')"/>
+            <!-- First, replace %% with a unique placeholder to avoid counting it as a formatter -->
+            <xsl:variable name="escaped" select="replace($txt, '(25)(25)', 'ESCAPED_PERCENT')"/>
+            <!-- %s -->
+            <xsl:variable name="strings" select="count(tokenize($escaped, '2573'))"/>
+            <!-- %d -->
+            <xsl:variable name="numbers" select="count(tokenize($escaped, '2564'))"/>
+            <!-- %f -->
+            <xsl:variable name="floats" select="count(tokenize($escaped, '2566'))"/>
+            <!-- %x -->
+            <xsl:variable name="bytes" select="count(tokenize($escaped, '2578'))"/>
+            <!-- %b -->
+            <xsl:variable name="bools" select="count(tokenize($escaped, '2562'))"/>
+            <xsl:value-of select="$strings + $numbers + $floats + $bytes + $bools - 5"/>
+          </xsl:variable>
+          <xsl:variable name="args" as="element()*">
+            <xsl:apply-templates select="o[2]" mode="constant-args"/>
+          </xsl:variable>
+          <xsl:if test="$formatters &gt; 0 and count($args) &gt; 0 and count($args[not(@base='Φ.string')]) = 0 and count($args[not(o[1][@base='Φ.bytes']/o[1]/text())]) = 0">
+            <defect>
+              <xsl:variable name="line" select="eo:lineno(@line)"/>
+              <xsl:attribute name="line">
+                <xsl:value-of select="$line"/>
+              </xsl:attribute>
+              <xsl:if test="$line = '0'">
+                <xsl:attribute name="context">
+                  <xsl:value-of select="eo:defect-context(.)"/>
+                </xsl:attribute>
+              </xsl:if>
+              <xsl:attribute name="severity">
+                <xsl:text>warning</xsl:text>
+              </xsl:attribute>
+              <xsl:text>The "Φ.txt.sprintf" object is used with a constant format template and constant string arguments only; since the result is already known, a plain literal string should be used instead</xsl:text>
+            </defect>
+          </xsl:if>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/misc/sprintf-constant-args.md
+++ b/src/main/resources/org/eolang/motives/misc/sprintf-constant-args.md
@@ -1,8 +1,8 @@
 # `QQ.txt.sprintf` With Constant String Arguments Only
 
 Using `QQ.txt.sprintf` makes no sense when the format template and all
-the arguments filling its placeholders are constant strings: the result
-is already known and a plain literal string can be used instead.
+the arguments filling its placeholders are constant strings. The result
+is already known, so a plain literal string can be used instead.
 
 Incorrect:
 

--- a/src/main/resources/org/eolang/motives/misc/sprintf-constant-args.md
+++ b/src/main/resources/org/eolang/motives/misc/sprintf-constant-args.md
@@ -1,0 +1,23 @@
+# `QQ.txt.sprintf` With Constant String Arguments Only
+
+Using `QQ.txt.sprintf` makes no sense when the format template and all
+the arguments filling its placeholders are constant strings: the result
+is already known and a plain literal string can be used instead.
+
+Incorrect:
+
+```eo
+[] > app
+  QQ.io.stdout > @
+    QQ.txt.sprintf
+      "%s %s"
+      * "hello" "world!"
+```
+
+Correct:
+
+```eo
+[] > app
+  QQ.io.stdout > @
+    "hello world!"
+```

--- a/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/allows-sprintf-with-dynamic-args.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/allows-sprintf-with-dynamic-args.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/sprintf-constant-args.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [a b] > app
+    io.stdout > @
+      txt.sprintf
+        "%s %s"
+        * a b

--- a/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/allows-sprintf-with-dynamic-template.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/allows-sprintf-with-dynamic-template.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/sprintf-constant-args.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [fmt] > app
+    io.stdout > @
+      txt.sprintf
+        fmt
+        * "hello"

--- a/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/allows-sprintf-with-mixed-constant-and-dynamic-args.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/allows-sprintf-with-mixed-constant-and-dynamic-args.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/sprintf-constant-args.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [name] > app
+    io.stdout > @
+      txt.sprintf
+        "Hello, %s and %s!"
+        *
+          "Jeff"
+          name

--- a/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/allows-sprintf-with-number-arg.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/allows-sprintf-with-number-arg.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/sprintf-constant-args.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [] > app
+    io.stdout > @
+      txt.sprintf
+        "%s %d"
+        *
+          "hello"
+          42

--- a/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/allows-sprintf-without-args.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/allows-sprintf-without-args.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/sprintf-constant-args.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [] > app
+    io.stdout > @
+      txt.sprintf
+        "%s"
+        *

--- a/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/catches-sprintf-with-constant-string-args.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/catches-sprintf-with-constant-string-args.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/sprintf-constant-args.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='3']
+input: |
+  [] > app
+    io.stdout > @
+      txt.sprintf
+        "%s %s"
+        *
+          "hello"
+          "world!"

--- a/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/catches-sprintf-with-single-constant-arg.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/catches-sprintf-with-single-constant-arg.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/sprintf-constant-args.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@line='3']
+input: |
+  [] > app
+    io.stdout > @
+      txt.sprintf
+        "Hello, %s!"
+        * "Jeff"

--- a/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/ignores-sprintf-absence.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/ignores-sprintf-absence.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/sprintf-constant-args.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=0]
+input: |
+  [] > app
+    io.stdout > @
+      "just text"


### PR DESCRIPTION
Fixes #787

## What

A new XSL-based lint `sprintf-constant-args` is added:

- `src/main/resources/org/eolang/lints/misc/sprintf-constant-args.xsl` — the lint implementation
- `src/main/resources/org/eolang/motives/misc/sprintf-constant-args.md` — the motive
- `src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/*.yaml` — declarative test packs

## Why

```eo
tt.sprintf *1
  "%s %s"
  "hello"
  "world!"
```

Here, both the format template and every argument filling its placeholders
are literal strings, so the result is already known at "compile time" and a
plain literal string (`"hello world!"`) should be used instead of calling
`QQ.txt.sprintf`.

## How it works

The lint looks at every `//o[@base='Φ.txt.sprintf']` call whose first
argument is a literal string template (same literal-detection pattern as
the existing `wrong-sprintf-arguments` and `sprintf-without-formatters`
lints) and whose second argument is a proper `Φ.tuple`. It walks the tuple
(the same cons-list shape `wrong-sprintf-arguments.xsl` already walks to
count arguments) collecting the actual value node at each level, and fires
a `warning` when:

- the template has at least one supported format specifier (`%s`, `%d`,
  `%f`, `%x`, `%b`), and
- there is at least one argument, and
- every argument is itself a literal string (`Φ.string` wrapping literal
  `Φ.bytes` text) — a single non-string or dynamic argument (a number
  literal, a variable, a method call, etc.) prevents the defect from firing.

## Tests

- `catches-sprintf-with-constant-string-args` — two constant string args
- `catches-sprintf-with-single-constant-arg` — a single constant string arg
- `allows-sprintf-with-dynamic-args` — variables passed as args
- `allows-sprintf-with-number-arg` — a numeric literal among the args
- `allows-sprintf-without-args` — formatter present but no arguments
- `allows-sprintf-with-dynamic-template` — non-literal format template
- `allows-sprintf-with-mixed-constant-and-dynamic-args` — one literal, one variable
- `ignores-sprintf-absence` — no `sprintf` call at all

`mvn test -Dtest=LtByXslTest` passes locally, including the new packs and
the repo's structural checks (`checksLocationsOfYamlPacks`,
`checksIdsInXslStylesheets`, `checksMotivesForPresence`).


---
_Generated by [Claude Code](https://claude.ai/code/session_011VQ2n6mJeAspeXPTENkXu3)_