### PR TITLE
feat(#571): add zizmor static analysis workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -20,5 +20,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: zizmorcore/zizmor-action@v0.6.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: zizmor
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+permissions: {}
+jobs:
+  zizmor:
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: zizmorcore/zizmor-action@v0.6.3


### PR DESCRIPTION
Closes #571.

**What.** Adds `.github/workflows/zizmor.yml`, wiring [zizmor](https://github.com/zizmorcore/zizmor) — a static analyzer for GitHub Actions workflows — into the build pipeline, as requested in #571.

**How.** The workflow runs on every push and pull request to `master`, matching the trigger shape already used by `actionlint.yml`, `yamllint.yml`, `typos.yml` and the other workflow-level checks in this repository. It uses the official `zizmorcore/zizmor-action@v0.6.3` in its default (recommended) mode: findings are uploaded to the repository's Security tab via GitHub Advanced Security code scanning rather than failing the build outright, so existing workflows aren't blocked while any findings are triaged. Permissions are scoped explicitly and minimally: a top-level `permissions: {}` denies everything by default, and the job itself is granted only `security-events: write`, `contents: read`, and `actions: read`, following the same pattern `zizmor` itself recommends.

Only a single GitHub Actions workflow file was added — no source, tests, or `pom.xml` changes were needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGFw6AQC3hfMh48xYgpwth)_