### PR TITLE
test(#348): guard the Lt prefix on Lint implementations via ArchUnit

### DIFF
--- a/src/test/java/org/eolang/lints/LintTest.java
+++ b/src/test/java/org/eolang/lints/LintTest.java
@@ -29,6 +29,18 @@ final class LintTest {
 
     @Test
     @SuppressWarnings("JTCOP.RuleAssertionMessage")
+    void ensuresEveryLintImplementationHasProperPrefix() {
+        ArchRuleDefinition.classes()
+            .that().implement(Lint.class)
+            .should().haveSimpleNameStartingWith("Lt").check(
+                new ClassFileImporter()
+                    .withImportOption(new ImportOption.DoNotIncludeTests())
+                    .importPackages("org.eolang.lints")
+            );
+    }
+
+    @Test
+    @SuppressWarnings("JTCOP.RuleAssertionMessage")
     void ensuresLintsStayInTheirPackages() {
         ArchRuleDefinition.classes()
             .that().implement(Lint.class)


### PR DESCRIPTION
## Summary

Closes #348.

`prefixed-maven-plugin` was proposed to enforce that every Java-implemented
lint class is prefixed with `Lt`. As pointed out in the issue discussion,
that guarantee already holds for all current classes, and the codebase
already has an ArchUnit-based test class (`LintTest`) that enforces this
kind of naming convention with zero extra dependencies:

- `ensuresEveryLintHasProperPrefix` only checked one direction: that any
  class named `Lt*` implements `Lint`.
- Nothing checked the other direction: that every class implementing
  `Lint` is named `Lt*`. A `Lint` implementation without the `Lt` prefix
  would silently go unnoticed.

This PR adds the missing `ensuresEveryLintImplementationHasProperPrefix`
rule (`classes().that().implement(Lint.class).should().haveSimpleNameStartingWith("Lt")`)
to `LintTest`, giving the same guarantee `prefixed-maven-plugin` would have,
without adding a new build dependency.

## Test plan

- [x] `mvn -Dtest=LintTest test` — new rule passes against the current codebase
- [x] `mvn -Pqulice clean install -DskipTests` — style checks pass
- [x] `mvn test` — full test suite passes

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01M2Zfc8Dg3RDEAWApW6yeft

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2Zfc8Dg3RDEAWApW6yeft)_