### PR TITLE
fix(#1385): report one defect with the filtered depth

### DIFF
--- a/src/main/resources/org/eolang/lints/design/too-deep-object.xsl
+++ b/src/main/resources/org/eolang/lints/design/too-deep-object.xsl
@@ -3,14 +3,24 @@
 * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="too-deep-object">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.0" id="too-deep-object">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/escape.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
+  <!--
+  Depth of the object in its nesting chain, counting only the ancestors that
+  represent real nesting: the wrapper objects ("Φ.tuple", "Φ.bytes",
+  "Φ.number", "Φ.string") do not count. The selector and the message use the
+  same metric.
+  -->
+  <xsl:function name="eo:depth" as="xs:integer">
+    <xsl:param name="o" as="element()"/>
+    <xsl:sequence select="count($o/ancestor::o[not(@base='Φ.tuple') and not(@base='Φ.bytes') and not(@base='Φ.number') and not(@base='Φ.string')])"/>
+  </xsl:function>
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[count(ancestor::o[not(@base='Φ.tuple') and not(@base='Φ.bytes') and not(@base='Φ.number') and not(@base='Φ.string')]) &gt; 12 and not(o[count(ancestor::o[not(@base='Φ.tuple') and not(@base='Φ.bytes') and not(@base='Φ.number') and not(@base='Φ.string')]) &gt; 12])]">
+      <xsl:for-each select="//o[eo:depth(.) &gt; 12 and not(.//o[eo:depth(.) &gt; 12])]">
         <defect>
           <xsl:variable name="line" select="eo:lineno(@line)"/>
           <xsl:attribute name="line">
@@ -23,9 +33,9 @@
           </xsl:if>
           <xsl:attribute name="severity">warning</xsl:attribute>
           <xsl:text>The object </xsl:text>
-          <xsl:value-of select="eo:escape(@base)"/>
+          <xsl:value-of select="eo:escape(if (string(@name) != '') then @name else tokenize(@base, '\.')[last()])"/>
           <xsl:text> is nested too deep: </xsl:text>
-          <xsl:value-of select="count(ancestor::o)"/>
+          <xsl:value-of select="eo:depth(.)"/>
           <xsl:text> levels of nesting, while the maximum is 12</xsl:text>
         </defect>
       </xsl:for-each>

--- a/src/test/resources/org/eolang/lints/packs/single/too-deep-object/catches-too-deep-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/too-deep-object/catches-too-deep-object.yaml
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+# yamllint disable rule:line-length
 sheets:
   - /org/eolang/lints/design/too-deep-object.xsl
-defects:
-  - severity: warning
-    line: 16
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - "/defects/defect[1][normalize-space()='The object \"m\" is nested too deep: 13 levels of nesting, while the maximum is 12']"
 input: |
   # Foo.
 


### PR DESCRIPTION
Fixes #1385.

## Problem
`too-deep-object` reported several defects along a single nesting chain (a cascade), printed a raw `count(ancestor::o)` depth that could exceed the rule's threshold (which excludes `Φ.tuple`/`Φ.bytes`/`Φ.number`/`Φ.string` wrappers), and named objects by `@base` (empty for formations, `ξ.φ` for data).

## Solution
- Extracted the filtered depth into `eo:depth()` and use it in both the selector and the message, so the reported number matches the threshold metric.
- The selector now excludes a node whenever **any** descendant (`.//o`, not just a direct child) is deeper than the threshold — one report per branch, no cascade.
- The object label uses `@name` when present, otherwise the last segment of `@base` (a clear short name like `m` instead of `Φ.m` or `ξ.φ`).

## Changes
- `src/main/resources/org/eolang/lints/design/too-deep-object.xsl` — new `eo:depth()` function, descendant-based guard, filtered depth and name-based label in the message.
- `src/test/resources/org/eolang/lints/packs/single/too-deep-object/catches-too-deep-object.yaml` — asserts now check a single defect and the exact message (`The object "m" is nested too deep: 13 levels...`).

## Tests
- `mvn clean install -Pqulice` (668 tests) — pass
- `mvn clean test -Pdeep` (15 tests) — pass
- `mvn clean test -Preserved` (6 tests) — pass
