### PR TITLE
fix(#1388): warn on invalid +unlint format

### DIFF
--- a/src/main/java/org/eolang/lints/LtIncorrectUnlint.java
+++ b/src/main/java/org/eolang/lints/LtIncorrectUnlint.java
@@ -38,20 +38,12 @@ final class LtIncorrectUnlint implements Lint {
     @Override
     public Collection<Defect> defects(final XML xmir) throws IOException {
         return new Xnav(xmir.inner()).path("/object/metas/meta[head='unlint']").filter(
-            u -> !this.names.contains(
-                u.element("tail").text().orElse("unknown").split(":", -1)[0]
-            )
-        ).map(
-            u -> new Defect.Default(
-                this.name(),
-                Severity.ERROR,
-                new LineOf(u).value(),
-                String.format(
-                    "Suppressing \"%s\" does not make sense, because there is no lint with that name",
-                    u.element("tail").text().orElse("unknown")
-                )
-            )
-        ).collect(Collectors.toList());
+            u -> {
+                final String tail = LtIncorrectUnlint.tail(u);
+                final String name = LtIncorrectUnlint.nameOf(tail);
+                return !this.names.contains(name) || LtIncorrectUnlint.invalid(tail, name);
+            }
+        ).map(u -> this.defect(u)).collect(Collectors.toList());
     }
 
     @Override
@@ -62,5 +54,42 @@ final class LtIncorrectUnlint implements Lint {
     @Override
     public Fix fix() {
         return new FxEmpty();
+    }
+
+    private Defect defect(final Xnav meta) {
+        final String tail = LtIncorrectUnlint.tail(meta);
+        final String name = LtIncorrectUnlint.nameOf(tail);
+        final String msg;
+        if (this.names.contains(name)) {
+            msg = String.format(
+                "Suppressing \"%s\" has an invalid format, use \"%s\", \"%s:N\" or \"%s:N-M\"",
+                tail, name, name, name
+            );
+        } else {
+            msg = String.format(
+                "Suppressing \"%s\" does not make sense, because there is no lint with that name",
+                tail
+            );
+        }
+        return new Defect.Default(
+            this.name(),
+            Severity.ERROR,
+            new LineOf(meta).value(),
+            msg
+        );
+    }
+
+    private static String tail(final Xnav meta) {
+        return meta.element("tail").text().orElse("unknown");
+    }
+
+    private static String nameOf(final String tail) {
+        return tail.split(":", -1)[0];
+    }
+
+    private static boolean invalid(final String tail, final String name) {
+        return !tail.equals(name)
+            && !tail.matches(String.format("%s:\\d+", name))
+            && !tail.matches(String.format("%s:\\d+-\\d+", name));
     }
 }

--- a/src/test/java/org/eolang/lints/LtIncorrectUnlintTest.java
+++ b/src/test/java/org/eolang/lints/LtIncorrectUnlintTest.java
@@ -80,4 +80,46 @@ final class LtIncorrectUnlintTest {
             Matchers.hasSize(Matchers.greaterThan(0))
         );
     }
+
+    @Test
+    void catchesUnlintWithInvalidLineFormat() throws IOException {
+        MatcherAssert.assertThat(
+            "Unlint with a non-numeric line part should be caught",
+            new LtIncorrectUnlint(new ListOf<>("ascii-only")).defects(
+                new EoProgram(
+                    "+unlint ascii-only:abc",
+                    new InputOf("+unlint ascii-only:abc")
+                ).parse()
+            ),
+            Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
+
+    @Test
+    void catchesUnlintWithEmptyLinePart() throws IOException {
+        MatcherAssert.assertThat(
+            "Unlint with an empty line part should be caught",
+            new LtIncorrectUnlint(new ListOf<>("ascii-only")).defects(
+                new EoProgram(
+                    "+unlint ascii-only:",
+                    new InputOf("+unlint ascii-only:")
+                ).parse()
+            ),
+            Matchers.hasSize(Matchers.greaterThan(0))
+        );
+    }
+
+    @Test
+    void allowsUnlintWithRange() throws IOException {
+        MatcherAssert.assertThat(
+            "Unlint with a valid range should be supported",
+            new LtIncorrectUnlint(new ListOf<>("ascii-only")).defects(
+                new EoProgram(
+                    "+unlint ascii-only:5-10",
+                    new InputOf("+unlint ascii-only:5-10")
+                ).parse()
+            ),
+            Matchers.emptyIterable()
+        );
+    }
 }

--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-unlint/catches-invalid-format.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-unlint/catches-invalid-format.yaml
@@ -10,4 +10,3 @@ input: |
   +spdx SPDX-License-Identifier: MIT
 
   [] > foo
-

--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-unlint/catches-invalid-format.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-unlint/catches-invalid-format.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: incorrect-unlint
+asserts:
+  - /defects[count(defect[@severity='error'])=1]
+input: |
+  +unlint ascii-only:abc
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+
+  [] > foo
+


### PR DESCRIPTION
Fixes #1388.

## Problem
Malformed `+unlint` values such as `+unlint ascii-only:abc` or `+unlint ascii-only:` (empty line part) are silently ignored: neither suppression nor a warning happens, so a typo quietly disables an intended suppression. `LtIncorrectUnlint` only validated the *name* part (up to `:`), not the format after it.

## Solution
`LtIncorrectUnlint` now also validates the format of the tail. When the lint name exists but the tail is neither the bare name, `name:N` nor `name:N-M`, it reports an error explaining the expected formats.

## Changes
- `src/main/java/org/eolang/lints/LtIncorrectUnlint.java` — filter and message extended to flag invalid formats; extracted private helpers (`tail`, `nameOf`, `invalid`, `defect`).
- `src/test/java/org/eolang/lints/LtIncorrectUnlintTest.java` — new tests: `catchesUnlintWithInvalidLineFormat`, `catchesUnlintWithEmptyLinePart`, `allowsUnlintWithRange`.
- `src/test/resources/org/eolang/lints/packs/single/incorrect-unlint/catches-invalid-format.yaml` — new YAML pack.

## Tests
- `mvn clean install -Pqulice` (672 tests) — pass
- `mvn clean test -Pdeep` (15 tests) — pass