### PR TITLE
fix(#1357): match the printf dispatch that EO actually emits

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/sprintf-without-formatters.xsl
+++ b/src/main/resources/org/eolang/lints/misc/sprintf-without-formatters.xsl
@@ -17,31 +17,16 @@
   </xsl:function>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[@base='Φ.txt.sprintf']">
-        <xsl:variable name="text" select="o[1][@base='Φ.string']/o[1][@base='Φ.bytes']/o/text()"/>
-        <xsl:variable name="txt" select="translate($text, '-', '')"/>
-        <xsl:variable name="formatters">
-          <xsl:variable name="txt" select="translate($text, '-', '')"/>
-          <!-- First, replace %% with a unique placeholder to avoid counting it as a formatter -->
-          <xsl:variable name="escaped" select="replace($txt, '(25)(25)', 'ESCAPED_PERCENT')"/>
-          <!-- %s -->
-          <xsl:variable name="strings" select="count(tokenize($escaped, '2573'))"/>
-          <!-- %d -->
-          <xsl:variable name="numbers" select="count(tokenize($escaped, '2564'))"/>
-          <!-- %f -->
-          <xsl:variable name="floats" select="count(tokenize($escaped, '2566'))"/>
-          <!-- %x -->
-          <xsl:variable name="bytes" select="count(tokenize($escaped, '2578'))"/>
-          <!-- %b -->
-          <xsl:variable name="bools" select="count(tokenize($escaped, '2562'))"/>
-          <xsl:value-of select="$strings + $numbers + $floats + $bytes + $bools - 5"/>
+      <xsl:for-each select="//o[@base='.printf'][o[not(@as)][@base='Φ.string']/o[@base='Φ.bytes']/o/text()]">
+        <xsl:variable name="text" select="o[not(@as)][@base='Φ.string']/o[@base='Φ.bytes']/o/text()"/>
+        <xsl:variable name="placeholder">
+          <xsl:for-each select="tokenize($text, '-')">
+            <xsl:value-of select="codepoints-to-string(eo:hex-to-placeholder(.))"/>
+          </xsl:for-each>
         </xsl:variable>
-        <xsl:if test="$formatters = 0">
-          <xsl:variable name="placeholder">
-            <xsl:for-each select="tokenize($text, '-')">
-              <xsl:value-of select="codepoints-to-string(eo:hex-to-placeholder(.))"/>
-            </xsl:for-each>
-          </xsl:variable>
+        <!-- A specifier reads as %[N$][flags][width][.precision]conversion, and a
+        doubled percent is a literal one rather than the start of a specifier -->
+        <xsl:if test="not(matches(replace($placeholder, '%%', ''), '%(\d+\$)?[-0]*\d*(\.\d+)?[sdfxb]'))">
           <defect>
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">
@@ -55,9 +40,9 @@
             <xsl:attribute name="severity">
               <xsl:text>warning</xsl:text>
             </xsl:attribute>
-            <xsl:text>According to the formatting template of the "Φ.txt.sprintf" object, </xsl:text>
+            <xsl:text>According to the formatting template of the ".printf" object, </xsl:text>
             <xsl:value-of select="eo:escape($placeholder)"/>
-            <xsl:text> does not have any supported formatters ("%s", "%d", "%f", "%x", "%b"), which makes no sense to use "Φ.txt.sprintf"</xsl:text>
+            <xsl:text> does not have any supported formatters ("%s", "%d", "%f", "%x", "%b"), which makes no sense to use ".printf"</xsl:text>
           </defect>
         </xsl:if>
       </xsl:for-each>

--- a/src/main/resources/org/eolang/lints/misc/sprintf-without-formatters.xsl
+++ b/src/main/resources/org/eolang/lints/misc/sprintf-without-formatters.xsl
@@ -24,8 +24,10 @@
             <xsl:value-of select="codepoints-to-string(eo:hex-to-placeholder(.))"/>
           </xsl:for-each>
         </xsl:variable>
-        <!-- A specifier reads as %[N$][flags][width][.precision]conversion, and a
-        doubled percent is a literal one rather than the start of a specifier -->
+        <!--
+        A specifier reads as %[N$][flags][width][.precision]conversion, and a
+        doubled percent is a literal one rather than the start of a specifier
+        -->
         <xsl:if test="not(matches(replace($placeholder, '%%', ''), '%(\d+\$)?[-0]*\d*(\.\d+)?[sdfxb]'))">
           <defect>
             <xsl:variable name="line" select="eo:lineno(@line)"/>

--- a/src/test/resources/org/eolang/lints/packs/single/sprintf-without-formatters/catches-multiple-sprintf.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sprintf-without-formatters/catches-multiple-sprintf.yaml
@@ -7,13 +7,11 @@ defects:
   - severity: warning
     line: 3
   - severity: warning
-    line: 6
+    line: 5
 input: |
   [] > app
     io.stdout > @
-      txt.sprintf
-        "Hello, Jeff Your account is $200"
+      "Hello, Jeff Your account is $200".printf
         *
-      txt.sprintf
-        "We are good"
+      "We are good".printf
         * f

--- a/src/test/resources/org/eolang/lints/packs/single/sprintf-without-formatters/catches-sprintf-with-incorrect-formatter.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sprintf-without-formatters/catches-sprintf-with-incorrect-formatter.yaml
@@ -7,10 +7,9 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
   - /defects/defect[@line='3']
-  - /defects/defect[1][normalize-space()='According to the formatting template of the "Φ.txt.sprintf" object, "Hello⌴%o" does not have any supported formatters ("%s", "%d", "%f", "%x", "%b"), which makes no sense to use "Φ.txt.sprintf"']
+  - /defects/defect[1][normalize-space()='According to the formatting template of the ".printf" object, "Hello⌴%o" does not have any supported formatters ("%s", "%d", "%f", "%x", "%b"), which makes no sense to use ".printf"']
 input: |
   [args] > app
     io.stdout > @
-      txt.sprintf
-        "Hello %o"
+      "Hello %o".printf
         * args

--- a/src/test/resources/org/eolang/lints/packs/single/sprintf-without-formatters/catches-sprintf-with-only-an-escaped-percent.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sprintf-without-formatters/catches-sprintf-with-only-an-escaped-percent.yaml
@@ -9,5 +9,5 @@ defects:
 input: |
   [] > app
     io.stdout > @
-      "Boom! We are here".printf
-        * name "x"
+      "100%% done".printf
+        *

--- a/src/test/resources/org/eolang/lints/packs/single/sprintf-without-formatters/catches-sprintf-without-formatters.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sprintf-without-formatters/catches-sprintf-without-formatters.yaml
@@ -7,10 +7,9 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
   - /defects/defect[@line='3']
-  - /defects/defect[1][normalize-space()='According to the formatting template of the "Φ.txt.sprintf" object, "Hello⌴Jeff!" does not have any supported formatters ("%s", "%d", "%f", "%x", "%b"), which makes no sense to use "Φ.txt.sprintf"']
+  - /defects/defect[1][normalize-space()='According to the formatting template of the ".printf" object, "Hello⌴Jeff!" does not have any supported formatters ("%s", "%d", "%f", "%x", "%b"), which makes no sense to use ".printf"']
 input: |
   [] > app
     io.stdout > @
-      txt.sprintf
-        "Hello Jeff!"
+      "Hello Jeff!".printf
         *

--- a/src/test/resources/org/eolang/lints/packs/single/sprintf-without-formatters/passes-sprintf-with-a-padded-formatter.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sprintf-without-formatters/passes-sprintf-with-a-padded-formatter.yaml
@@ -3,11 +3,9 @@
 ---
 sheets:
   - /org/eolang/lints/misc/sprintf-without-formatters.xsl
-defects:
-  - severity: warning
-    line: 3
+defects: 0
 input: |
   [] > app
     io.stdout > @
-      "Boom! We are here".printf
-        * name "x"
+      "Total: %08.2f".printf
+        * 42.0

--- a/src/test/resources/org/eolang/lints/packs/single/sprintf-without-formatters/passes-sprintf-with-formatters.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sprintf-without-formatters/passes-sprintf-with-formatters.yaml
@@ -7,6 +7,5 @@ defects: 0
 input: |
   [] > app
     io.stdout > @
-      txt.sprintf
-        "Hello, %s!"
+      "Hello, %s!".printf
         * "Jeff"

--- a/src/test/resources/org/eolang/lints/packs/single/sprintf-without-formatters/prints-context-when-lines-empty.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sprintf-without-formatters/prints-context-when-lines-empty.yaml
@@ -9,13 +9,13 @@ document: |
   <object author="tests">
     <o name="app">
       <o base="Φ.io.stdout" name="φ">
-          <o base="Φ.txt.sprintf">
+          <o base=".printf">
              <o base="Φ.string">
                 <o base="Φ.bytes">
                    <o>48-65-6C-6C-6F-20-4A-65-66-66-21</o>
                 </o>
              </o>
-             <o base="Φ.tuple.empty"/>
+             <o as="α0" base="Φ.tuple.empty"/>
           </o>
        </o>
       </o>


### PR DESCRIPTION
Fixes #1357.

The rule selected `Φ.txt.sprintf`, which current EO does not emit at all: there is no `txt` package any more, and formatting is a method on the format string, so an XMIR carries `base=".printf"`. The rule could not fire on anything.

It matches the dispatch now. The template is read from the receiver, which in a real XMIR is the child without an `as` attribute:

```xml
<o base=".printf">
  <o base="Φ.string">…the format…</o>
  <o as="α0" base="Φ.tuple">…the arguments…</o>
</o>
```

Checked against `eo-runtime/target/eo/1-parse/bytes/as-i16.xmir` rather than assumed.

The detection of a formatter changed with it. Counting the byte pairs of `%s`, `%d`, `%f`, `%x` and `%b` misses everything current `printf` accepts around the conversion letter — `%08.2f`, `%5d`, `%1$s` — and would report a template using only those as having no formatters. The template is decoded first and then matched against the specifier grammar `printf.eo` documents: `%[N$][flags][width][.precision]conversion`, with a doubled percent taken out first, since it is a literal one.

The message names `.printf` instead of the object that no longer exists.

The existing packs are rewritten to the current call form, and two more cover a padded specifier that must pass and a template whose only percent is an escaped one.
