### PR TITLE
fix(#1353): report the physical line of a wide line inside a comment

### DIFF
--- a/src/main/resources/org/eolang/lints/comments/comment-is-too-wide.xsl
+++ b/src/main/resources/org/eolang/lints/comments/comment-is-too-wide.xsl
@@ -7,15 +7,6 @@
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <!--
-  @todo #1046:30min Report the exact physical line of the too-wide line
-  inside a multi-line comment. Right now every offending line is reported
-  with the comment block's own start @line, since the XSL has no way to
-  compute the offset of a line within the tokenized comment text. Add a
-  $pos-based offset (comment @line + position() - 1) so
-  catches-multiline-wide-comment.yaml can assert on line 2 (the actual
-  offending line) instead of line 1.
-  -->
   <xsl:template match="/">
     <xsl:variable name="max" select="100"/>
     <defects>
@@ -24,25 +15,27 @@
         <xsl:variable name="lines" select="tokenize(replace(., '\\n', '&#10;'), '&#10;')"/>
         <xsl:choose>
           <xsl:when test="count($lines) &gt; 1">
-            <xsl:for-each select="$lines[string-length(.) &gt; $max]">
-              <xsl:element name="defect">
-                <xsl:attribute name="line">
-                  <xsl:value-of select="$line"/>
-                </xsl:attribute>
-                <xsl:if test="$line = '0'">
-                  <xsl:attribute name="context">
-                    <xsl:value-of select="eo:defect-context(.)"/>
+            <xsl:for-each select="$lines">
+              <xsl:if test="string-length(.) &gt; $max">
+                <xsl:element name="defect">
+                  <xsl:attribute name="line">
+                    <xsl:value-of select="if ($line = '0') then $line else number($line) + position() - 1"/>
                   </xsl:attribute>
-                </xsl:if>
-                <xsl:attribute name="severity">
-                  <xsl:text>warning</xsl:text>
-                </xsl:attribute>
-                <xsl:text>The comment line width is </xsl:text>
-                <xsl:value-of select="string-length(.)"/>
-                <xsl:text>, while </xsl:text>
-                <xsl:value-of select="$max"/>
-                <xsl:text> is max allowed</xsl:text>
-              </xsl:element>
+                  <xsl:if test="$line = '0'">
+                    <xsl:attribute name="context">
+                      <xsl:value-of select="eo:defect-context(.)"/>
+                    </xsl:attribute>
+                  </xsl:if>
+                  <xsl:attribute name="severity">
+                    <xsl:text>warning</xsl:text>
+                  </xsl:attribute>
+                  <xsl:text>The comment line width is </xsl:text>
+                  <xsl:value-of select="string-length(.)"/>
+                  <xsl:text>, while </xsl:text>
+                  <xsl:value-of select="$max"/>
+                  <xsl:text> is max allowed</xsl:text>
+                </xsl:element>
+              </xsl:if>
             </xsl:for-each>
           </xsl:when>
           <xsl:otherwise>

--- a/src/test/resources/org/eolang/lints/packs/single/comment-is-too-wide/catches-multiline-wide-comment.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/comment-is-too-wide/catches-multiline-wide-comment.yaml
@@ -6,7 +6,7 @@ sheets:
   - /org/eolang/lints/comments/comment-is-too-wide.xsl
 defects:
   - severity: warning
-    line: 1
+    line: 2
 input: |
   # This is good line.
   # This is a very long line that contains more than 100 characters and should be flagged by the lint as too wide.


### PR DESCRIPTION
Fixes #1353.

Every over-wide line inside a multi-line comment was reported at the line the comment starts on, so a comment with three wide lines produced three defects all naming the same line.

The loop now walks every line and tests inside it, so `position()` is the index among all lines rather than among the offending ones, and the defect carries `@line + position() - 1`.

The `'0'` fallback is left alone: when the comment carries no `@line` there is no location to offset from, and counting from zero would invent one.

This closes the `@todo #1046` in the same file, and `catches-multiline-wide-comment.yaml` now asserts line 2, the line that is actually too wide. That pack fails on master and passes here.
