### PR TITLE
perf(#1389): reuse defect cache in unlint-non-existing-defect

### DIFF
--- a/src/main/java/org/eolang/lints/PkMono.java
+++ b/src/main/java/org/eolang/lints/PkMono.java
@@ -5,10 +5,10 @@
 package org.eolang.lints;
 
 import javax.annotation.concurrent.ThreadSafe;
-import org.cactoos.func.Chained;
 import org.cactoos.iterable.IterableEnvelope;
 import org.cactoos.iterable.Joined;
 import org.cactoos.iterable.Mapped;
+import org.cactoos.iterable.Sticky;
 import org.cactoos.list.ListOf;
 
 /**
@@ -39,17 +39,17 @@ final class PkMono extends IterableEnvelope<Lint> {
      * @param lints Lints
      */
     PkMono(final Iterable<Lint> lints) {
-        super(
-            new Joined<>(
-                new Mapped<Lint>(
-                    new Chained<>(LtUnlint::new, LtDfSticky::new),
-                    new Joined<Lint>(
-                        lints,
-                        new ListOf<>(
-                            new LtUnlintNonExistingDefect(lints)
-                        )
-                    )
-                )
+        super(PkMono.build(lints));
+    }
+
+    private static Iterable<Lint> build(final Iterable<Lint> lints) {
+        final Iterable<Lint> cached = new Sticky<>(
+            new Mapped<Lint>(LtDfSticky::new, lints)
+        );
+        return new Joined<Lint>(
+            new Mapped<Lint>(LtUnlint::new, cached),
+            new ListOf<>(
+                new LtDfSticky(new LtUnlint(new LtUnlintNonExistingDefect(cached)))
             )
         );
     }


### PR DESCRIPTION
Fixes #1389.

## Problem
`unlint-non-existing-defect` was the slowest lint (14513 ms on XXL, ~10x the next). Its `existing()` re-ran every referenced lint's XSL transformation for every `+unlint` name, because it operated on raw lints — duplicating work already done by the main pass (where lints are wrapped in `LtDfSticky`).

## Solution
Rebuild the lint decorations so the `LtDfSticky`-wrapped instances are shared between the main pass and `existing()`. A single `Sticky` iterable materializes each `LtDfSticky` wrapper once; `existing()` reads from the same cached instances (raw defects, before `LtUnlint` suppression), so the XSL workload is not duplicated.

## Changes
- `src/main/java/org/eolang/lints/PkMono.java` — extract `build()`; wrap all lints in `LtDfSticky` into one `Sticky` iterable; the main pass wraps it with `LtUnlint`, while `LtUnlintNonExistingDefect` (wrapped as `LtDfSticky(LtUnlint(...))`) receives the shared cached iterable. Removed the now-unused `Chained`.

## Tests
- `mvn clean install -Pqulice` (668 tests) — pass
- `mvn clean test -Pdeep` (15 tests) — pass
- `mvn clean test -Preserved` (6 tests) — pass
