### PR TITLE
fix(#1390): bound the LtDfSticky cache by content

### DIFF
--- a/src/main/java/org/eolang/lints/LtDfSticky.java
+++ b/src/main/java/org/eolang/lints/LtDfSticky.java
@@ -4,16 +4,18 @@
  */
 package org.eolang.lints;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.jcabi.xml.XML;
 import java.io.IOException;
 import java.util.Collection;
-import org.cactoos.Func;
-import org.cactoos.func.IoCheckedFunc;
-import org.cactoos.func.StickyFunc;
-import org.cactoos.func.SyncFunc;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Lint caching decorator that calls defects method only once. Uses in memory storage for caching.
+ *
+ * <p>The cache is bounded and keyed by the XMIR content, so a long-lived JVM does not run
+ * out of memory while repeatedly analyzing the same documents.</p>
  *
  * <p>This class is thread-safe.</p>
  *
@@ -27,29 +29,18 @@ final class LtDfSticky implements Lint {
     private final Lint origin;
 
     /**
-     * Function that caches result of origin.defects().
+     * Cache of the defects, keyed by the document content.
      */
-    private final Func<XML, Collection<Defect>> cache;
+    private final Cache<String, Collection<Defect>> cache;
 
     /**
      * Ctor.
      * @param origin Object wrapped by a decorator
+     * @checkstyle ConstructorsCodeFreeCheck (4 lines)
      */
     LtDfSticky(final Lint origin) {
-        this(
-            origin,
-            new SyncFunc<>(new StickyFunc<>(origin::defects))
-        );
-    }
-
-    /**
-     * Ctor.
-     * @param origin Object wrapped by a decorator
-     * @param cache Defects cache
-     */
-    LtDfSticky(final Lint origin, final Func<XML, Collection<Defect>> cache) {
         this.origin = origin;
-        this.cache = cache;
+        this.cache = LtDfSticky.newCache();
     }
 
     @Override
@@ -59,7 +50,16 @@ final class LtDfSticky implements Lint {
 
     @Override
     public Collection<Defect> defects(final XML xmir) throws IOException {
-        return new IoCheckedFunc<>(this.cache).apply(xmir);
+        final Collection<Defect> defects;
+        try {
+            defects = this.cache.get(
+                xmir.toString(),
+                () -> this.origin.defects(xmir)
+            );
+        } catch (final ExecutionException exc) {
+            throw LtDfSticky.propagate(exc);
+        }
+        return defects;
     }
 
     @Override
@@ -70,5 +70,21 @@ final class LtDfSticky implements Lint {
     @Override
     public Fix fix() {
         return this.origin.fix();
+    }
+
+    private static Cache<String, Collection<Defect>> newCache() {
+        return CacheBuilder.newBuilder()
+            .maximumSize(1_000)
+            .build();
+    }
+
+    private static IOException propagate(final ExecutionException exc) {
+        final IOException result;
+        if (exc.getCause() instanceof IOException) {
+            result = (IOException) exc.getCause();
+        } else {
+            result = new IOException(exc);
+        }
+        return result;
     }
 }

--- a/src/test/java/org/eolang/lints/LtDfStickyTest.java
+++ b/src/test/java/org/eolang/lints/LtDfStickyTest.java
@@ -65,6 +65,19 @@ final class LtDfStickyTest {
         );
     }
 
+    @Test
+    void reusesCacheForIdenticalContent() throws IOException {
+        final LtCounter counter = new LtDfStickyTest.LtCounter();
+        final Lint lint = new LtDfSticky(new LtDfStickyTest.LtFake(counter));
+        lint.defects(new XMLDocument("<o/>"));
+        lint.defects(new XMLDocument("<o/>"));
+        MatcherAssert.assertThat(
+            "Two XMLs with identical content should share a cache entry",
+            counter.count(),
+            Matchers.equalTo(1)
+        );
+    }
+
     /**
      * Counter for lint calls.
      * @since 0.0.42


### PR DESCRIPTION
Fixes #1390.

## Problem
The `LtDfSticky` defect cache (cactoos `StickyFunc`) never evicted entries and keyed on the `XML` object, whose `hashCode` is node-identity based while `equals` compares content. In a long-lived JVM (static `Source.MONO`), every analyzed XMIR stayed in memory forever (OOM under batch), and identical documents almost never hit the cache.

## Solution
Replace the unbounded `StickyFunc` with a bounded Guava `Cache` keyed by the document content (`xmir.toString()`):
- `maximumSize(1_000)` bounds memory in long-lived JVMs.
- The content-based key makes identical documents share a cache entry, fixing the broken `equals`/`hashCode` contract of `XMLDocument`.

## Changes
- `src/main/java/org/eolang/lints/LtDfSticky.java` — bounded Guava cache keyed by content; dropped the unused `LtDfSticky(Lint, Func)` ctor and cactoos `Func` wrappers.
- `src/test/java/org/eolang/lints/LtDfStickyTest.java` — new `reusesCacheForIdenticalContent`: two distinct `XML` objects with identical content yield a single origin call.

## Tests
- `mvn clean install -Pqulice` (669 tests) — pass
- `mvn clean test -Pdeep` (15 tests) — pass
- `mvn clean test -Preserved` (6 tests) — pass
