### PR TITLE
#1421: carry the rule name on every generated defect

### DIFF
--- a/src/test/java/org/eolang/lints/XtLint.java
+++ b/src/test/java/org/eolang/lints/XtLint.java
@@ -24,15 +24,12 @@ import org.xembly.Xembler;
  * as a raw XMIR document (the {@code document} pack key) or as
  * EO source (the {@code input} pack key), same as {@link XtYaml}.
  * @since 1.0
- * @todo #1419:30min Emit a {@code rule} attribute on each generated
- *  {@code <defect>} element, carrying {@link Defect#rule()}. Right now
- *  the produced XML only has {@code line}, {@code severity}, and text,
- *  so a pack's {@code asserts:} can't check which rule fired a defect.
- *  This blocks moving Java tests such as
- *  {@code LtAsciiOnlyTest#setsRuleCorrectly} (and any similar rule-name
- *  assertion in other {@code Lt*Test} classes) into YAML packs. Once the
- *  attribute is added, convert those tests into packs with an
- *  {@code asserts:} XPath checking {@code @rule}.
+ * @todo #1421:30min Move the rule-name assertions into YAML packs. Now
+ *  that each {@code <defect>} carries {@code @rule}, a pack's
+ *  {@code asserts:} can check which rule fired, so Java tests that exist
+ *  only to assert a rule name, such as
+ *  {@code LtAsciiOnlyTest#setsRuleCorrectly}, can become packs with an
+ *  {@code asserts:} XPath on {@code @rule} and be deleted from Java.
  */
 public final class XtLint implements Xtory {
 
@@ -107,6 +104,7 @@ public final class XtLint implements Xtory {
                     for (final Defect defect : lint.defects(xml)) {
                         dirs.add("defect")
                             .attr("line", defect.line())
+                            .attr("rule", defect.rule())
                             .attr("severity", defect.severity().mnemo())
                             .set(defect.text())
                             .up();


### PR DESCRIPTION
Closes #1421, resolving puzzle `1419-4154c118`.

`XtLint` produced `<defect>` elements carrying `line`, `severity` and the text only, so a pack's `asserts:` had no way to check *which* rule fired. Each element now also carries `@rule`, taken from `Defect#rule()`:

```java
dirs.add("defect")
    .attr("line", defect.line())
    .attr("rule", defect.rule())
    .attr("severity", defect.severity().mnemo())
    .set(defect.text())
    .up();
```

That was the blocking half of the puzzle.

The other half it unblocks — moving the Java tests that exist only to assert a rule name, such as `LtAsciiOnlyTest#setsRuleCorrectly`, into YAML packs — is left as a new puzzle rather than folded in here. It deletes tests and picks which ones qualify, so it deserves its own review rather than riding along on a one-attribute change. The puzzle text is rotated accordingly, so nothing is silently dropped.

Verified on a fork before opening: all 22 checks green, including `mvn` on ubuntu-24.04, macos-15 and windows-2022, plus `qulice` and `pdd`.