### PR TITLE
fix(#1375): attribute comments to the object they precede

### DIFF
--- a/src/main/resources/org/eolang/lints/tests/test-with-comment.xsl
+++ b/src/main/resources/org/eolang/lints/tests/test-with-comment.xsl
@@ -11,22 +11,27 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="/object/o[eo:test-name(@name) and /object/comments/comment]">
-        <defect>
-          <xsl:variable name="line" select="eo:lineno(@line)"/>
-          <xsl:attribute name="line">
-            <xsl:value-of select="$line"/>
-          </xsl:attribute>
-          <xsl:if test="$line = '0'">
-            <xsl:attribute name="context">
-              <xsl:value-of select="eo:defect-context(.)"/>
+      <xsl:for-each select="/object/comments/comment">
+        <xsl:variable name="cline" select="number(@line)"/>
+        <xsl:variable name="following" select="/object/o[number(@line) &gt; $cline]"/>
+        <xsl:variable name="next" select="$following[number(@line) = min($following/number(@line))][1]"/>
+        <xsl:if test="eo:test-name($next/@name)">
+          <defect>
+            <xsl:variable name="line" select="eo:lineno($next/@line)"/>
+            <xsl:attribute name="line">
+              <xsl:value-of select="$line"/>
             </xsl:attribute>
-          </xsl:if>
-          <xsl:attribute name="severity">warning</xsl:attribute>
-          <xsl:text>The test object </xsl:text>
-          <xsl:value-of select="eo:escape(@name)"/>
-          <xsl:text> has a comment, which duplicates its name. Make the name self-explanatory and remove the comment</xsl:text>
-        </defect>
+            <xsl:if test="$line = '0'">
+              <xsl:attribute name="context">
+                <xsl:value-of select="eo:defect-context($next)"/>
+              </xsl:attribute>
+            </xsl:if>
+            <xsl:attribute name="severity">warning</xsl:attribute>
+            <xsl:text>The test object </xsl:text>
+            <xsl:value-of select="eo:escape($next/@name)"/>
+            <xsl:text> has a comment, which duplicates its name. Make the name self-explanatory and remove the comment</xsl:text>
+          </defect>
+        </xsl:if>
       </xsl:for-each>
     </defects>
   </xsl:template>

--- a/src/test/resources/org/eolang/lints/packs/single/test-with-comment/allows-comment-for-other-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/test-with-comment/allows-comment-for-other-object.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/test-with-comment.xsl
+defects: 0
+input: |
+  # This is app.
+
+  [] > app
+
+    [] +> checks-the-app
+      42 > @


### PR DESCRIPTION
Fixes #1375.

## Problem
`test-with-comment` flagged **any** top-level test whenever **any** comment existed anywhere in the document, because the selector was `/object/o[eo:test-name(@name) and /object/comments/comment]` — a document-global existential check. A comment documenting an ordinary object (e.g. `# This is app.` before `[] > app`) caused every test to be reported as "has a comment".

## Solution
Attribute each comment to the object it precedes: iterate comments, find the nearest following object (by `@line`), and report a defect only when that object is a test (`+`/`-` prefix). A comment is "before a test" only if no object sits between it and the test.

## Changes
- `src/main/resources/org/eolang/lints/tests/test-with-comment.xsl` — iterate `/object/comments/comment`, compute the nearest following object via `min(.../number(@line))`, flag only when that object is a test; defect now references the test (`$next`) instead of the comment context.
- `src/test/resources/org/eolang/lints/packs/single/test-with-comment/allows-comment-for-other-object.yaml` — new pack: comment documents `app`, test has no comment of its own → 0 defects.

## Tests
- `mvn clean install -Pqulice` (669 tests) — pass
- `mvn clean test -Pdeep` (15 tests) — pass
- `mvn clean test -Preserved` (6 tests) — pass
