### PR TITLE
#1393: Do not flag public numeric constants as methods

### DIFF
--- a/src/main/resources/org/eolang/lints/design/excessive-visibility.xsl
+++ b/src/main/resources/org/eolang/lints/design/excessive-visibility.xsl
@@ -15,7 +15,7 @@
       <xsl:for-each select="//o[eo:abstract(.) and @name]">
         <xsl:variable name="tests" select="o[eo:test-name(@name)]"/>
         <xsl:if test="exists($tests)">
-          <xsl:for-each select="o[@name and @base and @base != '∅' and @name != 'φ' and not(@local) and not(eo:test-name(@name))]">
+          <xsl:for-each select="o[@name and @base and @base != '∅' and @base != 'Φ.number' and @name != 'φ' and not(@local) and not(eo:test-name(@name))]">
             <xsl:variable name="method" select="@name"/>
             <!--
             A test refers to a sibling method either by calling it on

--- a/src/test/resources/org/eolang/lints/packs/single/excessive-visibility/allows-public-constant.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/excessive-visibility/allows-public-constant.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/design/excessive-visibility.xsl
+defects: 0
+input: |
+  [] > foo
+    8 > append
+
+    [] +> checks-foo
+      42 > @


### PR DESCRIPTION
Fixes #1393.

`excessive-visibility` treated every named public child as a method. Numeric
constants such as `8 > append` and `256 > creat` in the `win32` and `posix`
runtime wrappers were therefore reported when their names were not repeated
in local tests. The suggested `>>` replacement would make those constants
unreachable, although other runtime files use them as part of syscall flags.

The selector now excludes attributes whose value is an EO numeric literal
(`Φ.number`). Such values are constants, not callable methods whose visibility
can be reduced based on local test references. Existing analysis of named
object and method attributes remains unchanged, including its current
test-scoped boundary.

A regression fixture defines a public numeric constant in an object with a
unit test and asserts that no excessive-visibility defect is emitted. The
fixture also keeps the constant unused locally, matching the runtime case that
was incorrectly reported.

Verification:

- `mvn -q -Dtest=LtByXslTest test` — 514 tests, 0 failures, 0 errors.
