### PR TITLE
fix(#1376): match test word at token boundaries

### DIFF
--- a/src/main/resources/org/eolang/lints/tests/test-word.xsl
+++ b/src/main/resources/org/eolang/lints/tests/test-word.xsl
@@ -12,7 +12,7 @@
   <xsl:template match="/">
     <defects>
       <xsl:variable name="top" select="/object/o[1]"/>
-      <xsl:for-each select="//o[@name and not(@name='φ') and matches(@name, 'test', 'i') and not(generate-id() = generate-id($top))]">
+      <xsl:for-each select="//o[@name and not(@name='φ') and matches(@name, '(^|-)test[a-z]*(-|$)', 'i') and not(generate-id() = generate-id($top))]">
         <xsl:if test="eo:test-name(@name) or ancestor::o[eo:test-name(@name)] or matches($top/@name, '-tests$')">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>

--- a/src/test/resources/org/eolang/lints/packs/single/test-word/allows-test-substring-in-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-word/allows-test-substring-in-name.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/test-word.xsl
+defects: 0
+input: |
+  [] > foo-tests
+
+    [] +> can-use-latest
+      42 > @


### PR DESCRIPTION
Fixes #1376.

## Problem
`test-word` flagged names that merely *contain* the substring "test" (`latest`, `contest`, `attest`, `protester`) instead of matching the *word* "test". A legitimate test like `+can-use-latest` was wrongly reported.

## Solution
Match "test" as a word token at boundaries instead of as a substring. Since XPath 2.0 `matches()` uses XSD regex (no `\b`/`\w`), the pattern is explicit: `(^|-)test[a-z]*(-|$)` — a token that *starts* with "test" (covers `test`, `tests`, `testing`), which keeps `tests-helper` and `+can-test-add` flagged while allowing `latest`/`contest`/`attest`/`protester`.

## Changes
- `src/main/resources/org/eolang/lints/tests/test-word.xsl` — selector `matches(@name, 'test', 'i')` → `matches(@name, '(^|-)test[a-z]*(-|$)', 'i')`.
- `src/test/resources/org/eolang/lints/packs/single/test-word/allows-test-substring-in-name.yaml` — new pack: `+can-use-latest` yields 0 defects.

## Tests
- `mvn clean install -Pqulice` (669 tests) — pass
- `mvn clean test -Pdeep` (15 tests) — pass
