### PR TITLE
anemic-getter flags ^ > name, but naming the receiver is not a rename

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/anemic-getter.xsl
+++ b/src/main/resources/org/eolang/lints/misc/anemic-getter.xsl
@@ -11,13 +11,19 @@
   <!--
   A named object whose whole body is a reference to something the code can
   already reach, unchanged, right where the object sits is an "anemic getter".
-  Two shapes of body qualify: a sibling attribute of the same formation, as in
-  "title > t" inside a "[title] > book" formation, and a bare chain of "ξ" and
-  "ρ" hops, as in "^ > f" or "$ > f", which "^" and "$" already say. Such
-  renaming is redundant, since the original may be used directly, so we
-  complain about it here. A reference that reaches past the hops for an
-  attribute, such as "^.bar", names something other than the hop itself, so it
-  is not a rename and stays out of scope.
+  One shape of body qualifies: a sibling attribute of the same formation, as
+  in "title > t" inside a "[title] > book" formation, which is redundant
+  since the original may be used directly, so we complain about it here. A
+  bare chain of "ρ" hops, as in "^ > f" or "^.^ > f", stays out of scope even
+  though "^" or "^.^" already says it: naming a receiver reached this way
+  adds something a hop count does not, a name that survives nesting, where
+  the hop-count spelling silently retargets when a block using it is
+  re-indented or wrapped (objectionary/lints#1300). "$ > f", a bare reference
+  to the formation itself, is still flagged: "$" is already the shortest
+  possible spelling, so nothing is gained by naming it either way. A
+  reference that reaches past the hops for an attribute, such as "^.bar",
+  names something other than the hop itself, so it is not a rename and stays
+  out of scope too.
   -->
   <xsl:template match="/">
     <defects>
@@ -28,10 +34,6 @@
             <!-- "$", the formation itself -->
             <xsl:when test="@base='ξ'">
               <xsl:text>$</xsl:text>
-            </xsl:when>
-            <!-- "^", "^.^", and so on: one "^" per "ρ" hop -->
-            <xsl:when test="matches(@base, '^ξ(\.ρ)+$')">
-              <xsl:value-of select="replace($ref, 'ρ', '^')"/>
             </xsl:when>
             <!-- a sibling attribute of the same formation -->
             <xsl:when test="matches(@base, '^ξ\.[^.]+$') and ../o[@name=$ref]">

--- a/src/main/resources/org/eolang/motives/misc/anemic-getter.md
+++ b/src/main/resources/org/eolang/motives/misc/anemic-getter.md
@@ -35,22 +35,27 @@ sibling attribute, not only void ones:
 
 Here `y` is an anemic getter for `x` and should be removed.
 
-The parent object and the formation itself are reachable by `^` and `$`, so
-renaming them is just as redundant:
+The formation itself is reachable by `$`, so renaming it is just as
+redundant:
 
 ```eo
 # Foo.
 [] > foo
-  ^ > f
   $ > s
 ```
 
-Here `f` is an anemic getter for `^`, and `s` is one for `$`. Write `^` and
-`$` where `f` and `s` were used, and drop both. A longer chain of hops, such
-as `^.^`, is no different.
+Here `s` is an anemic getter for `$`. Write `$` where `s` was used, and drop
+it.
 
-A reference that goes past the hops for an attribute, though, is not a
-rename, and we leave it alone:
+The parent object, reachable by `^` (or a longer chain of hops, such as
+`^.^`), is different: naming it, as in `^ > f`, is not flagged, even though
+`^` already says it. The name survives nesting, where the hop-count spelling
+does not. A name written once as `f` stays `f` however the formation is
+nested later, while `^.^` points at whatever happens to be two hops up
+if a block using it is re-indented or wrapped in another formation.
+
+A reference that goes past the hops for an attribute is not a rename either,
+and we leave it alone:
 
 ```eo
 # Foo.

--- a/src/test/resources/org/eolang/lints/packs/single/anemic-getter/allows-double-rho-rename.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anemic-getter/allows-double-rho-rename.yaml
@@ -4,8 +4,8 @@
 sheets:
   - /org/eolang/lints/misc/anemic-getter.xsl
 asserts:
-  - /defects[count(defect[@severity='warning'])=1]
-  - /defects/defect[@line='2']
+  - /defects[count(defect[@severity='warning'])=0]
 input: |
   [] > foo
-    ^ > f
+    [] > inner
+      ^.^ > f

--- a/src/test/resources/org/eolang/lints/packs/single/anemic-getter/allows-rho-rename.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/anemic-getter/allows-rho-rename.yaml
@@ -4,9 +4,7 @@
 sheets:
   - /org/eolang/lints/misc/anemic-getter.xsl
 asserts:
-  - /defects[count(defect[@severity='warning'])=1]
-  - /defects/defect[@line='3']
+  - /defects[count(defect[@severity='warning'])=0]
 input: |
   [] > foo
-    [] > inner
-      ^.^ > f
+    ^ > f


### PR DESCRIPTION
Fixes #1300. `anemic-getter` flagged `^ > f` (and `^.^ > f`, and so on) as a redundant rename of `^`, but naming the receiver this way adds something a hop count does not: a name that survives nesting. `^.^` retargets silently if a block using it is re-indented or wrapped in another formation; a name written once as `f` does not.

Removed the branch that treated a bare chain of `^` hops as a rename target. `$ > f`, a bare reference to the formation itself, is still flagged, since `$` is already the shortest possible spelling.

Converted the two packs that exercised this shape, `catches-rho-rename` and `catches-double-rho-rename`, into `allows-*` packs asserting zero defects, and updated the motive doc to match.

Same change as #1303, which was closed because the commits were not signed. This one is signed.
