### PR TITLE
fix(#1336): report exact physical line of too-wide line in multi-line comments

### DIFF
--- a/src/main/resources/org/eolang/lints/comments/comment-is-too-wide.xsl
+++ b/src/main/resources/org/eolang/lints/comments/comment-is-too-wide.xsl
@@ -7,67 +7,49 @@
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <!--
-  @todo #1046:30min Report the exact physical line of the too-wide line
-  inside a multi-line comment. Right now every offending line is reported
-  with the comment block's own start @line, since the XSL has no way to
-  compute the offset of a line within the tokenized comment text. Add a
-  $pos-based offset (comment @line + position() - 1) so
-  catches-multiline-wide-comment.yaml can assert on line 2 (the actual
-  offending line) instead of line 1.
-  -->
   <xsl:template match="/">
     <xsl:variable name="max" select="100"/>
     <defects>
       <xsl:for-each select="/object/comments/comment">
         <xsl:variable name="line" select="if (@line) then @line else '0'"/>
         <xsl:variable name="lines" select="tokenize(replace(., '\\n', '&#10;'), '&#10;')"/>
-        <xsl:choose>
-          <xsl:when test="count($lines) &gt; 1">
-            <xsl:for-each select="$lines[string-length(.) &gt; $max]">
-              <xsl:element name="defect">
-                <xsl:attribute name="line">
-                  <xsl:value-of select="$line"/>
+        <xsl:for-each select="$lines">
+          <xsl:variable name="offset" select="position() - 1"/>
+          <xsl:if test="string-length(.) &gt; $max">
+            <xsl:element name="defect">
+              <xsl:attribute name="line">
+                <xsl:choose>
+                  <xsl:when test="$line = '0'">
+                    <xsl:value-of select="$line"/>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <xsl:value-of select="format-number(number($line) + $offset, '0')"/>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </xsl:attribute>
+              <xsl:if test="$line = '0'">
+                <xsl:attribute name="context">
+                  <xsl:value-of select="eo:defect-context(.)"/>
                 </xsl:attribute>
-                <xsl:if test="$line = '0'">
-                  <xsl:attribute name="context">
-                    <xsl:value-of select="eo:defect-context(.)"/>
-                  </xsl:attribute>
-                </xsl:if>
-                <xsl:attribute name="severity">
-                  <xsl:text>warning</xsl:text>
-                </xsl:attribute>
-                <xsl:text>The comment line width is </xsl:text>
-                <xsl:value-of select="string-length(.)"/>
-                <xsl:text>, while </xsl:text>
-                <xsl:value-of select="$max"/>
-                <xsl:text> is max allowed</xsl:text>
-              </xsl:element>
-            </xsl:for-each>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:if test="string-length(.) &gt; $max">
-              <xsl:element name="defect">
-                <xsl:attribute name="line">
-                  <xsl:value-of select="$line"/>
-                </xsl:attribute>
-                <xsl:if test="$line = '0'">
-                  <xsl:attribute name="context">
-                    <xsl:value-of select="eo:defect-context(.)"/>
-                  </xsl:attribute>
-                </xsl:if>
-                <xsl:attribute name="severity">
-                  <xsl:text>warning</xsl:text>
-                </xsl:attribute>
-                <xsl:text>The comment width is </xsl:text>
-                <xsl:value-of select="string-length(.)"/>
-                <xsl:text>, while </xsl:text>
-                <xsl:value-of select="$max"/>
-                <xsl:text> is max allowed</xsl:text>
-              </xsl:element>
-            </xsl:if>
-          </xsl:otherwise>
-        </xsl:choose>
+              </xsl:if>
+              <xsl:attribute name="severity">
+                <xsl:text>warning</xsl:text>
+              </xsl:attribute>
+              <xsl:choose>
+                <xsl:when test="count($lines) &gt; 1">
+                  <xsl:text>The comment line width is </xsl:text>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:text>The comment width is </xsl:text>
+                </xsl:otherwise>
+              </xsl:choose>
+              <xsl:value-of select="string-length(.)"/>
+              <xsl:text>, while </xsl:text>
+              <xsl:value-of select="$max"/>
+              <xsl:text> is max allowed</xsl:text>
+            </xsl:element>
+          </xsl:if>
+        </xsl:for-each>
       </xsl:for-each>
     </defects>
   </xsl:template>

--- a/src/main/resources/org/eolang/lints/comments/comment-is-too-wide.xsl
+++ b/src/main/resources/org/eolang/lints/comments/comment-is-too-wide.xsl
@@ -11,7 +11,8 @@
     <xsl:variable name="max" select="100"/>
     <defects>
       <xsl:for-each select="/object/comments/comment">
-        <xsl:variable name="line" select="if (@line) then @line else '0'"/>
+        <xsl:variable name="comment" select="."/>
+        <xsl:variable name="line" select="eo:lineno(@line)"/>
         <xsl:variable name="lines" select="tokenize(replace(., '\\n', '&#10;'), '&#10;')"/>
         <xsl:for-each select="$lines">
           <xsl:variable name="offset" select="position() - 1"/>
@@ -29,7 +30,7 @@
               </xsl:attribute>
               <xsl:if test="$line = '0'">
                 <xsl:attribute name="context">
-                  <xsl:value-of select="eo:defect-context(.)"/>
+                  <xsl:value-of select="eo:defect-context($comment)"/>
                 </xsl:attribute>
               </xsl:if>
               <xsl:attribute name="severity">

--- a/src/test/resources/org/eolang/lints/packs/single/comment-is-too-wide/catches-multiline-wide-comment.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/comment-is-too-wide/catches-multiline-wide-comment.yaml
@@ -6,7 +6,7 @@ sheets:
   - /org/eolang/lints/comments/comment-is-too-wide.xsl
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
-  - /defects/defect[@line='1']
+  - /defects/defect[@line='2']
 input: |
   # This is good line.
   # This is a very long line that contains more than 100 characters and should be flagged by the lint as too wide.


### PR DESCRIPTION
Fixes #1336.

## Summary

`comment-is-too-wide.xsl` used to report every offending line inside a multi-line comment with the comment block's own start `@line`, since the XSL had no way to compute the offset of a line within the tokenized comment text.

Now each defect's `@line` is computed as the comment's start `@line` plus that line's offset within the tokenized text (`position() - 1`), so the reported location points at the actual offending physical line instead of always the first line of the comment.

As part of this fix, the previously duplicated multi-line/single-line `xsl:choose` branches were merged into a single loop over the tokenized lines, since the offset computation subsumes both cases (a single-line comment simply has an offset of 0).

## Changes

- `src/main/resources/org/eolang/lints/comments/comment-is-too-wide.xsl`: compute per-line offset and remove the resolved `@todo` puzzle.
- `src/test/resources/org/eolang/lints/packs/single/comment-is-too-wide/catches-multiline-wide-comment.yaml`: assert on line `2` (the actual offending line) instead of line `1`.

## Test plan

- [x] `mvn test -Dtest=LtByXslTest` passes (463 tests, 0 failures) — includes all `comment-is-too-wide` fixtures plus structural checks (XSL `@id` checks, motive presence, schema validation).
- [x] Verified via a scratch parse of the fixture input that XMIR represents a multi-line comment as a single `<comment @line="N">` node containing real newlines, confirming the offset approach is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtgvknNrK4TEQvMPqP7E7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtgvknNrK4TEQvMPqP7E7p)_