### PR TITLE
fix(#1372): use anyMatch for range unlints covering part of the defects

### DIFF
--- a/src/main/java/org/eolang/lints/DefectMissing.java
+++ b/src/main/java/org/eolang/lints/DefectMissing.java
@@ -47,7 +47,7 @@ final class DefectMissing implements Function<String, Boolean> {
             if (lines == null) {
                 missing = !this.excluded.contains(name);
             } else {
-                missing = !lines.stream().allMatch(new UnlintInRange(unlint));
+                missing = !lines.stream().anyMatch(new UnlintInRange(unlint));
             }
         } else {
             final Set<String> names;

--- a/src/test/java/org/eolang/lints/DefectMissingTest.java
+++ b/src/test/java/org/eolang/lints/DefectMissingTest.java
@@ -81,12 +81,12 @@ final class DefectMissingTest {
     }
 
     @Test
-    void returnsTrueIfSomeLineIsOutOfRange() {
+    void returnsFalseWhenSomeLineIsInTheRange() {
         MatcherAssert.assertThat(
-            "Defect should be missing, but it was not",
+            "Defect should not be missing, since at least one defect is covered by the range",
             new DefectMissing(new MapOf<>("noisy-lint", new ListOf<>(4, 6)), new ListOf<>())
                 .apply("noisy-lint:6-10"),
-            Matchers.equalTo(true)
+            Matchers.equalTo(false)
         );
     }
 


### PR DESCRIPTION
Fixes #1372.

## Problem
`DefectMissing` reported a range `+unlint foo:10-20` as "doesn't make sense" whenever *any* defect of `foo` was outside the range, even if the range covered another defect. E.g. defects on lines `[5, 15]` with `foo:10-20` produced a false warning, although line `15` is legitimately suppressed.

## Root cause
`src/main/java/org/eolang/lints/DefectMissing.java:50` used `allMatch(new UnlintInRange(unlint))`, so the presence of a single out-of-range defect made the whole suppression "missing".

## Solution
Use `anyMatch` — the suppression makes sense as long as at least one defect falls into the range (the same semantics `LtUnlint` applies via `removeIf(inRange)`).

## Changes
- `src/main/java/org/eolang/lints/DefectMissing.java` — `allMatch` → `anyMatch`.
- `src/test/java/org/eolang/lints/DefectMissingTest.java` — `returnsTrueIfSomeLineIsOutOfRange` (which encoded the buggy behavior) replaced with `returnsFalseWhenSomeLineIsInTheRange`.

## Tests
- `mvn clean install -Pqulice` (1019 rules) — pass
- `mvn clean test` (668 tests) — pass