### PR TITLE
fix(#1305): skip proguard obfuscation in rultor merge script

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -17,7 +17,8 @@ install: |
   pdd --file=/dev/null
 merge:
   script: |
-    mvn clean install -ntp -P!hone,qulice --errors -Dstyle.color=never
+    export MAVEN_OPTS="--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED"
+    mvn clean install -ntp -P!hone,!proguard,qulice --errors -Dstyle.color=never
 release:
   pre: false
   script: |-


### PR DESCRIPTION
Fixes #1305.

## Problem

Every `@rultor merge` fails on rultor's `yegor256/java` image (JDK 21):

```
Failed to execute goal com.github.wvengen:proguard-maven-plugin:2.7.0:proguard (default)
on project lints: Obfuscation failed (result=1)
```

The `proguard` profile in `pom.xml` activates on JDK `[,22)`, so it's active on rultor's JDK 21 but not on a locally used JDK 23 — which is why `mvn clean install -Pqulice` passes locally while the merge check fails. ProGuard 2.7.0 needs `--add-opens` to read JDK classes on JDK 21+, and obfuscation doesn't add anything to a merge check anyway — it only matters for the deployed artifact.

The `release` script already works around exactly this (exports `MAVEN_OPTS` and passes `!proguard`), but the `merge` script did neither.

## Fix

Align the `merge` script in `.rultor.yml` with the `release` script:

```yaml
merge:
  script: |
    export MAVEN_OPTS="--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED"
    mvn clean install -ntp -P!hone,!proguard,qulice --errors -Dstyle.color=never
```

## Changes

- `.rultor.yml` — export `MAVEN_OPTS` and exclude the `proguard` profile in the `merge` script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aav9e7z6jdPsj47FrtbxJY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aav9e7z6jdPsj47FrtbxJY)_