### PR TITLE
test(#1419): migrate LtAsciiOnlyTest cases to YAML packs

### DIFF
--- a/src/test/java/org/eolang/lints/LtAsciiOnlyTest.java
+++ b/src/test/java/org/eolang/lints/LtAsciiOnlyTest.java
@@ -6,8 +6,6 @@ package org.eolang.lints;
 
 import fixtures.EoProgram;
 import java.io.IOException;
-import matchers.DefectMatcher;
-import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
@@ -18,33 +16,6 @@ import org.junit.jupiter.api.Test;
  * @since 0.0.1
  */
 final class LtAsciiOnlyTest {
-
-    @Test
-    void catchesSomeNonAsciiInComment() throws IOException {
-        MatcherAssert.assertThat(
-            "non-ascii comment is not welcome",
-            new LtAsciiOnly().defects(
-                new EoProgram("org/eolang/lints/non-ascii-cyrillic.eo").parse()
-            ),
-            Matchers.allOf(
-                Matchers.<Defect>iterableWithSize(Matchers.greaterThan(0)),
-                Matchers.<Defect>everyItem(new DefectMatcher())
-            )
-        );
-    }
-
-    @Test
-    void catchesNonAsciiInComment() throws IOException {
-        MatcherAssert.assertThat(
-            "non-ascii comment error should contain abusive character",
-            new ListOf<>(
-                new LtAsciiOnly().defects(
-                    new EoProgram("org/eolang/lints/non-ascii-cyrillic.eo").parse()
-                )
-            ).get(0).text(),
-            Matchers.containsString("Only ASCII characters are allowed in comments")
-        );
-    }
 
     @Test
     void explainsMotive() throws IOException {
@@ -63,28 +34,6 @@ final class LtAsciiOnlyTest {
                 new EoProgram("org/eolang/lints/non-ascii-tuk-tuk.eo").parse()
             ).iterator().next().rule(),
             Matchers.equalTo("ascii-only")
-        );
-    }
-
-    @Test
-    void complainsAsWarning() throws IOException {
-        MatcherAssert.assertThat(
-            "The lint should complain as warning",
-            new LtAsciiOnly().defects(
-                new EoProgram("org/eolang/lints/non-ascii-chinese.eo").parse()
-            ).iterator().next().severity(),
-            Matchers.equalTo(Severity.WARNING)
-        );
-    }
-
-    @Test
-    void doesNotFlagNewlinesInMultilineComment() throws IOException {
-        MatcherAssert.assertThat(
-            "Multi-line ASCII comment must not trigger ascii-only false positive",
-            new LtAsciiOnly().defects(
-                new EoProgram("org/eolang/lints/ascii-multiline-comment.eo").parse()
-            ),
-            Matchers.emptyIterable()
         );
     }
 }

--- a/src/test/java/org/eolang/lints/XtLint.java
+++ b/src/test/java/org/eolang/lints/XtLint.java
@@ -24,6 +24,15 @@ import org.xembly.Xembler;
  * as a raw XMIR document (the {@code document} pack key) or as
  * EO source (the {@code input} pack key), same as {@link XtYaml}.
  * @since 1.0
+ * @todo #1419:30min Emit a {@code rule} attribute on each generated
+ *  {@code <defect>} element, carrying {@link Defect#rule()}. Right now
+ *  the produced XML only has {@code line}, {@code severity}, and text,
+ *  so a pack's {@code asserts:} can't check which rule fired a defect.
+ *  This blocks moving Java tests such as
+ *  {@code LtAsciiOnlyTest#setsRuleCorrectly} (and any similar rule-name
+ *  assertion in other {@code Lt*Test} classes) into YAML packs. Once the
+ *  attribute is added, convert those tests into packs with an
+ *  {@code asserts:} XPath checking {@code @rule}.
  */
 public final class XtLint implements Xtory {
 

--- a/src/test/resources/org/eolang/lints/packs/single/ascii-only/allows-multiline-ascii-comment.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/ascii-only/allows-multiline-ascii-comment.yaml
@@ -4,10 +4,11 @@
 lint: ascii-only
 defects: 0
 input: |
-  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-  +spdx SPDX-License-Identifier: MIT
-
   # This is a multi-line comment
   # that spans several lines
   # all characters are valid ASCII
+
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+
   [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/ascii-only/allows-multiline-ascii-comment.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/ascii-only/allows-multiline-ascii-comment.yaml
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 lint: ascii-only
-asserts:
-  - /defects[count(defect)=0]
+defects: 0
 input: |
   +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
   +spdx SPDX-License-Identifier: MIT

--- a/src/test/resources/org/eolang/lints/packs/single/ascii-only/allows-multiline-ascii-comment.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/ascii-only/allows-multiline-ascii-comment.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: ascii-only
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+
+  # This is a multi-line comment
+  # that spans several lines
+  # all characters are valid ASCII
+  [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/ascii-only/catches-chinese-comment-as-warning.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/ascii-only/catches-chinese-comment-as-warning.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: ascii-only
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+input: |
+  # 计算机编程是我的生活!
+
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+
+  [] > a

--- a/src/test/resources/org/eolang/lints/packs/single/ascii-only/catches-chinese-comment-as-warning.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/ascii-only/catches-chinese-comment-as-warning.yaml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 lint: ascii-only
+defects: 1
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
 input: |

--- a/src/test/resources/org/eolang/lints/packs/single/ascii-only/catches-cyrillic-comment-text.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/ascii-only/catches-cyrillic-comment-text.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: ascii-only
+asserts:
+  - /defects[count(defect)=1]
+  - /defects/defect[contains(text(), 'Only ASCII characters are allowed in comments')]
+input: |
+  # привет
+  # как дела?
+
+  +architect yegor256@gmail.com
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+
+  [] > foo

--- a/src/test/resources/org/eolang/lints/packs/single/ascii-only/catches-cyrillic-comment-text.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/ascii-only/catches-cyrillic-comment-text.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+# yamllint disable rule:line-length
 lint: ascii-only
 asserts:
   - /defects[count(defect)=1]


### PR DESCRIPTION
Migrate `LtAsciiOnlyTest` Java test cases to YAML pack format for consistency with the generic `PkMono` test runner, removing redundant hand-written defect assertions.

Fixes #1419