### PR TITLE
fix(#1381): detect self-recursion in all three spellings

### DIFF
--- a/src/main/resources/org/eolang/lints/design/unoptimizable-recursion.xsl
+++ b/src/main/resources/org/eolang/lints/design/unoptimizable-recursion.xsl
@@ -52,6 +52,36 @@
   a reason of its own, the way the four below are.
   -->
   <!--
+  TRUE when the @base is a self-call of the object with the given name, in
+  any of the three forms the parser emits: the plain name resolves to
+  "Phi.<name>", the "^" form to "xi.rho.<name>", and the "$" form to
+  "xi.<name>". A dispatch on the self-call is also a self-call.
+  -->
+  <xsl:function name="eo:is-self-call" as="xs:boolean">
+    <xsl:param name="base" as="xs:string"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="$base = concat('Φ.', $name) or starts-with($base, concat('Φ.', $name, '.')) or $base = concat('ξ.ρ.', $name) or starts-with($base, concat('ξ.ρ.', $name, '.')) or $base = concat('ξ.', $name) or starts-with($base, concat('ξ.', $name, '.'))"/>
+  </xsl:function>
+  <!--
+  TRUE when the @base is a dispatch on a self-call, i.e. the self-call is
+  the receiver and a method is dispatched on it.
+  -->
+  <xsl:function name="eo:is-self-dispatch" as="xs:boolean">
+    <xsl:param name="base" as="xs:string"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="starts-with($base, concat('Φ.', $name, '.')) or starts-with($base, concat('ξ.ρ.', $name, '.')) or starts-with($base, concat('ξ.', $name, '.'))"/>
+  </xsl:function>
+  <!--
+  TRUE when the @base is a self-call in a tail position: the plain call of
+  the object, with no method dispatched on it. A dispatch on the self-call
+  is never a tail call, because the receiver is evaluated, not the call.
+  -->
+  <xsl:function name="eo:is-self-tail" as="xs:boolean">
+    <xsl:param name="base" as="xs:string"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="$base = concat('Φ.', $name) or $base = concat('ξ.ρ.', $name) or $base = concat('ξ.', $name)"/>
+  </xsl:function>
+  <!--
   A nested formation that calls itself has its recursion turned into a Java
   loop, one copy of the object per step instead of one Java stack block, but
   only when the compiler recognises the shape. When it does not, the program
@@ -60,11 +90,11 @@
   -->
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[eo:abstract(.) and @name and parent::o and o[@name='φ']]">
-        <xsl:variable name="self" select="concat('ξ.ρ.', @name)"/>
+      <xsl:for-each select="//o[eo:abstract(.) and @name and o[@name='φ']]">
+        <xsl:variable name="name" select="string(@name)"/>
         <xsl:variable name="root" select="o[@name='φ']"/>
-        <xsl:variable name="calls" select=".//o[@base = $self or starts-with(@base, concat($self, '.'))]"/>
-        <xsl:variable name="loops" select="($root | $root//o)[@base = $self and eo:tail(., $root)]"/>
+        <xsl:variable name="calls" select=".//o[eo:is-self-call(string(@base), $name)]"/>
+        <xsl:variable name="loops" select="($root | $root//o)[eo:is-self-tail(string(@base), $name) and eo:tail(., $root)]"/>
         <xsl:if test="exists($calls) and empty($loops)">
           <defect>
             <xsl:variable name="line" select="eo:lineno($calls[1]/@line)"/>
@@ -88,7 +118,7 @@
               <xsl:when test=".//o[contains(@base, 'φ')]">
                 <xsl:text>its body reads its own φ</xsl:text>
               </xsl:when>
-              <xsl:when test="$calls[starts-with(@base, concat($self, '.'))]">
+              <xsl:when test="$calls[eo:is-self-dispatch(string(@base), $name)]">
                 <xsl:text>the self-call is the receiver of a dispatch</xsl:text>
               </xsl:when>
               <xsl:otherwise>

--- a/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/allows-plain-name-tail-call.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/allows-plain-name-tail-call.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/unoptimizable-recursion.xsl
+defects: 0
+input: |
+  [] > calc
+    seq > @
+      *
+        1
+        calc (n.minus 1)

--- a/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/catches-dollar-self-call.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/catches-dollar-self-call.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/lints/design/unoptimizable-recursion.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[1][normalize-space()='The recursion in "rec" cannot be turned into a loop, no self-call sits in a tail position']
+input: |
+  [] > app
+    [n] > rec
+      if. > @
+        n.lt 1
+        0
+        n.plus ($.rec (n.minus 1))
+    rec 5 > @

--- a/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/catches-plain-name-self-call.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/catches-plain-name-self-call.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/lints/design/unoptimizable-recursion.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[1][normalize-space()='The recursion in "calc" cannot be turned into a loop, no self-call sits in a tail position']
+input: |
+  [] > calc
+    if. > @
+      n.eq 0
+      1
+      n.mul (calc (n.sub 1))


### PR DESCRIPTION
Fixes #1381.

## Problem
`unoptimizable-recursion` missed self-recursion written by plain name. The modern parser resolves such calls to `Φ.<name>`, while the lint only looked for `ξ.ρ.<name>` (the `^`-style form), so the recursion went unreported depending on how it was spelled.

## Solution
Detect self-calls in all three forms the parser emits:
- plain name → `Φ.<name>`
- `^` → `ξ.ρ.<name>`
- `$` → `ξ.<name>`

Three helper functions were added: `eo:is-self-call` (self-call, including a dispatch on it), `eo:is-self-dispatch` (the self-call used as the receiver of a dispatch), and `eo:is-self-tail` (a plain self-call, with no method dispatched — only these can sit in a tail position). The selector no longer requires `parent::o`, so a top-level formation recursing by plain name is also reported.

## Changes
- `src/main/resources/org/eolang/lints/design/unoptimizable-recursion.xsl` — new helper functions; `$calls`/`$loops` use them; dropped `parent::o` from the selector.
- `src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/catches-plain-name-self-call.yaml` — plain-name recursion under an operation is caught.
- `src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/catches-dollar-self-call.yaml` — `$`-form recursion is caught.
- `src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/allows-plain-name-tail-call.yaml` — plain-name recursion in a tail position stays allowed.

## Tests
- `mvn clean install -Pqulice` (671 tests) — pass
- `mvn clean test -Pdeep` (15 tests) — pass
- `mvn clean test -Preserved` (6 tests) — pass
