### PR TITLE
feat(#1343): Add EO source support to XtLint

### DIFF
--- a/src/test/java/org/eolang/lints/XtLint.java
+++ b/src/test/java/org/eolang/lints/XtLint.java
@@ -20,12 +20,10 @@ import org.xembly.Xembler;
  * A story that runs a Java-implemented lint by its name.
  * Reads the {@code lint} key from the pack YAML and applies
  * the resolved {@link Lint} to the input, producing a
- * {@code <defects>} document.
+ * {@code <defects>} document. The input itself may be given either
+ * as a raw XMIR document (the {@code document} pack key) or as
+ * EO source (the {@code input} pack key), same as {@link XtYaml}.
  * @since 1.0
- * @todo #1271:30min Let XtLint accept EO sources (the {@code input:} pack key) in
- *  addition to raw XMIR documents, so that Java-implemented lints can be tested
- *  from EO programs the same way XSL-based lints are tested, instead of the
- *  hand-written {@code document:} blocks that the current packs use.
  */
 public final class XtLint implements Xtory {
 

--- a/src/test/resources/org/eolang/lints/packs/single/ascii-only/catches-cyrillic-comment.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/ascii-only/catches-cyrillic-comment.yaml
@@ -4,9 +4,10 @@
 lint: ascii-only
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
-document: |
-  <object author="tests">
-    <comments>
-      <comment line="1">привет</comment>
-    </comments>
-  </object>
+input: |
+  # привет
+
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+
+  [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-unlint/catches-unknown-lint.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-unlint/catches-unknown-lint.yaml
@@ -6,7 +6,6 @@ asserts:
   - /defects[count(defect[@severity='error'])=1]
 input: |
   +unlint non-existent-lint-name:5
-
   +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
   +spdx SPDX-License-Identifier: MIT
 

--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-unlint/catches-unknown-lint.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-unlint/catches-unknown-lint.yaml
@@ -4,13 +4,10 @@
 lint: incorrect-unlint
 asserts:
   - /defects[count(defect[@severity='error'])=1]
-document: |
-  <object author="tests">
-    <metas>
-      <meta line="1">
-        <head>unlint</head>
-        <tail>non-existent-lint-name:5</tail>
-      </meta>
-    </metas>
-    <o line="3" name="foo"/>
-  </object>
+input: |
+  +unlint non-existent-lint-name:5
+
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+
+  [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/reserved-name/allows-custom-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/reserved-name/allows-custom-name.yaml
@@ -9,5 +9,4 @@ input: |
   +spdx SPDX-License-Identifier: MIT
 
   [] > main
-    [] > my-object
-      foo
+    foo > my-object

--- a/src/test/resources/org/eolang/lints/packs/single/reserved-name/allows-custom-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/reserved-name/allows-custom-name.yaml
@@ -4,9 +4,10 @@
 lint: reserved-name
 asserts:
   - /defects[count(defect)=0]
-document: |
-  <object author="tests">
-    <o line="1" name="main">
-      <o line="2" name="my-object" base="Φ.foo"/>
-    </o>
-  </object>
+input: |
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+
+  [] > main
+    [] > my-object
+      foo

--- a/src/test/resources/org/eolang/lints/packs/single/syntax-version/allows-older-syntax.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/syntax-version/allows-older-syntax.yaml
@@ -3,13 +3,10 @@
 ---
 lint: syntax-version
 defects: 0
-document: |
-  <object author="tests" version="0.0.1">
-    <metas>
-      <meta line="1">
-        <head>syntax</head>
-        <tail>0.0.1</tail>
-      </meta>
-    </metas>
-    <o line="3" name="foo"/>
-  </object>
+input: |
+  +syntax 0.0.1
+
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+
+  [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/syntax-version/allows-older-syntax.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/syntax-version/allows-older-syntax.yaml
@@ -5,7 +5,6 @@ lint: syntax-version
 defects: 0
 input: |
   +syntax 0.0.1
-
   +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
   +spdx SPDX-License-Identifier: MIT
 

--- a/src/test/resources/org/eolang/lints/packs/single/syntax-version/catches-newer-syntax.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/syntax-version/catches-newer-syntax.yaml
@@ -6,7 +6,6 @@ asserts:
   - /defects[count(defect[@severity='error'])=1]
 input: |
   +syntax 999.0.0
-
   +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
   +spdx SPDX-License-Identifier: MIT
 

--- a/src/test/resources/org/eolang/lints/packs/single/syntax-version/catches-newer-syntax.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/syntax-version/catches-newer-syntax.yaml
@@ -4,13 +4,10 @@
 lint: syntax-version
 asserts:
   - /defects[count(defect[@severity='error'])=1]
-document: |
-  <object author="tests" version="0.0.1">
-    <metas>
-      <meta line="1">
-        <head>syntax</head>
-        <tail>999.0.0</tail>
-      </meta>
-    </metas>
-    <o line="3" name="foo"/>
-  </object>
+input: |
+  +syntax 999.0.0
+
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+
+  [] > foo


### PR DESCRIPTION
Resolve puzzle #1271: Enable `XtLint` to accept EO source code via the `input` pack key in addition to raw XMIR documents. Update test fixtures to use EO sources instead of hand-written XML documents, allowing Java-implemented lints to be tested consistently with XSL-based lints.

Fixes #1343