### PR TITLE
fix(#1371): match the .printf dispatch form in sprintf-constant-args

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/sprintf-constant-args.xsl
+++ b/src/main/resources/org/eolang/lints/misc/sprintf-constant-args.xsl
@@ -16,7 +16,7 @@
   </xsl:template>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[@base='Φ.txt.sprintf'][count(o)=2][o[2][@base='Φ.tuple']]">
+      <xsl:for-each select="//o[@base='.printf' or @base='Φ.txt.sprintf'][count(o)=2][o[2][@base='Φ.tuple']]">
         <xsl:variable name="text" select="o[1][@base='Φ.string']/o[1][@base='Φ.bytes']/o/text()"/>
         <xsl:if test="$text">
           <xsl:variable name="formatters">
@@ -52,7 +52,7 @@
               <xsl:attribute name="severity">
                 <xsl:text>warning</xsl:text>
               </xsl:attribute>
-              <xsl:text>The "Φ.txt.sprintf" object is used with a constant format template and constant string arguments only; since the result is already known, a plain literal string should be used instead</xsl:text>
+              <xsl:text>The ".printf" object is used with a constant format template and constant string arguments only; since the result is already known, a plain literal string should be used instead</xsl:text>
             </defect>
           </xsl:if>
         </xsl:if>

--- a/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/catches-printf-with-constant-args.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/catches-printf-with-constant-args.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/sprintf-constant-args.xsl
+defects:
+  - severity: warning
+    line: 3
+input: |
+  [] > app
+    io.stdout > @
+      "Hello, %s!".printf
+        * "Jeff"


### PR DESCRIPTION
Fixes #1371.

## Problem
`sprintf-constant-args` only matched the `Φ.txt.sprintf` base (the `txt.sprintf` form) and missed the idiomatic `".format".printf` dispatch that the other two sprintf lints (`sprintf-without-formatters` #1357, `wrong-sprintf-arguments` #1355) were already aligned to.

## Solution
Extend the selector to match both dispatch forms the parser emits: `@base='.printf' or @base='Φ.txt.sprintf'`. The defect text now refers to `.printf`.

## Changes
- `src/main/resources/org/eolang/lints/misc/sprintf-constant-args.xsl` — selector and message updated.
- `src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/catches-printf-with-constant-args.yaml` — new pack with a constant `"Hello, %s!".printf * "Jeff"` call.

## Tests
- `mvn clean install -Pqulice` (1019 rules) — pass
- `mvn clean test` (669 tests) — pass