### PR TITLE
fix(#1358): do not count the piece after a trailing newline as a line

### DIFF
--- a/src/main/resources/org/eolang/lints/lines/error-line-out-of-listing.xsl
+++ b/src/main/resources/org/eolang/lints/lines/error-line-out-of-listing.xsl
@@ -6,7 +6,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="error-line-out-of-listing" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:variable name="max" select="count(tokenize(/object/listing, '&#10;'))"/>
+  <xsl:variable name="max" select="count(tokenize(replace(/object/listing, '&#10;$', ''), '&#10;'))"/>
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="/object/errors/error[number(@line) and @line &gt; $max]">

--- a/src/main/resources/org/eolang/lints/lines/meta-line-out-of-listing.xsl
+++ b/src/main/resources/org/eolang/lints/lines/meta-line-out-of-listing.xsl
@@ -6,7 +6,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="meta-line-out-of-listing" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:variable name="max" select="count(tokenize(/object/listing, '&#10;'))"/>
+  <xsl:variable name="max" select="count(tokenize(replace(/object/listing, '&#10;$', ''), '&#10;'))"/>
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="/object/metas/meta[number(@line) and @line &gt; $max]">

--- a/src/main/resources/org/eolang/lints/lines/object-line-out-of-listing.xsl
+++ b/src/main/resources/org/eolang/lints/lines/object-line-out-of-listing.xsl
@@ -6,7 +6,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" id="object-line-out-of-listing" version="2.0">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <xsl:variable name="max" select="count(tokenize(/object/listing, '&#10;'))"/>
+  <xsl:variable name="max" select="count(tokenize(replace(/object/listing, '&#10;$', ''), '&#10;'))"/>
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="//o[number(@line) and @line &gt; $max]">

--- a/src/test/resources/org/eolang/lints/packs/single/error-line-out-of-listing/catches-line-just-past-a-trailing-newline.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/error-line-out-of-listing/catches-line-just-past-a-trailing-newline.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/lines/error-line-out-of-listing.xsl
+defects:
+  - severity: error
+document: |
+  <object author="tests">
+    <listing>first line
+  second line
+  </listing>
+    <errors>
+      <error check="abc" line="3" severity="warning">hello</error>
+    </errors>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/meta-line-out-of-listing/catches-line-just-past-a-trailing-newline.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/meta-line-out-of-listing/catches-line-just-past-a-trailing-newline.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/lines/meta-line-out-of-listing.xsl
+defects:
+  - severity: error
+document: |
+  <object author="tests">
+    <listing>first line
+  second line
+  </listing>
+    <metas>
+      <meta line="3">
+        <head>hello</head>
+        <tail/>
+      </meta>
+    </metas>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/object-line-out-of-listing/catches-line-just-past-a-trailing-newline.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/object-line-out-of-listing/catches-line-just-past-a-trailing-newline.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/lines/object-line-out-of-listing.xsl
+defects:
+  - severity: error
+document: |
+  <object author="tests">
+    <listing>first line
+  second line
+  </listing>
+    <o line="3" name="foo"/>
+  </object>


### PR DESCRIPTION
Fixes #1358.

`tokenize("a\nb\n", "\n")` returns three pieces for two lines, and EO sources end with a newline, so `$max` was one too high in all three rules. A line exactly one past the end of the file passed the `@line > $max` test unreported, which is the most likely wrong value: counting from the wrong end, or adding one to the last line, lands precisely there.

The listing is tokenized with its trailing newline removed, which also leaves a listing that does not end with one counted correctly.

One pack per rule, each with a listing that ends in a newline and a defect on the line just past it. All three fail on master and pass here.
