### PR TITLE
fix(#1374): fall back to an empty version when the manifest attribute is absent

### DIFF
--- a/src/main/java/org/eolang/lints/Defect.java
+++ b/src/main/java/org/eolang/lints/Defect.java
@@ -188,7 +188,7 @@ public interface Defect {
 
         @Override
         public String version() {
-            return Manifests.read("Lints-Version");
+            return Defect.Default.versionOf("Lints-Version");
         }
 
         @Override
@@ -219,6 +219,16 @@ public interface Defect {
         @Override
         public int hashCode() {
             return Objects.hash(this.rle, this.sev, this.lineno, this.txt);
+        }
+
+        static String versionOf(final String attribute) {
+            String version;
+            try {
+                version = Manifests.read(attribute);
+            } catch (final IllegalArgumentException ex) {
+                version = "";
+            }
+            return version;
         }
     }
 }

--- a/src/test/java/org/eolang/lints/DefectTest.java
+++ b/src/test/java/org/eolang/lints/DefectTest.java
@@ -29,6 +29,15 @@ final class DefectTest {
     }
 
     @Test
+    void returnsEmptyVersionWhenAttributeIsAbsent() {
+        MatcherAssert.assertThat(
+            "Version must not throw when the manifest attribute is absent",
+            Defect.Default.versionOf("No-Such-Manifest-Attribute"),
+            Matchers.equalTo("")
+        );
+    }
+
+    @Test
     void printsWithoutZeroLineNumber() {
         MatcherAssert.assertThat(
             "toString() prints zero for line number",


### PR DESCRIPTION
Fixes #1374.

## Problem
`Defect.version()` threw an unhandled `IllegalArgumentException` when the `Lints-Version` manifest attribute was absent from the classpath (library used as a dependency, shaded jar, IDE run) — crashing callers on the default path (via `DfContext.version()`).

## Root cause
`Defect.Default.version()` called `Manifests.read("Lints-Version")`, which throws when the attribute is not found.

## Solution
Extract the read into `Defect.Default.versionOf(String)` that catches `IllegalArgumentException` and returns an empty string. `version()` delegates to it.

## Changes
- `src/main/java/org/eolang/lints/Defect.java` — `versionOf(...)` fallback helper; `version()` uses it.
- `src/test/java/org/eolang/lints/DefectTest.java` — new test `returnsEmptyVersionWhenAttributeIsAbsent`.

## Tests
- `mvn clean install -Pqulice` (1019 rules) — pass
- `mvn clean test` (669 tests) — pass