### PR TITLE
chore(#1326): upgrade qulice to 0.35.0 and add ctors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.32.0</version>
+            <version>0.35.0</version>
           </plugin>
           <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>

--- a/src/main/java/org/eolang/lints/MeasuredXsl.java
+++ b/src/main/java/org/eolang/lints/MeasuredXsl.java
@@ -16,11 +16,6 @@ import com.jcabi.xml.XSL;
 final class MeasuredXsl implements XSL {
 
     /**
-     * Default threshold in milliseconds.
-     */
-    private static final long DEFAULT = 100L;
-
-    /**
      * Rule name.
      */
     private final String rule;
@@ -41,7 +36,7 @@ final class MeasuredXsl implements XSL {
      * @param decorated Decorated XSL
      */
     MeasuredXsl(final String name, final XSL decorated) {
-        this(name, decorated, MeasuredXsl.DEFAULT);
+        this(name, decorated, 100L);
     }
 
     /**

--- a/src/test/java/benchmarks/BenchmarkState.java
+++ b/src/test/java/benchmarks/BenchmarkState.java
@@ -33,6 +33,13 @@ public class BenchmarkState {
     private XML xmir;
 
     /**
+     * Ctor.
+     */
+    public BenchmarkState() {
+        // nothing to do
+    }
+
+    /**
      * Initialize the state.
      */
     @Setup(Level.Trial)

--- a/src/test/java/benchmarks/SourceBench.java
+++ b/src/test/java/benchmarks/SourceBench.java
@@ -30,6 +30,13 @@ import org.openjdk.jmh.annotations.Warmup;
 public class SourceBench {
 
     /**
+     * Ctor.
+     */
+    public SourceBench() {
+        // nothing to do
+    }
+
+    /**
      * Benchmark for XMIR scanning.
      * Scans XMIR.
      * @param state State

--- a/src/test/java/fixtures/EoProgram.java
+++ b/src/test/java/fixtures/EoProgram.java
@@ -22,15 +22,10 @@ import org.eolang.parser.EoSyntax;
 public final class EoProgram {
 
     /**
-     * Maximum number of cached entries.
-     */
-    private static final int MAX = 1000;
-
-    /**
      * Cache of parsed XMIR documents, keyed by resource path.
      */
     private static final Cache<String, XML> CACHE = CacheBuilder.newBuilder()
-        .maximumSize(EoProgram.MAX)
+        .maximumSize(1000)
         .build();
 
     /**

--- a/src/test/java/matchers/DefectMatcher.java
+++ b/src/test/java/matchers/DefectMatcher.java
@@ -21,8 +21,15 @@ public final class DefectMatcher extends BaseMatcher<Defect> {
     /**
      * Synthetic matcher that is built when input arrives.
      */
-    // @checkstyle ConditionalRegexpMultilineCheck (1 line)
-    private final List<Matcher<?>> matchers = new ArrayList<>();
+    private final List<Matcher<?>> matchers;
+
+    /**
+     * Ctor.
+     */
+    public DefectMatcher() {
+        // @checkstyle ConditionalRegexpMultilineCheck (1 line)
+        this.matchers = new ArrayList<>();
+    }
 
     @Override
     public boolean matches(final Object input) {

--- a/src/test/java/matchers/DefectsMatcher.java
+++ b/src/test/java/matchers/DefectsMatcher.java
@@ -25,6 +25,13 @@ public final class DefectsMatcher extends BaseMatcher<XML> {
      */
     private Matcher<Iterable<? extends Defect>> matcher;
 
+    /**
+     * Ctor.
+     */
+    public DefectsMatcher() {
+        // nothing to do
+    }
+
     @Override
     public boolean matches(final Object xml) {
         // @checkstyle ConditionalRegexpMultilineCheck (1 line)

--- a/src/test/java/matchers/GrammarMatcher.java
+++ b/src/test/java/matchers/GrammarMatcher.java
@@ -36,6 +36,13 @@ public final class GrammarMatcher extends BaseMatcher<String> {
      */
     private List<RuleMatch> errors;
 
+    /**
+     * Ctor.
+     */
+    public GrammarMatcher() {
+        // nothing to do
+    }
+
     @Override
     public boolean matches(final Object obj) {
         final JLanguageTool tool = new JLanguageTool(


### PR DESCRIPTION
Upgrade `qulice-maven-plugin` to v0.35.0 and refactor code to comply with new linting rules, including removal of unnecessary constants and addition of default constructors to test fixtures.

Fixes #1326