### PR TITLE
#1368: Accept complete Semantic Version strings

### DIFF
--- a/src/main/resources/org/eolang/lints/metas/incorrect-version.xsl
+++ b/src/main/resources/org/eolang/lints/metas/incorrect-version.xsl
@@ -13,7 +13,7 @@
       <xsl:for-each select="/object/metas/meta">
         <xsl:variable name="meta-head" select="head"/>
         <xsl:variable name="meta-tail" select="tail"/>
-        <xsl:if test="$meta-head='version' and not(matches($meta-tail, '^\d+\.\d+\.\d+(-[a-zA-Z0-9-]+)?$|^\d+\.\d+-SNAPSHOT$'))">
+        <xsl:if test="$meta-head='version' and not(matches($meta-tail, '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-((0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$|^\d+\.\d+-SNAPSHOT$'))">
           <xsl:element name="defect">
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-version/allows-semver-prerelease-and-build.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-version/allows-semver-prerelease-and-build.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/metas/incorrect-version.xsl
+defects: 0
+input: |
+  +version 1.0.0-alpha.1
+  +version 1.0.0+20130313144700
+  +version 1.0.0-rc.2+build.7
+
+  [x] > foo
+    42 > @

--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-version/catches-incorrect-version.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-version/catches-incorrect-version.yaml
@@ -24,11 +24,8 @@ defects:
     line: 9
   - severity: warning
     line: 10
-  - severity: warning
-    line: 11
 input: |
   +version alpha
-  +version 1.0.0-alpha.beta
   +version привет, друг!
   +version привет, как дела?
   +version 你好，伙计


### PR DESCRIPTION
Fixes #1368.

`incorrect-version` claimed to enforce SemVer but accepted only a single
hyphenated pre-release token and no build metadata. Consequently valid versions
such as `1.0.0-alpha.1` and `1.0.0+20130313144700` were reported as malformed.
The old expression also allowed numeric components with leading zeroes, which
SemVer explicitly disallows.

The rule now uses the complete SemVer 2.0 grammar for numeric components,
dot-separated pre-release identifiers, and dot-separated build identifiers.
The existing Maven `X.Y-SNAPSHOT` compatibility form remains accepted. Invalid
versions and their diagnostics are unchanged apart from the newly valid SemVer
forms.

The regression coverage adds pre-release, build-only, and combined SemVer
examples. The existing invalid-version fixture was updated so its former
`alpha.beta` case is treated as valid and all remaining defects retain their
line-specific assertions.

Verification:

- `mvn -q -Dtest=LtByXslTest test` — 514 tests, 0 failures, 0 errors.
