### PR TITLE
Scope last() to each formation in phi-is-not-first

### DIFF
--- a/src/main/resources/org/eolang/lints/names/phi-is-not-first.xsl
+++ b/src/main/resources/org/eolang/lints/names/phi-is-not-first.xsl
@@ -10,7 +10,9 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:apply-templates select="(//o[@name='φ'][not(@pipe)][preceding-sibling::o[not(@base='∅') and not(@base='ξ' and @name='xi🌵')]])[last()]" mode="unordered"/>
+      <xsl:for-each select="//o[o[@name='φ'][not(@pipe)][preceding-sibling::o[not(@base='∅') and not(@base='ξ' and @name='xi🌵')]]]">
+        <xsl:apply-templates select="(o[@name='φ'][not(@pipe)][preceding-sibling::o[not(@base='∅') and not(@base='ξ' and @name='xi🌵')]])[last()]" mode="unordered"/>
+      </xsl:for-each>
     </defects>
   </xsl:template>
   <xsl:template match="o" mode="unordered">

--- a/src/test/resources/org/eolang/lints/packs/single/phi-is-not-first/catches-phi-in-each-formation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/phi-is-not-first/catches-phi-in-each-formation.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/names/phi-is-not-first.xsl
+defects:
+  - severity: warning
+    line: 4
+  - severity: warning
+    line: 8
+document: |
+  <object author="tests">
+    <o>
+      <o name="f">
+        <o base="Φ.x" name="a" line="3"/>
+        <o base="Φ.y" name="φ" line="4"/>
+      </o>
+      <o name="g">
+        <o base="Φ.x" name="a" line="7"/>
+        <o base="Φ.y" name="φ" line="8"/>
+      </o>
+    </o>
+  </object>


### PR DESCRIPTION
Fixes #1359.

`phi-is-not-first.xsl` selected `(//o[@name='φ']...)[last()]`. The
parentheses made `[last()]` apply to the sequence of misplaced `φ`
nodes across the *entire document*, not to each formation's own
sequence. A file with two formations, each with one misplaced `φ`,
only reported the second formation's defect — the first was silently
dropped.

The fix iterates over every formation that contains a misplaced `φ`
and applies `[last()]` scoped to that formation's own children, so
each formation gets its own defect (still reporting only the last
offender within a single formation, preserving the previously pinned
behavior).

Added `catches-phi-in-each-formation.yaml`, a pack with two sibling
formations each carrying a misplaced `φ`, asserting `2` defects
(one per formation, at their respective lines).

## Test plan

- [x] `mvn test -Dtest=LtByXslTest` — all 489 tests pass, including
      the new pack and the existing `validatesPacksAgainstXsdSchema`
      / `phi-is-not-first` packs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzCPMT23UNH1YL28ZDJLQc

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzCPMT23UNH1YL28ZDJLQc)_