### PR TITLE
fix(#1386): decode entities in defect context

### DIFF
--- a/src/main/java/org/eolang/lints/DfContext.java
+++ b/src/main/java/org/eolang/lints/DfContext.java
@@ -57,11 +57,15 @@ final class DfContext implements Defect {
 
     @Override
     public String context() {
-        return this.ctxt.replace("&lt;", "<")
+        return this.ctxt.replace("&amp;", "&")
+            .replace("&lt;", "<")
             .replace("&gt;", ">")
             .replace("&#34;", "\"")
-            .replace("&#xA;", System.lineSeparator())
-            .replace("&amp;", "&");
+            .replace("&quot;", "\"")
+            .replace("&#39;", "'")
+            .replace("&apos;", "'")
+            .replace("&#10;", String.valueOf('\n'))
+            .replace("&#xA;", String.valueOf('\n'));
     }
 
     @Override

--- a/src/test/java/org/eolang/lints/DfContextTest.java
+++ b/src/test/java/org/eolang/lints/DfContextTest.java
@@ -29,11 +29,54 @@ final class DfContextTest {
             ).context(),
             Matchers.equalTo(
                 String.join(
-                    System.lineSeparator(),
+                    String.valueOf('\n'),
                     "<o base=\"man\">",
                     "<o as=\"name\" base=\"string\"/>",
                     "<o base=\"number\"/>",
                     "</o>"
+                )
+            )
+        );
+    }
+
+    @Test
+    void decodesStandardEntities() {
+        MatcherAssert.assertThat(
+            "Standard entities are not decoded",
+            new DfContext(
+                new Defect.Default("foo", Severity.ERROR, 0, "Boom!"),
+                "&quot;x&quot; &#39;y&#39; &apos;z&apos;"
+            ).context(),
+            Matchers.equalTo("\"x\" 'y' 'z'")
+        );
+    }
+
+    @Test
+    void decodesDoubleEncodedEntities() {
+        MatcherAssert.assertThat(
+            "Double-encoded entities are not decoded",
+            new DfContext(
+                new Defect.Default("foo", Severity.ERROR, 0, "Boom!"),
+                "&amp;lt;o&amp;gt;"
+            ).context(),
+            Matchers.equalTo("<o>")
+        );
+    }
+
+    @Test
+    void usesLfForLineBreaks() {
+        MatcherAssert.assertThat(
+            "Line breaks are not normalized to LF",
+            new DfContext(
+                new Defect.Default("foo", Severity.ERROR, 0, "Boom!"),
+                "a&#10;b&#xA;c"
+            ).context(),
+            Matchers.equalTo(
+                String.join(
+                    String.valueOf('\n'),
+                    "a",
+                    "b",
+                    "c"
                 )
             )
         );


### PR DESCRIPTION
Fixes #1386.

## Problem
`DfContext` decoded HTML entities in the defect `@context` incompletely and platform-dependently: `&amp;` was replaced last (so `&amp;lt;` stayed as `&lt;`), standard entities `&quot;`/`&#39;`/`&apos;` were not handled, and line breaks used `System.lineSeparator()` instead of a fixed LF.

## Solution
Decode entities in a single normalized pass with `&amp;` first, add the missing standard entities, and normalize both `&#10;` and `&#xA;` to LF.

## Changes
- `src/main/java/org/eolang/lints/DfContext.java` — reordered replacements (`&amp;` first) and added `&quot;`, `&#39;`, `&apos;`, `&#10;`; line breaks now use LF (`String.valueOf(n)`) instead of `System.lineSeparator()`.
- `src/test/java/org/eolang/lints/DfContextTest.java` — updated expectation to LF, added `decodesStandardEntities`, `decodesDoubleEncodedEntities`, `usesLfForLineBreaks`.

## Tests
- `mvn clean install -Pqulice` (671 tests) — pass