### PR TITLE
fix(#1382): check an spdx meta that carries one part

### DIFF
--- a/src/main/resources/org/eolang/lints/metas/incorrect-spdx.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-spdx.xsl
@@ -10,7 +10,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="/object/metas/meta[head/text()='spdx' and count(part) &gt; 1]">
+      <xsl:for-each select="/object/metas/meta[head/text()='spdx' and count(part) &gt; 0]">
         <xsl:variable name="meta-tail" select="tail"/>
         <xsl:variable name="header" select="normalize-space(substring-before(concat($meta-tail, ' '), ' '))"/>
         <xsl:if test="$header!='SPDX-FileCopyrightText:' and $header!='SPDX-License-Identifier:'">

--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-spdx/catches-spdx-of-one-part.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-spdx/catches-spdx-of-one-part.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/incorrect-spdx.xsl
+defects:
+  - severity: warning
+    line: 1
+input: |
+  +spdx MIT
+
+  [] > foo


### PR DESCRIPTION
Fixes #1382.

The loop skipped any `+spdx` whose tail is a single word, so `+spdx MIT` was never looked at. A compliant tail always has at least two parts, the `SPDX-...:` header and what follows it, which means a one-part tail can only ever be wrong, and it was the one shape the lint let through.

The guard now stands at `count(part) > 0`: a tail is checked as soon as there is one, and a bare `+spdx` with nothing after it is left where it was, since there is no header there to name in the message.

Against the sheet:

| `+spdx` tail | before | after |
| --- | --- | --- |
| `MIT` | passes | defect |
| `Hello world` | defect | defect |
| `SPDX-License-Identifier: MIT` | passes | passes |
| `SPDX-FileCopyrightText: Copyright (c) 2026 Objectionary.com` | passes | passes |
| nothing | passes | passes |
