### PR TITLE
fix(#1355): check the arguments of the printf dispatch EO emits

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/wrong-sprintf-arguments.xsl
+++ b/src/main/resources/org/eolang/lints/misc/wrong-sprintf-arguments.xsl
@@ -7,6 +7,10 @@
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
+  <!-- One format specifier, matched over the hex bytes of the template:
+  a percent, an optional N$ position, the "-" and "0" flags, a width,
+  an optional .precision, and one of the five conversion letters -->
+  <xsl:variable name="eo:specifier" select="'25((3[0-9])+24)?(2D|30)*(3[0-9])*(2E(3[0-9])+)?(73|64|66|78|62)'"/>
   <!-- Find arguments in tuple -->
   <xsl:template match="o" mode="arguments" as="xs:integer">
     <xsl:choose>
@@ -33,10 +37,10 @@
   </xsl:template>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[@base='Φ.txt.sprintf']">
-        <xsl:variable name="text" select="o[1][@base='Φ.string']/o[1][@base='Φ.bytes']/o/text()"/>
+      <xsl:for-each select="//o[@base='.printf']">
+        <xsl:variable name="text" select="o[not(@as)][1][@base='Φ.string']/o[1][@base='Φ.bytes']/o/text()"/>
         <xsl:choose>
-          <xsl:when test="count(o)&gt;2">
+          <xsl:when test="count(o[@as])&gt;1">
             <defect>
               <xsl:variable name="line" select="eo:lineno(@line)"/>
               <xsl:attribute name="line">
@@ -50,30 +54,19 @@
               <xsl:attribute name="severity">
                 <xsl:text>warning</xsl:text>
               </xsl:attribute>
-              <xsl:text>The "Φ.txt.sprintf" object expects only 2 arguments, but </xsl:text>
-              <xsl:value-of select="count(o)"/>
+              <xsl:text>The ".printf" object expects only 1 argument, but </xsl:text>
+              <xsl:value-of select="count(o[@as])"/>
               <xsl:text> provided</xsl:text>
             </defect>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:variable name="declared">
-              <xsl:variable name="txt" select="translate($text, '-', '')"/>
-              <!-- First, replace %% with a unique placeholder to avoid counting it as a formatter -->
-              <xsl:variable name="escaped" select="replace($txt, '(25)(25)', 'ESCAPED_PERCENT')"/>
-              <!-- %s -->
-              <xsl:variable name="strings" select="count(tokenize($escaped, '2573'))"/>
-              <!-- %d -->
-              <xsl:variable name="numbers" select="count(tokenize($escaped, '2564'))"/>
-              <!-- %f -->
-              <xsl:variable name="floats" select="count(tokenize($escaped, '2566'))"/>
-              <!-- %x -->
-              <xsl:variable name="bytes" select="count(tokenize($escaped, '2578'))"/>
-              <!-- %b -->
-              <xsl:variable name="bools" select="count(tokenize($escaped, '2562'))"/>
-              <xsl:value-of select="$strings + $numbers + $floats + $bytes + $bools - 5"/>
-            </xsl:variable>
+            <!-- The bytes of the template, with a doubled percent taken out,
+            since it stands for a literal one and starts no specifier -->
+            <xsl:variable name="escaped" select="replace(translate($text, '-', ''), '2525', '')"/>
+            <!-- A specifier is %[N$][flags][width][.precision]conversion, in bytes -->
+            <xsl:variable name="declared" select="count(tokenize($escaped, $eo:specifier)) - 1"/>
             <xsl:variable name="used">
-              <xsl:apply-templates select="o[2]" mode="arguments"/>
+              <xsl:apply-templates select="o[@as][1]" mode="arguments"/>
             </xsl:variable>
             <xsl:choose>
               <xsl:when test="$used=-1">
@@ -90,11 +83,11 @@
                   <xsl:attribute name="severity">
                     <xsl:text>warning</xsl:text>
                   </xsl:attribute>
-                  <xsl:text>The second argument "Φ.txt.sprintf" object must be a right structured "Φ.tuple" object</xsl:text>
+                  <xsl:text>The argument of the ".printf" object must be a right structured "Φ.tuple" object</xsl:text>
                 </defect>
               </xsl:when>
               <xsl:otherwise>
-                <xsl:if test="$declared!=$used and o[1]/@base = 'Φ.string'">
+                <xsl:if test="$declared!=$used and o[not(@as)][1]/@base = 'Φ.string' and not(matches($escaped, '25(3[0-9])+24'))">
                   <defect>
                     <xsl:variable name="line" select="eo:lineno(@line)"/>
                     <xsl:attribute name="line">
@@ -108,9 +101,9 @@
                     <xsl:attribute name="severity">
                       <xsl:text>warning</xsl:text>
                     </xsl:attribute>
-                    <xsl:text>According to the formatting template of the "Φ.txt.sprintf" object, a tuple of </xsl:text>
+                    <xsl:text>According to the formatting template of the ".printf" object, a tuple of </xsl:text>
                     <xsl:value-of select="$declared"/>
-                    <xsl:text> element(s) is expected as the second argument of it, while a tuple of </xsl:text>
+                    <xsl:text> element(s) is expected as its argument, while a tuple of </xsl:text>
                     <xsl:value-of select="$used"/>
                     <xsl:text> element(s) is provided</xsl:text>
                   </defect>

--- a/src/main/resources/org/eolang/lints/misc/wrong-sprintf-arguments.xsl
+++ b/src/main/resources/org/eolang/lints/misc/wrong-sprintf-arguments.xsl
@@ -7,9 +7,11 @@
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <!-- One format specifier, matched over the hex bytes of the template:
+  <!--
+  One format specifier, matched over the hex bytes of the template:
   a percent, an optional N$ position, the "-" and "0" flags, a width,
-  an optional .precision, and one of the five conversion letters -->
+  an optional .precision, and one of the five conversion letters
+  -->
   <xsl:variable name="eo:specifier" select="'25((3[0-9])+24)?(2D|30)*(3[0-9])*(2E(3[0-9])+)?(73|64|66|78|62)'"/>
   <!-- Find arguments in tuple -->
   <xsl:template match="o" mode="arguments" as="xs:integer">
@@ -60,8 +62,10 @@
             </defect>
           </xsl:when>
           <xsl:otherwise>
-            <!-- The bytes of the template, with a doubled percent taken out,
-            since it stands for a literal one and starts no specifier -->
+            <!--
+            The bytes of the template, with a doubled percent taken out,
+            since it stands for a literal one and starts no specifier
+            -->
             <xsl:variable name="escaped" select="replace(translate($text, '-', ''), '2525', '')"/>
             <!-- A specifier is %[N$][flags][width][.precision]conversion, in bytes -->
             <xsl:variable name="declared" select="count(tokenize($escaped, $eo:specifier)) - 1"/>

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/allows-many-good-arguments.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/allows-many-good-arguments.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+# yamllint disable rule:line-length
 sheets:
   - /org/eolang/lints/misc/wrong-sprintf-arguments.xsl
 defects: 0

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/allows-many-good-arguments.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/allows-many-good-arguments.yaml
@@ -7,6 +7,5 @@ defects: 0
 input: |
   [] > app
     io.stdout > @
-      org.eolang.txt.sprintf
-        "Hello, %s (%x, match: %b)! Your account is %d, your temperature %f."
+      "Hello, %s (%x, match: %b)! Your account is %d, your temperature %f.".printf
         * name name.as-bytes true acc t

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/allows-padded-specifiers.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/allows-padded-specifiers.yaml
@@ -7,5 +7,5 @@ defects: 0
 input: |
   [] > app
     io.stdout > @
-      "Hello, %s! Your account is %d.".printf
-        * name acc
+      "%08.2f is %5d, or %-10s".printf
+        * t acc name

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/allows-percentage-sign.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/allows-percentage-sign.yaml
@@ -6,6 +6,5 @@ sheets:
 defects: 0
 input: |
   [] > app
-    txt.sprintf > @
-      "Water constitutes 0.023%% of Earth mass, which is %d tons"
+    "Water constitutes 0.023%% of Earth mass, which is %d tons".printf > @
       * 1.4e18

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/allows-sprintf-containing-tuple-with-number.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/allows-sprintf-containing-tuple-with-number.yaml
@@ -7,6 +7,5 @@ defects: 0
 input: |
   [] > app
     io.stdout > @
-      org.eolang.txt.sprintf
-        "Привет, %d"
+      "Привет, %d".printf
         * 52

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/allows-sprintf-containing-tuple-with-string.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/allows-sprintf-containing-tuple-with-string.yaml
@@ -7,6 +7,5 @@ defects: 0
 input: |
   [] > app
     io.stdout > @
-      org.eolang.txt.sprintf
-        "Hello, %s"
+      "Hello, %s".printf
         * "Jeff"

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/catches-arguments-absence.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/catches-arguments-absence.yaml
@@ -9,6 +9,5 @@ defects:
 input: |
   [] > app
     io.stdout > @
-      txt.sprintf
-        "Hello, %s! Your account is %d."
+      "Hello, %s! Your account is %d.".printf
         *

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/catches-incorrect-arguments-as-mix-of-static-and-dynamic.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/catches-incorrect-arguments-as-mix-of-static-and-dynamic.yaml
@@ -7,18 +7,16 @@ sheets:
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
   - /defects/defect[@line='6']
-  - /defects/defect[1][normalize-space()='According to the formatting template of the "Φ.txt.sprintf" object, a tuple of 1 element(s) is expected as the second argument of it, while a tuple of 2 element(s) is provided']
+  - /defects/defect[1][normalize-space()='According to the formatting template of the ".printf" object, a tuple of 1 element(s) is expected as its argument, while a tuple of 2 element(s) is provided']
 input: |
   [fmt args kid] > log
     seq > @
       *
         stdout
           magenta
-            txt.sprintf
-              "\033[90m%s\033[0m\n"
+            "\033[90m%s\033[0m\n".printf
               *
-                txt.sprintf
-                  fmt
+                fmt.printf
                   * args
                 1
         kid

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/catches-more-arguments-than-needed.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/catches-more-arguments-than-needed.yaml
@@ -9,6 +9,5 @@ defects:
 input: |
   [] > app
     io.stdout > @
-      txt.sprintf
-        "Hello, %s! Your account is %d."
+      "Hello, %s! Your account is %d.".printf
         * name acc foo bar

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/catches-more-than-one-argument.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/catches-more-than-one-argument.yaml
@@ -9,7 +9,6 @@ defects:
 input: |
   [] > app
     io.stdout > @
-      txt.sprintf
-        "Hey, Jeff"
+      "Hey, Jeff".printf
         *
         unnecessary

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/catches-multiple-sprintfs.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/catches-multiple-sprintfs.yaml
@@ -5,13 +5,11 @@ sheets:
   - /org/eolang/lints/misc/wrong-sprintf-arguments.xsl
 defects:
   - severity: warning
-    line: 6
+    line: 5
 input: |
   [] > app
     io.stdout > @
-      txt.sprintf
-        "Hello, %s! Your account is %d."
+      "Hello, %s! Your account is %d.".printf
         * name acc
-      txt.sprintf
-        "Hello, %s! Your account is %f."
+      "Hello, %s! Your account is %f.".printf
         * f

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/catches-sparse-sprintf.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/catches-sparse-sprintf.yaml
@@ -9,6 +9,5 @@ defects:
 input: |
   [] > app
     io.stdout > @
-      txt.sprintf
-        "Hello, %s! Your account is %d."
+      "Hello, %s! Your account is %d.".printf
         * name

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/catches-wrong-argument.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/catches-wrong-argument.yaml
@@ -9,6 +9,5 @@ defects:
 input: |
   [] > app
     io.stdout > @
-      txt.sprintf
-        "Hey, Jeff"
+      "Hey, Jeff".printf
         wrong

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/catches-wrong-arguments-with-raw-values.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/catches-wrong-arguments-with-raw-values.yaml
@@ -9,6 +9,5 @@ defects:
 input: |
   [] > app
     io.stdout > @
-      txt.sprintf
-        "Привет %s, %d"
+      "Привет %s, %d".printf
         * 52

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/ignores-a-positional-template.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/ignores-a-positional-template.yaml
@@ -7,5 +7,5 @@ defects: 0
 input: |
   [] > app
     io.stdout > @
-      "Hello, %s! Your account is %d.".printf
-        * name acc
+      "%1$s and %1$s again".printf
+        * name

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/ignores-dynamic-sprintf-in-string-format-argument.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/ignores-dynamic-sprintf-in-string-format-argument.yaml
@@ -10,10 +10,8 @@ input: |
       *
         stdout
           magenta
-            txt.sprintf
-              "\033[90m%s\033[0m\n"
+            "\033[90m%s\033[0m\n".printf
               *
-                txt.sprintf
-                  fmt
+                fmt.printf
                   * args
         kid

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/ignores-outside-object-in-string-format-argument.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/ignores-outside-object-in-string-format-argument.yaml
@@ -10,7 +10,6 @@ input: |
       *
         stdout
           magenta
-            txt.sprintf
-              foo
+            foo.printf
               * 1 2 3
         kid

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/ignores-void-attribute-in-string-format-argument.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-sprintf-arguments/ignores-void-attribute-in-string-format-argument.yaml
@@ -10,7 +10,6 @@ input: |
       *
         stdout
           magenta
-            txt.sprintf
-              fmt
+            fmt.printf
               * 1 2 3
         kid


### PR DESCRIPTION
Fixes #1355.

The rule selected `Φ.txt.sprintf`, an object current EO does not emit: there is no `txt` package any more, and formatting is a method on the format string, so an XMIR carries `base=".printf"`. None of the three checks the rule performs could fire on anything.

The dispatch puts the template on the receiver and leaves exactly one argument, so:

- the arity check becomes "only 1 argument", counted over the children that carry `@as`;
- the template is read from the child without `@as`, which is where a real XMIR keeps the receiver (checked against `eo-runtime/target/eo/1-parse/bytes/as-i16.xmir`, not assumed);
- the tuple is the first `@as` child rather than `o[2]`.

Counting the specifiers changed with it. Looking for the byte pairs of `%s`, `%d`, `%f`, `%x` and `%b` misses everything current `printf` accepts around the conversion letter, so `"%08.2f"` counted as zero specifiers and the rule would have reported a correct call as passing one argument too many. The template bytes are matched against the specifier grammar `printf.eo` documents: `%[N$][flags][width][.precision]conversion`.

A template using positional specifiers is left alone by the count check, since `%1$s` twice needs one argument, not two.

The packs are rewritten to the current call form, with three added: padded specifiers, a positional template, and the renamed arity pack. The eight `catches-*` packs fail without the change and pass with it.
