### PR TITLE
fix(#1378): emit the duplicated meta as the context

### DIFF
--- a/src/main/resources/org/eolang/lints/metas/unique-metas.xsl
+++ b/src/main/resources/org/eolang/lints/metas/unique-metas.xsl
@@ -22,7 +22,7 @@
             </xsl:attribute>
             <xsl:if test="$line = '0'">
               <xsl:attribute name="context">
-                <xsl:value-of select="eo:defect-context(.)"/>
+                <xsl:value-of select="eo:defect-context($metas[head = $head][2])"/>
               </xsl:attribute>
             </xsl:if>
             <xsl:attribute name="severity">

--- a/src/test/resources/org/eolang/lints/packs/single/unique-metas/prints-meta-as-context.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unique-metas/prints-meta-as-context.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/unique-metas.xsl
+asserts:
+  - /defects[count(defect[@context and @severity='error'])=1]
+  - /defects/defect[contains(@context, '<head>version</head>')]
+document: |
+  <object author="tests">
+    <metas>
+      <meta>
+        <head>version</head>
+        <tail>0.0.1</tail>
+        <part>0.0.1</part>
+      </meta>
+      <meta>
+        <head>version</head>
+        <tail>0.0.2</tail>
+        <part>0.0.2</part>
+      </meta>
+    </metas>
+    <o name="foo"/>
+  </object>


### PR DESCRIPTION
Fixes #1378.

## Problem
For duplicated metas, `unique-metas` emitted a defect whose `@context` was the meta *head string* (e.g. `[version]`) instead of the actual duplicate meta element — useless for locating the second occurrence. The cause: `eo:defect-context(.)` was called inside `<xsl:for-each select="$unique">`, where the context node is a string, not an element.

## Solution
Compute the context from the actual duplicated meta element, `$metas[head = $head][2]` (the second occurrence that triggers the defect), so the serialized meta shows the offending content.

## Changes
- `src/main/resources/org/eolang/lints/metas/unique-metas.xsl` — `eo:defect-context(.)` → `eo:defect-context($metas[head = $head][2])`.
- `src/test/resources/org/eolang/lints/packs/single/unique-metas/prints-meta-as-context.yaml` — new `document:` pack asserting the context contains the serialized `<head>version</head>`.

## Tests
- `mvn clean install -Pqulice` (669 tests) — pass
- `mvn clean test -Pdeep` (15 tests) — pass
- `mvn clean test -Preserved` (6 tests) — pass
