### PR TITLE
#1391: Compare each meta with its nearest predecessor

### DIFF
--- a/src/main/resources/org/eolang/lints/metas/unsorted-metas.xsl
+++ b/src/main/resources/org/eolang/lints/metas/unsorted-metas.xsl
@@ -12,7 +12,7 @@
     <defects>
       <xsl:for-each select="/object/metas/meta">
         <xsl:variable name="meta-text" select="concat(head, ' ', tail)"/>
-        <xsl:variable name="previous" select="(preceding-sibling::meta)[1]"/>
+        <xsl:variable name="previous" select="preceding-sibling::meta[1]"/>
         <xsl:variable name="previous-text" select="concat($previous/head/text(), ' ', $previous/tail/text())"/>
         <xsl:if test="$meta-text &lt; $previous-text">
           <xsl:element name="defect">

--- a/src/test/resources/org/eolang/lints/canonical.eo
+++ b/src/test/resources/org/eolang/lints/canonical.eo
@@ -3,11 +3,11 @@
 +architect yegor256@gmail.com
 +home https://www.eolang.org
 +package canonical
-+version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint missed-obfuscation
 +unlint unit-test-missing
++version 0.0.0
 
 [start] > canonical
   malloc.for > @

--- a/src/test/resources/org/eolang/lints/main-with-test.eo
+++ b/src/test/resources/org/eolang/lints/main-with-test.eo
@@ -3,10 +3,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package f
-+version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint missed-obfuscation
++version 0.0.0
 
 [c] > main
   Q.io.stdout > @

--- a/src/test/resources/org/eolang/lints/packs/single/unsorted-metas/catches-neighbor-out-of-order-meta.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unsorted-metas/catches-neighbor-out-of-order-meta.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/unsorted-metas.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[contains(text(), 'home')]
+input: |
+  +architect yegor256@gmail.com
+  +version 0.0.0
+  +home https://github.com/objectionary/eo
+
+  [] > foo
+    42 > @

--- a/src/test/resources/org/eolang/lints/valid-source.eo
+++ b/src/test/resources/org/eolang/lints/valid-source.eo
@@ -1,10 +1,10 @@
 +architect h1alexbelx@gmail.com
 +home https://www.eolang.org
 +package com.example
-+version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint missed-obfuscation
++version 0.0.0
 
 # This is just a test object with no functionality.
 [i] > foo


### PR DESCRIPTION
Fixes #1391.

`unsorted-metas` used `(preceding-sibling::meta)[1]`. Parenthesizing a reverse
axis orders its result in document order before `[1]`, so every meta was
compared with the file's first meta. A neighbor violation that remained above
the first one alphabetically was silently missed.

The selector now uses `preceding-sibling::meta[1]`, which preserves the reverse
axis and selects the immediately preceding meta. Existing cases that are out
of order against the first remain reported; only the missing neighbor case is
added.

The regression fixture has `architect`, `version`, then `home` metadata.
`home` is out of order with `version` but greater than `architect`, so the old
rule reported zero while the corrected rule reports one warning for `home`.

Verification:

- `mvn -q -Dtest=LtByXslTest test` — 514 tests, 0 failures, 0 errors.
