### PR TITLE
add unoptimizable-recursion lint

### DIFF
--- a/.github/styles/config/vocabularies/Custom/accept.txt
+++ b/.github/styles/config/vocabularies/Custom/accept.txt
@@ -19,3 +19,5 @@ inlined
 [Ss]ubgraph
 [Aa]pplication
 [Ff]orma(e)?
+[Tt]ranspile(d|s|r)?
+[Uu]noptimizable

--- a/src/main/resources/org/eolang/lints/design/unoptimizable-recursion.xsl
+++ b/src/main/resources/org/eolang/lints/design/unoptimizable-recursion.xsl
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="unoptimizable-recursion" version="2.0">
+  <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
+  <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
+  <xsl:import href="/org/eolang/funcs/escape.xsl"/>
+  <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <!--
+  Is the object in a tail position of the expression rooted at $root? It is
+  when every step from $root down to it is one of two: a branch of an ".if",
+  which is the argument α0 or α1 and never the receiver, or the last element
+  of the tuple a "seq" is applied to, which is the α1 of the "Φ.tuple"
+  standing as the α0 of the "Φ.seq". Both answer exactly that element, so
+  the value of the whole expression is the value of the object whenever the
+  object is forced. This is the same test the compiler runs in
+  "_recursion.xsl", where it decides what to turn into a loop.
+  -->
+  <xsl:function name="eo:tail" as="xs:boolean">
+    <xsl:param name="o" as="element()"/>
+    <xsl:param name="root" as="element()"/>
+    <xsl:variable name="parent" as="element()?" select="$o/parent::o"/>
+    <xsl:choose>
+      <xsl:when test="$o is $root">
+        <xsl:sequence select="true()"/>
+      </xsl:when>
+      <xsl:when test="empty($parent)">
+        <xsl:sequence select="false()"/>
+      </xsl:when>
+      <xsl:when test="ends-with($parent/@base, '.if') and $o/@as = ('α0', 'α1')">
+        <xsl:sequence select="eo:tail($parent, $root)"/>
+      </xsl:when>
+      <xsl:when test="$parent/@base = 'Φ.tuple' and $parent/@as = 'α0' and $parent/parent::o/@base = 'Φ.seq' and $o/@as = 'α1'">
+        <xsl:sequence select="eo:tail($parent/parent::o, $root)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:sequence select="false()"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <!--
+  @todo #1321:60min Name the shapes this lint still misses.
+  The compiler also leaves the recursion alone when the self-call is
+  spelled "Phi.name" instead of "^.name", when the formation is reached
+  other than by a plain application, as a decoratee or as the receiver of
+  a dispatch, when an attribute holding a self-call is read from outside
+  the formation, as in "range", and when two formations call each other.
+  Each of those is syntactic, so each can be found here and reported with
+  a reason of its own, the way the four below are.
+  -->
+  <!--
+  A nested formation that calls itself has its recursion turned into a Java
+  loop, one copy of the object per step instead of one Java stack block, but
+  only when the compiler recognises the shape. When it does not, the program
+  still runs, only deeper and slower, and nothing says so at the call site.
+  We say it here.
+  -->
+  <xsl:template match="/">
+    <defects>
+      <xsl:for-each select="//o[eo:abstract(.) and @name and parent::o and o[@name='φ']]">
+        <xsl:variable name="self" select="concat('ξ.ρ.', @name)"/>
+        <xsl:variable name="root" select="o[@name='φ']"/>
+        <xsl:variable name="calls" select=".//o[@base = $self or starts-with(@base, concat($self, '.'))]"/>
+        <xsl:variable name="loops" select="($root | $root//o)[@base = $self and eo:tail(., $root)]"/>
+        <xsl:if test="exists($calls) and empty($loops)">
+          <defect>
+            <xsl:variable name="line" select="eo:lineno($calls[1]/@line)"/>
+            <xsl:attribute name="line">
+              <xsl:value-of select="$line"/>
+            </xsl:attribute>
+            <xsl:if test="$line = '0'">
+              <xsl:attribute name="context">
+                <xsl:value-of select="eo:defect-context(.)"/>
+              </xsl:attribute>
+            </xsl:if>
+            <xsl:attribute name="severity">warning</xsl:attribute>
+            <xsl:attribute name="experimental">true</xsl:attribute>
+            <xsl:text>The recursion in </xsl:text>
+            <xsl:value-of select="eo:escape(@name)"/>
+            <xsl:text> cannot be turned into a loop, </xsl:text>
+            <xsl:choose>
+              <xsl:when test="o[@name='λ']">
+                <xsl:text>the formation is an atom</xsl:text>
+              </xsl:when>
+              <xsl:when test=".//o[contains(@base, 'φ')]">
+                <xsl:text>its body reads its own φ</xsl:text>
+              </xsl:when>
+              <xsl:when test="$calls[starts-with(@base, concat($self, '.'))]">
+                <xsl:text>the self-call is the receiver of a dispatch</xsl:text>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:text>no self-call sits in a tail position</xsl:text>
+              </xsl:otherwise>
+            </xsl:choose>
+          </defect>
+        </xsl:if>
+      </xsl:for-each>
+    </defects>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/motives/design/unoptimizable-recursion.md
+++ b/src/main/resources/org/eolang/motives/design/unoptimizable-recursion.md
@@ -1,0 +1,38 @@
+# Unoptimizable recursion
+
+A nested formation that calls itself in a tail position is turned into a
+Java loop at transpile time: the compiler wraps the copies into `PhLoop`
+and the calls into `PhAgain`, so a run takes one object per step instead
+of one Java stack block per step.
+
+The compiler recognises two tail positions, a branch of an `if.` and the
+last step of a `seq *`:
+
+```eo
+[] > app
+  [n] > rec
+    if. > @
+      n.lt 1
+      0
+      ^.rec (n.minus 1)
+  rec 5 > @
+```
+
+Every other shape runs as plain recursion, which is correct but deeper
+and slower, and the compiler says nothing about it. This lint says it,
+naming the reason it found. A self-call under an operation, for example,
+is not in a tail position, because the operation has work left to do
+after the call answers:
+
+```eo
+[] > app
+  [n] > rec
+    if. > @
+      n.lt 1
+      0
+      n.plus (^.rec (n.minus 1))
+  rec 5 > @
+```
+
+Rewrite such an object with an accumulator, the way `repeated` was
+rewritten by hand, and the recursion becomes a loop again.

--- a/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/allows-a-formation-that-never-calls-itself.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/allows-a-formation-that-never-calls-itself.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/unoptimizable-recursion.xsl
+defects: 0
+input: |
+  [] > app
+    [n] > twice
+      n.plus n > @
+    twice 5 > @

--- a/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/allows-tail-call-as-the-last-step-of-a-seq.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/allows-tail-call-as-the-last-step-of-a-seq.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/unoptimizable-recursion.xsl
+defects: 0
+input: |
+  [] > app
+    [n] > rec
+      seq > @
+        *
+          n
+          ^.rec (n.minus 1)
+    rec 5 > @

--- a/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/allows-tail-call-in-an-if-branch.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/allows-tail-call-in-an-if-branch.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/unoptimizable-recursion.xsl
+defects: 0
+input: |
+  [] > app
+    [n] > rec
+      if. > @
+        n.lt 1
+        0
+        ^.rec (n.minus 1)
+    rec 5 > @

--- a/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/catches-a-dispatch-on-the-self-call.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/catches-a-dispatch-on-the-self-call.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/lints/design/unoptimizable-recursion.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[1][normalize-space()='The recursion in "rec" cannot be turned into a loop, the self-call is the receiver of a dispatch']
+input: |
+  [] > app
+    [n] > rec
+      if. > @
+        n.lt 1
+        0
+        ^.rec.plus 1
+    rec 5 > @

--- a/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/catches-a-self-call-under-an-operation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/catches-a-self-call-under-an-operation.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/lints/design/unoptimizable-recursion.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[1][normalize-space()='The recursion in "rec" cannot be turned into a loop, no self-call sits in a tail position']
+input: |
+  [] > app
+    [n] > rec
+      if. > @
+        n.lt 1
+        0
+        n.plus (^.rec (n.minus 1))
+    rec 5 > @


### PR DESCRIPTION
The compiler turns a tail self-call of a nested formation into a Java loop, and stays silent when it cannot. The program then runs as plain recursion, one stack block per step, and nothing at the site says why.

This adds `design/unoptimizable-recursion.xsl`. For every nested formation with a bound `φ` it collects the self-calls, and when none of them sits in a tail position it reports one warning naming the reason: the formation is an atom, its body reads its own `φ`, the self-call is the receiver of a dispatch, or no self-call is in a tail position at all.

The tail test is the one the compiler runs in `_recursion.xsl`: a branch of an `if.`, or the last element of the tuple a `seq` is applied to. Both shapes already carry `@as` in parsed XMIR, so the test ports over as is.

Five packs: a tail call in an `if.` branch, a tail call as the last step of a `seq *`, a formation that never calls itself, a self-call under an operation, and a dispatch on the self-call.

The lint is `experimental`, like `no-attribute-formation` next to it.

The remaining shapes from #1321, a `Φ.name` self-call, a formation reached other than by a plain application, an attribute with a self-call read from outside, and mutual recursion, are left as a `@todo` in the stylesheet.
