### PR TITLE
fix(#1366): decode formatter specifiers instead of matching raw hex in sprintf-constant-args

### DIFF
--- a/src/main/resources/org/eolang/lints/misc/sprintf-constant-args.xsl
+++ b/src/main/resources/org/eolang/lints/misc/sprintf-constant-args.xsl
@@ -3,7 +3,7 @@
 * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" version="2.0" id="sprintf-constant-args">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:math="http://www.w3.org/2005/xpath-functions/math" xmlns:eo="https://www.eolang.org" version="2.0" id="sprintf-constant-args">
   <xsl:import href="/org/eolang/funcs/lineno.xsl"/>
   <xsl:import href="/org/eolang/funcs/defect-context.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
@@ -14,27 +14,28 @@
       <xsl:sequence select="o[2]"/>
     </xsl:if>
   </xsl:template>
+  <xsl:function name="eo:hex-to-placeholder" as="xs:integer">
+    <xsl:param name="hex" as="xs:string"/>
+    <xsl:variable name="hex-upper" select="upper-case($hex)"/>
+    <xsl:variable name="length" select="string-length($hex-upper)"/>
+    <xsl:variable name="decimal" select="sum(for $i in 1 to $length return (index-of(string-to-codepoints('0123456789ABCDEF'), string-to-codepoints(substring($hex-upper, $i, 1))) - 1) * xs:integer(math:pow(16, $length - $i)))"/>
+    <xsl:sequence select="$decimal"/>
+  </xsl:function>
   <xsl:template match="/">
     <defects>
       <xsl:for-each select="//o[@base='.printf' or @base='Φ.txt.sprintf'][count(o)=2][o[2][@base='Φ.tuple']]">
         <xsl:variable name="text" select="o[1][@base='Φ.string']/o[1][@base='Φ.bytes']/o/text()"/>
         <xsl:if test="$text">
-          <xsl:variable name="formatters">
-            <xsl:variable name="txt" select="translate($text, '-', '')"/>
-            <!-- First, replace %% with a unique placeholder to avoid counting it as a formatter -->
-            <xsl:variable name="escaped" select="replace($txt, '(25)(25)', 'ESCAPED_PERCENT')"/>
-            <!-- %s -->
-            <xsl:variable name="strings" select="count(tokenize($escaped, '2573'))"/>
-            <!-- %d -->
-            <xsl:variable name="numbers" select="count(tokenize($escaped, '2564'))"/>
-            <!-- %f -->
-            <xsl:variable name="floats" select="count(tokenize($escaped, '2566'))"/>
-            <!-- %x -->
-            <xsl:variable name="bytes" select="count(tokenize($escaped, '2578'))"/>
-            <!-- %b -->
-            <xsl:variable name="bools" select="count(tokenize($escaped, '2562'))"/>
-            <xsl:value-of select="$strings + $numbers + $floats + $bytes + $bools - 5"/>
+          <xsl:variable name="placeholder">
+            <xsl:for-each select="tokenize($text, '-')">
+              <xsl:value-of select="codepoints-to-string(eo:hex-to-placeholder(.))"/>
+            </xsl:for-each>
           </xsl:variable>
+          <!--
+          A specifier reads as %[N$][flags][width][.precision]conversion, and a
+          doubled percent is a literal one rather than the start of a specifier
+          -->
+          <xsl:variable name="formatters" select="count(tokenize(replace($placeholder, '%%', ''), '%(\d+\$)?[-0]*\d*(\.\d+)?[sdfxb]')) - 1"/>
           <xsl:variable name="args" as="element()*">
             <xsl:apply-templates select="o[2]" mode="constant-args"/>
           </xsl:variable>

--- a/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/catches-printf-with-flagged-format-and-constant-args.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sprintf-constant-args/catches-printf-with-flagged-format-and-constant-args.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/sprintf-constant-args.xsl
+defects:
+  - severity: warning
+    line: 3
+input: |
+  [] > app
+    io.stdout > @
+      "%08.2f".printf
+        * "3.14"


### PR DESCRIPTION
## Problem

Closes #1366.

`sprintf-constant-args` selects the `.printf` dispatch correctly, but its formatter count is computed by searching the hex dump of the format string for the *literal* hex byte sequence of a bare specifier (`2573` for `%s`, `2564` for `%d`, `2566` for `%f`, `2578` for `%x`, `2562` for `%b`). A specifier that carries a flag, width, or precision — e.g. `%08.2f` — inserts extra bytes between `%` and the conversion letter, so its hex sequence never matches and the lint silently misses the defect (0 formatters counted instead of 1).

## Fix

Decode the hex-encoded bytes back into the actual characters (the same `eo:hex-to-placeholder` approach already used by the sibling lint `sprintf-without-formatters.xsl`), then count specifiers with a regex that understands `%[N$][flags][width][.precision]conversion`, consistent with how `sprintf-without-formatters` already detects formatters.

## Testing

Added a pack, `catches-printf-with-flagged-format-and-constant-args.yaml`, using a real `"%08.2f".printf (* "3.14")` call with a constant string argument. It fails on `master` (0 defects reported instead of 1) and passes with this change. Ran the full `LtByXslTest` suite (517 tests) — all green, including the pre-existing `sprintf-constant-args` and `sprintf-without-formatters` packs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFrxLNmS5phrWQhwndWUCU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFrxLNmS5phrWQhwndWUCU)_