### PR TITLE
fix(#1384): align rule texts with the conditions

### DIFF
--- a/src/main/resources/org/eolang/lints/atoms/not-empty-atom.xsl
+++ b/src/main/resources/org/eolang/lints/atoms/not-empty-atom.xsl
@@ -28,7 +28,7 @@
           <xsl:text>The atom </xsl:text>
           <xsl:value-of select="eo:escape(@name)"/>
           <xsl:text> may not have any attributes, which however exist: </xsl:text>
-          <xsl:for-each select="o[@base and not(@name='λ')]">
+          <xsl:for-each select="o[@base and @base!='∅' and not(@name='λ') and not(@base='ξ' and @name='xi🌵')]">
             <xsl:if test="position() &gt; 1">
               <xsl:text>, </xsl:text>
             </xsl:if>

--- a/src/main/resources/org/eolang/lints/comments/comment-without-dot.xsl
+++ b/src/main/resources/org/eolang/lints/comments/comment-without-dot.xsl
@@ -10,7 +10,7 @@
   <xsl:template match="/">
     <xsl:variable name="min" select="32"/>
     <defects>
-      <xsl:for-each select="/object/comments/comment[not(ends-with(., '.')) and not(ends-with(., '?')) and not(ends-with(., '!'))]">
+      <xsl:for-each select="/object/comments/comment[not(ends-with(., '.')) and not(ends-with(., '?')) and not(ends-with(., '!')) and not(ends-with(., ':'))]">
         <xsl:element name="defect">
           <xsl:variable name="line" select="eo:lineno(@line)"/>
           <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/lints/metas/incorrect-version.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-version.xsl
@@ -29,7 +29,7 @@
             </xsl:attribute>
             <xsl:text>The format of the +version meta is wrong: </xsl:text>
             <xsl:value-of select="eo:escape($meta-tail)"/>
-            <xsl:text> (SemVer expected instead)</xsl:text>
+            <xsl:text> (SemVer or a Maven "X.Y-SNAPSHOT" version expected instead)</xsl:text>
           </xsl:element>
         </xsl:if>
       </xsl:for-each>

--- a/src/main/resources/org/eolang/motives/metas/incorrect-version.md
+++ b/src/main/resources/org/eolang/motives/metas/incorrect-version.md
@@ -1,6 +1,7 @@
 # Incorrect `+version`
 
-The value of the special `+version` meta must follow the [SemVer] format.
+The value of the special `+version` meta must follow the [SemVer] format, or
+the [Maven] snapshot convention `X.Y-SNAPSHOT`.
 
 Incorrect:
 
@@ -23,8 +24,10 @@ Correct:
 +version 42.0.555555
 +version 0.0.1-alpha
 +version 0.0.1-beta-1
++version 1.0-SNAPSHOT
 
 [] > foo
 ```
 
 [SemVer]: https://semver.org/
+[Maven]: https://maven.apache.org/

--- a/src/test/resources/org/eolang/lints/packs/single/comment-without-dot/allows-comment-with-colon.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/comment-without-dot/allows-comment-with-colon.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/comments/comment-without-dot.xsl
+defects: 0
+input: |
+  # This comment ends with a colon:
+
+  [] > foo
+    52 > @

--- a/src/test/resources/org/eolang/lints/packs/single/not-empty-atom/catches-atom-with-void-and-real-attrs.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/not-empty-atom/catches-atom-with-void-and-real-attrs.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/lints/atoms/not-empty-atom.xsl
+asserts:
+  - /defects[count(defect[@severity='error'])=1]
+  - /defects/defect[not(contains(., 'foo'))]
+document: |
+  <object author="tests">
+    <o line="1" name="number">
+      <o base="∅" name="λ"/>
+      <o base="∅" name="foo"/>
+      <o base="Φ.bar" name="baz"/>
+    </o>
+  </object>


### PR DESCRIPTION
Fixes #1384.

## Problem
Three lints had a discrepancy between their defect message and the XPath condition:

1. `comment-without-dot` — the message allows `:` at the end, the condition did not.
2. `incorrect-version` — the message promises strict SemVer, while the condition also accepts the Maven `X.Y-SNAPSHOT` convention (deliberately allowed by existing packs).
3. `not-empty-atom` — the message enumerated attributes that the selector excludes (void `@base='∅'` and `ξ`/`xi🌵`).

## Solution
Align each message with its condition:
- `comment-without-dot` — the condition now also accepts a trailing `:`.
- `incorrect-version` — the message (and the motive) now mention the Maven `X.Y-SNAPSHOT` convention alongside SemVer.
- `not-empty-atom` — the enumeration in the message now uses the same predicate as the selector.

## Changes
- `src/main/resources/org/eolang/lints/comments/comment-without-dot.xsl` — added `and not(ends-with(., ':'))`.
- `src/main/resources/org/eolang/lints/metas/incorrect-version.xsl` — new message text; `src/main/resources/org/eolang/motives/metas/incorrect-version.md` — motive updated.
- `src/main/resources/org/eolang/lints/atoms/not-empty-atom.xsl` — message enumeration matches the selector.
- New packs: `comment-without-dot/allows-comment-with-colon.yaml`, `not-empty-atom/catches-atom-with-void-and-real-attrs.yaml` (asserts the void attribute is not named).

## Tests
- `mvn clean install -Pqulice` (670 tests) — pass
- `mvn clean test -Pdeep` (15 tests) — pass
- `mvn clean test -Preserved` (6 tests) — pass
