### PR TITLE
docs(#799): document how to run lints locally on a .eo file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,44 @@ Whole-program analysis (running lints across a set of XMIR files
 instead of one at a time) lives in a separate package,
 [`org.eolang:wpa`](https://github.com/objectionary/wpa).
 
+## Running Locally on a `.eo` File
+
+There is no standalone CLI in this repository, but you can lint
+a single `.eo` file with a few lines of Java. Besides `lints`,
+add [`eo-parser`](https://github.com/objectionary/eo), which turns
+EO source into [XMIR]:
+
+```xml
+<dependency>
+  <groupId>org.eolang</groupId>
+  <artifactId>eo-parser</artifactId>
+  <version><!-- see "home.version" in this project's pom.xml --></version>
+</dependency>
+```
+
+```java
+import com.jcabi.xml.XML;
+import java.nio.file.Paths;
+import org.cactoos.io.InputOf;
+import org.eolang.lints.Source;
+import org.eolang.parser.EoSyntax;
+
+final class RunLints {
+    public static void main(final String... args) throws Exception {
+        final XML xmir = new EoSyntax(
+            new InputOf(Paths.get("my-program.eo"))
+        ).parsed();
+        new Source(xmir).defects().forEach(System.out::println);
+    }
+}
+```
+
+Each printed defect includes the source line, e.g.
+`[mandatory-spdx/S WARNING]:1 The +spdx meta is mandatory, but is absent`.
+Print `xmir` itself to inspect the parsed object tree, the `<errors>`
+parser diagnostics, and the original `<listing>`, which helps when a
+lint isn't behaving as expected.
+
 ## Design of This Library
 
 The library is designed as a set of lints, each of which

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ EO source into [XMIR]:
 <dependency>
   <groupId>org.eolang</groupId>
   <artifactId>eo-parser</artifactId>
-  <version><!-- see "home.version" in this project's pom.xml --></version>
+  <!-- keep this in sync with "home.version" in this project's pom.xml -->
+  <version>0.63.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Fixes #799.

## Problem

There is no CLI in this repository, and there was no documentation for
how to run the lints locally against a single `.eo` file. The question
came up in #799, and was answered ad hoc in a comment there.

## Solution

Add a "Running Locally on a `.eo` File" section to `README.md`, right
after the existing usage examples, with:

- the extra `eo-parser` dependency needed to turn EO source into XMIR
  (the `lints` artifact itself only depends on it at `runtime` scope)
- a minimal `EoSyntax` + `Source` snippet that parses a `.eo` file and
  prints its defects
- a short note on inspecting the parsed XMIR (`<errors>`, `<listing>`)
  when a lint doesn't behave as expected

The snippet mirrors the exact API used throughout the test suite
(`EoSyntax`, `InputOf`, `Source`), so it should keep working as-is.

## Tests

This is a documentation-only change.

- `npx markdownlint-cli2 "README.md"` — 0 issues
- Verified `Source`, `EoSyntax`, and `InputOf` constructor/method
  signatures against `Source.java` and existing test usages
  (`fixtures/EoProgram.java`, `LtIncorrectUnlintTest.java`, etc.)
- `.github/workflows/vale.yml` only checks
  `src/main/resources/org/eolang/motives`, so `README.md` isn't
  affected by the Vale style checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHwVStoyg2LNN5YxXKeFez

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHwVStoyg2LNN5YxXKeFez)_