### PR TITLE
fix(#1377): anchor the second alternative of the package regex

### DIFF
--- a/src/main/resources/org/eolang/lints/metas/incorrect-package.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-package.xsl
@@ -14,7 +14,7 @@
         <xsl:variable name="meta-head" select="head"/>
         <xsl:variable name="meta-tail" select="tail"/>
         <xsl:variable name="first" select="normalize-space(substring-before(concat($meta-tail, ' '), ' '))"/>
-        <xsl:if test="$meta-head='package' and not(matches($first, '^[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+|\$[a-zA-Z0-9_]*)*$|[\p{L}\p{M}\p{N}_]+(\.[\p{L}\p{M}\p{N}_]+)*$'))">
+        <xsl:if test="$meta-head='package' and not(matches($first, '^[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+|\$[a-zA-Z0-9_]*)*$|^[\p{L}\p{M}\p{N}_@][\p{L}\p{M}\p{N}_@-]*(\.[\p{L}\p{M}\p{N}_@][\p{L}\p{M}\p{N}_@-]*)*$'))">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-package/catches-package-invalid-anywhere-in-the-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-package/catches-package-invalid-anywhere-in-the-name.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/incorrect-package.xsl
+defects:
+  - severity: warning
+    line: 1
+  - severity: warning
+    line: 2
+input: |
+  +package -bad
+  +package org..example
+
+  [] > foo


### PR DESCRIPTION
Fixes #1377.

`matches()` in XPath is not anchored, and the second alternative of the `+package` pattern ended with `$` but never started with `^`. Any tail whose last segments look like a name therefore passed, whatever stood in front of them: `-bad` matched on `bad`, and `org..example` matched on `example`.

Anchoring alone is not enough. The alternative is also the one that lets a package carry `-` and `@`, which the existing packs rely on (`c.d-test.x-yz`, `universe@obj`, `a.b-привет.c-大家好`); once it is anchored, its character class has to hold those two characters itself instead of skipping past them. A segment still has to start with something other than a hyphen, so `-bad` stays a defect while `d-test` does not.

Checked every name the packs of this lint carry, plus the two from the issue, against the sheet directly:

| `+package` | before | after |
| --- | --- | --- |
| `-bad` | passes | defect |
| `org..example` | passes | defect |
| `test.` | defect | defect |
| `привет, как дела?` | defect | defect |
| `a.b.c`, `X.Y.Z`, `Foo`, `hello.world123`, `test_xyz` | passes | passes |
| `j$org.j$eolang.j$jeo`, `com.foo$bar` | passes | passes |
| `universe@obj`, `c.d-test.x-yz`, `a.b-привет.c-大家好`, `foo.бар` | passes | passes |

The two new cases are in a pack of their own.
