### PR TITLE
fix(#1379): compare the home URL without its trailing slash

### DIFF
--- a/src/main/resources/org/eolang/funcs/home-object.xsl
+++ b/src/main/resources/org/eolang/funcs/home-object.xsl
@@ -11,13 +11,16 @@
   neither "+package" (mandatory-package) nor "+package org.eolang"
   (prohibited-package) should be flagged on them. Keep this list in sync
   with the home repository; both lints share it from here so it never goes
-  stale in two places at once.
+  stale in two places at once. The "+home" tail is compared with its trailing
+  slashes cut off, because "https://github.com/objectionary/eo/" names the
+  same repository as the URL without the slash, and an exact match would let
+  a slash turn a runtime object into a defect of both lints (#1379).
   -->
   <xsl:variable name="eo:home-objects" as="xs:string*" select="('bool', 'buffer', 'bytes', 'chunk', 'clock', 'console', 'dataized', 'directory', 'e', 'eol', 'false', 'file', 'getenv', 'i16', 'i32', 'i64', 'i8', 'input', 'malloc', 'map', 'mktemp', 'nan', 'ninf', 'nop', 'number', 'os', 'output', 'path', 'pi', 'pinf', 'posix', 'range', 'recovered', 'seq', 'set', 'socket', 'stderr', 'stdin', 'stdout', 'string', 'switch', 'true', 'tuple', 'u16', 'u32', 'u64', 'u8', 'uri', 'while', 'win32')"/>
   <xsl:variable name="eo:home-repo" as="xs:string" select="'https://github.com/objectionary/eo'"/>
   <xsl:function name="eo:home-object" as="xs:boolean">
     <xsl:param name="name" as="xs:string?"/>
     <xsl:param name="metas" as="element()*"/>
-    <xsl:sequence select="$name = $eo:home-objects and $metas[head = 'home' and tail = $eo:home-repo]"/>
+    <xsl:sequence select="$name = $eo:home-objects and $metas[head = 'home' and replace(tail, '/+$', '') = $eo:home-repo]"/>
   </xsl:function>
 </xsl:stylesheet>

--- a/src/test/resources/org/eolang/lints/packs/single/mandatory-package/skips-home-objects-with-trailing-slash.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/mandatory-package/skips-home-objects-with-trailing-slash.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/mandatory-package.xsl
+defects: 0
+input: |
+  +home https://github.com/objectionary/eo/
+
+  [] > win32

--- a/src/test/resources/org/eolang/lints/packs/single/prohibited-package/skips-home-object-with-trailing-slash.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/prohibited-package/skips-home-object-with-trailing-slash.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/prohibited-package.xsl
+defects: 0
+input: |
+  +home https://github.com/objectionary/eo/
+  +package org.eolang
+
+  [] > win32


### PR DESCRIPTION
Fixes #1379.

`eo:home-object` asks whether the `+home` tail equals `https://github.com/objectionary/eo` character for character. A tail that names the same repository with a trailing slash does not, so both lints that share this function get the answer wrong: `prohibited-package` reports an ordinary runtime object as one that must not sit in `org.eolang`, and `mandatory-package` asks a runtime object for the `+package` it is not supposed to carry.

The tail is now compared with its trailing slashes cut off. Run against the sheets directly, with `+home https://github.com/objectionary/eo/`:

| sheet | object | before | after |
| --- | --- | --- | --- |
| `prohibited-package` | `bytes`, `+package org.eolang` | 1 defect | none |
| `mandatory-package` | `win32`, no `+package` | 1 defect | none |
| `prohibited-package` | `foo`, `+package org.eolang` | 1 defect | 1 defect |

A pack for each of the two lints.
