### PR TITLE
#1392: Do not report generated cactus names

### DIFF
--- a/src/main/resources/org/eolang/lints/design/unoptimizable-recursion.xsl
+++ b/src/main/resources/org/eolang/lints/design/unoptimizable-recursion.xsl
@@ -90,7 +90,7 @@
   -->
   <xsl:template match="/">
     <defects>
-      <xsl:for-each select="//o[eo:abstract(.) and @name and o[@name='φ']]">
+      <xsl:for-each select="//o[eo:abstract(.) and @name and not(contains(@name, '🌵')) and o[@name='φ']]">
         <xsl:variable name="name" select="string(@name)"/>
         <xsl:variable name="root" select="o[@name='φ']"/>
         <xsl:variable name="calls" select=".//o[eo:is-self-call(string(@base), $name)]"/>

--- a/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/allows-auto-named-formation.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/allows-auto-named-formation.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/unoptimizable-recursion.xsl
+defects: 0
+input: |
+  [] > app
+    [n] >>
+      if. > @
+        n.lt 1
+        0
+        ^.app (n.minus 1)


### PR DESCRIPTION
Fixes #1392.

`unoptimizable-recursion` reported every named recursive formation, including
the cactus names generated for anonymous `>>` formations. A message such as
`a🌵100-6` does not exist in the EO source and gives the author no searchable
name to act on. The rule's advice therefore pointed at an internal parser
identifier rather than a source-level formation.

The rule now excludes generated cactus names from this diagnostic. This is the
same boundary used by the naming lints: a generated identifier is an internal
parser detail, not a user-facing declaration. Named source formations keep the
existing recursion analysis and message unchanged.

A new fixture creates an auto-named recursive helper and asserts that the rule
reports no defect. The complete XSL fixture suite passes, including all
existing positive recursion diagnostics.

Verification:

- `mvn -q -Dtest=LtByXslTest test` — 514 tests, 0 failures, 0 errors;
- the new fixture is parsed and included in the full single-scope lint pack.
