### PR TITLE
fix(#1380): let the also meta be known

### DIFF
--- a/src/main/resources/org/eolang/lints/metas/unknown-metas.xsl
+++ b/src/main/resources/org/eolang/lints/metas/unknown-metas.xsl
@@ -12,7 +12,7 @@
     <defects>
       <xsl:for-each select="/object/metas/meta">
         <xsl:variable name="meta-head" select="head"/>
-        <xsl:variable name="predefined" select="('package', 'alias', 'version', 'rt', 'architect', 'home', 'unlint', 'probe', 'spdx', 'syntax')"/>
+        <xsl:variable name="predefined" select="('package', 'alias', 'also', 'version', 'rt', 'architect', 'home', 'unlint', 'probe', 'spdx', 'syntax')"/>
         <xsl:if test="not($meta-head = $predefined)">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>

--- a/src/main/resources/org/eolang/motives/metas/unknown-metas.md
+++ b/src/main/resources/org/eolang/motives/metas/unknown-metas.md
@@ -4,6 +4,7 @@ The following metas are supported:
 
 * `+package`
 * `+alias`
+* `+also`
 * `+version`
 * `+rt`
 * `+architect`
@@ -26,6 +27,7 @@ Correct:
 ```eo
 +package com.test
 +alias foo
++also foo
 +version 0.0.0
 +architect yegor256@gmail.com
 +rt jvm

--- a/src/test/resources/org/eolang/lints/packs/single/unknown-metas/catches-unknown-metas.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unknown-metas/catches-unknown-metas.yaml
@@ -16,6 +16,7 @@ input: |
   +bad
   +package test
   +alias foo
+  +also foo
   +version 0.0.0
   +architect yegor256@gmail.com
   +rt node


### PR DESCRIPTION
Fixes #1380.

`also` is a meta the parser knows: `add-default-package.xsl` and `resolve-aliases.xsl` in eo-parser both match `meta[head='also']` and rewrite its parts the way they rewrite an alias. The whitelist here never got it, so every `+also` is reported as a meta whose "usage has no effect", which is the opposite of what happens to it.

Added `also` to the list, to the pack, and to the motive, next to `alias`, since the two are read by the same sheets.

Run against the sheet directly, `+also app` no longer reports, while an actually unknown meta still does.
