### PR TITLE
fix(#1387): fall back to zero on non-numeric line

### DIFF
--- a/src/main/java/org/eolang/lints/LineOf.java
+++ b/src/main/java/org/eolang/lints/LineOf.java
@@ -33,10 +33,17 @@ final class LineOf {
     }
 
     /**
-     * Line number, or {@code 0} when the attribute is missing.
+     * Line number, or {@code 0} when the attribute is missing or not an integer.
      * @return Line number
      */
     int value() {
-        return Integer.parseInt(this.element.attribute("line").text().orElse("0"));
+        final String line = this.element.attribute("line").text().orElse("0");
+        final int result;
+        if (line.matches("\\d+")) {
+            result = Integer.parseInt(line);
+        } else {
+            result = 0;
+        }
+        return result;
     }
 }

--- a/src/test/java/org/eolang/lints/LineOfTest.java
+++ b/src/test/java/org/eolang/lints/LineOfTest.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link LineOf}.
+ * @since 0.0.50
+ */
+final class LineOfTest {
+
+    @Test
+    void returnsNumericLine() {
+        MatcherAssert.assertThat(
+            "Numeric line is not returned",
+            new LineOf(
+                LineOfTest.element("<o name=\"x\" line=\"7\"/>")
+            ).value(),
+            Matchers.equalTo(7)
+        );
+    }
+
+    @Test
+    void returnsZeroWhenLineIsAbsent() {
+        MatcherAssert.assertThat(
+            "Absent line is not zero",
+            new LineOf(LineOfTest.element("<o name=\"x\"/>")).value(),
+            Matchers.equalTo(0)
+        );
+    }
+
+    @Test
+    void returnsZeroWhenLineIsNotNumeric() {
+        MatcherAssert.assertThat(
+            "Non-numeric line should not throw",
+            new LineOf(LineOfTest.element("<o name=\"x\" line=\"abc\"/>")).value(),
+            Matchers.equalTo(0)
+        );
+    }
+
+    private static Xnav element(final String tag) {
+        return new Xnav(
+            new XMLDocument(
+                String.format("<object>%s</object>", tag)
+            ).inner()
+        ).path("/object/o").findFirst().get();
+    }
+}


### PR DESCRIPTION
Fixes #1387.

## Problem
`LineOf.value()` threw an unhandled `NumberFormatException` when a hand-written/broken XMIR carried a non-numeric `@line`, aborting the whole `Source.defects()` run. The javadoc only promised `0` for an absent attribute.

## Solution
Fall back to `0` when `@line` is present but not a non-negative integer, consistent with the missing-attribute case.

## Changes
- `src/main/java/org/eolang/lints/LineOf.java` — guard `Integer.parseInt` with a `\d+` check; non-numeric lines yield `0`.
- `src/test/java/org/eolang/lints/LineOfTest.java` — new dedicated test: `returnsNumericLine`, `returnsZeroWhenLineIsAbsent`, `returnsZeroWhenLineIsNotNumeric`.

## Tests
- `mvn clean install -Pqulice` (671 tests) — pass