### PR TITLE
fix(#1373): apply a lint's fix only when the lint reports defects

### DIFF
--- a/src/main/java/org/eolang/lints/Source.java
+++ b/src/main/java/org/eolang/lints/Source.java
@@ -82,14 +82,17 @@ public final class Source {
 
     /**
      * Apply all available fixes to the XMIR, returning the corrected document.
-     * Lints without a fix return the XMIR unchanged.
+     * A lint's fix is applied only when the lint reports at least one defect
+     * on the current document, so clean XMIR stays untouched.
      * @return Fixed XMIR
      * @throws IOException If a fix fails to apply
      */
     public XML fix() throws IOException {
         XML result = this.xmir;
         for (final Lint lint : this.lints) {
-            result = lint.fix().apply(result);
+            if (!lint.defects(result).isEmpty()) {
+                result = lint.fix().apply(result);
+            }
         }
         return result;
     }

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -173,6 +173,19 @@ final class SourceTest {
     }
 
     @Test
+    void doesNotApplyFixWithoutDefects() throws IOException {
+        final XML before = new XMLDocument("<object><o name='x'/></object>");
+        MatcherAssert.assertThat(
+            "fix() must not apply a lint's fix when the lint reports no defects",
+            new Source(
+                before,
+                new ListOf<>(new SourceTest.DestructiveLint())
+            ).fix().toString(),
+            Matchers.equalTo(before.toString())
+        );
+    }
+
+    @Test
     void createsSourceWithoutOneLint() {
         MatcherAssert.assertThat(
             "Defects for disabled lint are not empty, but should be",
@@ -595,6 +608,33 @@ final class SourceTest {
          */
         int total() {
             return this.count;
+        }
+    }
+
+    /**
+     * A lint that reports no defects but mutates the XMIR when its fix is applied.
+     * @since 0.1.0
+     */
+    private static final class DestructiveLint implements Lint {
+
+        @Override
+        public String name() {
+            return "destructive";
+        }
+
+        @Override
+        public Collection<Defect> defects(final XML entity) {
+            return new ListOf<>();
+        }
+
+        @Override
+        public String motive() {
+            return "Motive";
+        }
+
+        @Override
+        public Fix fix() {
+            return entity -> new XMLDocument("<object><o name='mutated'/></object>");
         }
     }
 }


### PR DESCRIPTION
Fixes #1373.

## Problem
`Source.fix()` applied every lint's fix unconditionally, so a fix could mutate a perfectly clean XMIR — e.g. re-sorting metas that were already sorted, or re-serializing a document that carried no relevant defects.

## Solution
Gate the application: a lint's fix runs only when that lint reports at least one defect on the current document (`if (!lint.defects(result).isEmpty())`). Clean XMIR therefore stays untouched.

## Changes
- `src/main/java/org/eolang/lints/Source.java` — gated `fix()` loop; javadoc updated.
- `src/test/java/org/eolang/lints/SourceTest.java` — new test `doesNotApplyFixWithoutDefects` backed by a `DestructiveLint` fake (reports no defects, mutates XMIR when fixed); verified to fail without the gating change.

## Tests
- `mvn clean install -Pqulice` (1019 rules) — pass
- `mvn clean test` (669 tests) — pass