### PR TITLE
fix(#1370): load XSL motives from the classpath instead of the URL string

### DIFF
--- a/src/main/java/org/eolang/lints/PkByXsl.java
+++ b/src/main/java/org/eolang/lints/PkByXsl.java
@@ -9,11 +9,12 @@ import io.github.secretx33.resourceresolver.Resource;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.cactoos.io.InputOf;
+import org.cactoos.io.ResourceOf;
 import org.cactoos.iterable.IterableEnvelope;
 import org.cactoos.iterable.Shuffled;
+import org.cactoos.text.FormattedText;
 
 /**
  * All lints defined by XSLs.
@@ -22,20 +23,6 @@ import org.cactoos.iterable.Shuffled;
  * @since 0.1.0
  */
 final class PkByXsl extends IterableEnvelope<Lint> {
-
-    /**
-     * XSL extension pattern.
-     */
-    private static final Pattern XSL_PATTERN = Pattern.compile(
-        ".xsl", Pattern.LITERAL
-    );
-
-    /**
-     * Lint paths pattern.
-     */
-    private static final Pattern LINTS_PATH = Pattern.compile(
-        "eolang/lints", Pattern.LITERAL
-    );
 
     /**
      * Cached lint instances.
@@ -68,24 +55,21 @@ final class PkByXsl extends IterableEnvelope<Lint> {
 
     private static Lint lint(final Resource res) {
         try {
-            final String url = res.getURL().toString();
+            final String name = res.getURL().toString()
+                .replaceAll(".*org/eolang/lints/", "")
+                .replaceAll("\\.xsl$", "");
             return new LtByXsl(
                 new InputOf(res.getInputStream()),
-                new InputOf(
-                    PkByXsl.XSL_PATTERN.matcher(
-                        PkByXsl.LINTS_PATH.matcher(url).replaceAll("eolang/motives")
-                    ).replaceAll(".md")
+                new ResourceOf(
+                    new FormattedText("org/eolang/motives/%s.md", name)
                 ),
                 new FxResource(
-                    String.format(
-                        "org/eolang/fixes/%s.xsl",
-                        url.replaceAll(".*org/eolang/lints/", "").replaceAll("\\.xsl$", "")
-                    )
+                    new FormattedText("org/eolang/fixes/%s.xsl", name)
                 )
             );
         } catch (final IOException ex) {
             throw new IllegalArgumentException(
-                "Failed to build a fix for an XSL lint",
+                "Failed to build an XSL lint from the classpath",
                 ex
             );
         }

--- a/src/test/java/org/eolang/lints/PkByXslTest.java
+++ b/src/test/java/org/eolang/lints/PkByXslTest.java
@@ -20,6 +20,7 @@ import java.util.function.Predicate;
 import org.cactoos.io.InputOf;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
+import org.cactoos.text.FormattedText;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 import org.hamcrest.MatcherAssert;
@@ -86,6 +87,27 @@ final class PkByXslTest {
                 Matchers.equalTo(false)
             );
         }
+    }
+
+    @Test
+    void returnsMarkdownContentInsteadOfUrl() throws Exception {
+        final String name = "self-referencing";
+        MatcherAssert.assertThat(
+            "Motive must contain the markdown content, not the classpath URL",
+            new ListOf<>(new PkByXsl()).stream()
+                .filter(l -> name.equals(l.name()))
+                .findFirst()
+                .orElseThrow().motive(),
+            Matchers.equalTo(
+                new TextOf(
+                    new ResourceOf(
+                        new FormattedText(
+                            "org/eolang/motives/critical/%s.md", name
+                        )
+                    )
+                ).asString()
+            )
+        );
     }
 
     @Test


### PR DESCRIPTION
Fixes #1370.

## Problem
`PkByXsl.motive()` returned the classpath URL string (e.g. `jar:file:/.../org/eolang/motives/misc/redundant-object.md!/`) instead of the markdown content, for all ~89 XSL lints. The root cause: `InputOf(CharSequence)` in cactoos treats the argument as *content*, not as a classpath path, and the derived string also carried the `jar:file:/...!/` prefix.

## Solution
Derive the clean relative path `org/eolang/motives/<dir>/<name>.md` from the XSL resource URL and load it via `ResourceOf`, exactly like the `LtByXsl(String)` constructor does. The now-unused `XSL_PATTERN`/`LINTS_PATH` patterns were removed.

## Changes
- `src/main/java/org/eolang/lints/PkByXsl.java` — build the motive (and fix) classpath paths from the resource name and use `ResourceOf`/`FormattedText` instead of `InputOf(<url-string>)`.
- `src/test/java/org/eolang/lints/PkByXslTest.java` — new test `returnsMarkdownContentInsteadOfUrl` asserting the motive equals the actual markdown file content.

## Tests
- `mvn clean install -Pqulice` (1019 rules) — pass
- `mvn clean test` (669 tests) — pass