### PR TITLE
fix(#215): remove obsolete platform-timeout puzzle

### DIFF
--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -2,7 +2,4 @@
 # SPDX-License-Identifier: MIT
 
 junit.jupiter.execution.parallel.enabled = true
-# @todo #107:45min Configure default timeout for tests running on windows to 10s and 3s on other platforms.
-#  Currently, it fails with the 3s timeout on windows platform. Let's try to configure
-#  test default timeout exclusively for windows, and keep 3s for other platforms.
 junit.jupiter.execution.timeout.test.method.default = 45s


### PR DESCRIPTION
## Summary

- Removes the stale `@todo #107:45min` puzzle from `src/test/resources/junit-platform.properties` that asked for a Windows-specific (10s) vs. other-platforms (3s) test timeout split.
- No behavior change: `junit.jupiter.execution.timeout.test.method.default = 45s` is left as-is.

## Why

Closes #215.

The puzzle's premise no longer holds, per the discussion on the issue:
1. Its parent issue (#107) is already closed, so the puzzle lost its anchor.
2. The default timeout was raised from the original 3s to 45s, which comfortably covers the Windows slowness that motivated the 10s/3s split — the "fails with the 3s timeout on Windows" problem the puzzle describes is gone.
3. Individual slow tests already carry their own explicit `@Timeout` annotations, so a platform-specific global default would add little value.

If a platform-specific default is ever needed again, `junit-platform.properties` doesn't support per-OS values natively — it would have to be wired through Maven Surefire profiles keyed on `os.family` — but the current 45s default makes that unnecessary for now.

## Test plan

- [x] Confirmed no other files reference the removed puzzle text.
- [x] Config-only change (comment removal); existing test suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqeNs55C79cT67tgEYJkrw

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqeNs55C79cT67tgEYJkrw)_