### PR TITLE
fix(#1369): drop the upper bound on the architect email TLD

### DIFF
--- a/src/main/resources/org/eolang/lints/metas/incorrect-architect.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-architect.xsl
@@ -13,7 +13,7 @@
       <xsl:for-each select="/object/metas/meta">
         <xsl:variable name="meta-head" select="head"/>
         <xsl:variable name="meta-tail" select="tail"/>
-        <xsl:if test="$meta-head='architect' and not(matches(upper-case($meta-tail),'^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$'))">
+        <xsl:if test="$meta-head='architect' and not(matches(upper-case($meta-tail),'^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$'))">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-architect/good-architect.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-architect/good-architect.yaml
@@ -6,6 +6,9 @@ sheets:
 defects: 0
 input: |
   +architect hello@gmail.com
+  +architect yegor@example.info
+  +architect yegor@example.online
+  +architect yegor@eolang.software
 
   [x] > foo
     42 > @


### PR DESCRIPTION
## Summary

- `incorrect-architect` rejected any `+architect` email whose top-level domain was longer than four characters (e.g. `.online`, `.software`, `.technology`), because the regex capped the TLD group at `{2,4}`.
- Dropped the upper bound (`{2,4}` → `{2,}`) in `src/main/resources/org/eolang/lints/metas/incorrect-architect.xsl`, so any TLD length is accepted, matching how the rule already behaves for two-to-four character TLDs.
- Extended `good-architect.yaml` with the addresses from the issue (`yegor@example.info`, `yegor@example.online`, `yegor@eolang.software`) to lock in the fix.

## Test plan

- [x] `mvn test -Dtest=org.eolang.lints.LtByXslTest` — 496 tests, 0 failures.

Closes #1369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFQ7orNQq55Vcavky8UMfR

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFQ7orNQq55Vcavky8UMfR)_