### PR TITLE
fix(#1429): assert rule name via pack @rule instead of Java tests

### DIFF
--- a/src/test/java/org/eolang/lints/LtAsciiOnlyTest.java
+++ b/src/test/java/org/eolang/lints/LtAsciiOnlyTest.java
@@ -4,10 +4,8 @@
  */
 package org.eolang.lints;
 
-import fixtures.EoProgram;
 import java.io.IOException;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 
@@ -23,17 +21,6 @@ final class LtAsciiOnlyTest {
             "The motive doesn't contain expected string",
             new LtAsciiOnly().motive().contains("# ASCII-Only Characters in Comments"),
             new IsEqual<>(true)
-        );
-    }
-
-    @Test
-    void setsRuleCorrectly() throws IOException {
-        MatcherAssert.assertThat(
-            "The rule name is set right",
-            new LtAsciiOnly().defects(
-                new EoProgram("org/eolang/lints/non-ascii-tuk-tuk.eo").parse()
-            ).iterator().next().rule(),
-            Matchers.equalTo("ascii-only")
         );
     }
 }

--- a/src/test/java/org/eolang/lints/LtSyntaxVersionTest.java
+++ b/src/test/java/org/eolang/lints/LtSyntaxVersionTest.java
@@ -67,17 +67,6 @@ final class LtSyntaxVersionTest {
     }
 
     @Test
-    void setsRuleCorrectly() throws IOException {
-        final String src = LtSyntaxVersionTest.program("+syntax 999.0.0");
-        MatcherAssert.assertThat(
-            "the rule name is set right",
-            new LtSyntaxVersion().defects(new EoProgram(src, new InputOf(src)).parse())
-                .iterator().next().rule(),
-            Matchers.equalTo("syntax-version")
-        );
-    }
-
-    @Test
     void ignoresMalformedSyntaxValue() throws IOException {
         final String src = LtSyntaxVersionTest.program("+syntax abracadabra");
         MatcherAssert.assertThat(

--- a/src/test/java/org/eolang/lints/XtLint.java
+++ b/src/test/java/org/eolang/lints/XtLint.java
@@ -24,12 +24,6 @@ import org.xembly.Xembler;
  * as a raw XMIR document (the {@code document} pack key) or as
  * EO source (the {@code input} pack key), same as {@link XtYaml}.
  * @since 1.0
- * @todo #1421:30min Move the rule-name assertions into YAML packs. Now
- *  that each {@code <defect>} carries {@code @rule}, a pack's
- *  {@code asserts:} can check which rule fired, so Java tests that exist
- *  only to assert a rule name, such as
- *  {@code LtAsciiOnlyTest#setsRuleCorrectly}, can become packs with an
- *  {@code asserts:} XPath on {@code @rule} and be deleted from Java.
  */
 public final class XtLint implements Xtory {
 

--- a/src/test/resources/org/eolang/lints/packs/single/ascii-only/catches-cyrillic-comment.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/ascii-only/catches-cyrillic-comment.yaml
@@ -4,6 +4,7 @@
 lint: ascii-only
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[@rule='ascii-only']
 input: |
   # привет
 

--- a/src/test/resources/org/eolang/lints/packs/single/syntax-version/catches-newer-syntax.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/syntax-version/catches-newer-syntax.yaml
@@ -4,6 +4,7 @@
 lint: syntax-version
 asserts:
   - /defects[count(defect[@severity='error'])=1]
+  - /defects/defect[@rule='syntax-version']
 input: |
   +syntax 999.0.0
   +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com


### PR DESCRIPTION
## Summary

Resolves #1429 (the `1421-d0131752` PDD puzzle in `XtLint.java`).

Now that every `<defect>` carries `@rule`, a pack's `asserts:` can check
which rule fired. This lets Java tests that existed only to assert a rule
name become pack-level XPath assertions instead.

- Added `/defects/defect[@rule='ascii-only']` to
  `packs/single/ascii-only/catches-cyrillic-comment.yaml`.
- Added `/defects/defect[@rule='syntax-version']` to
  `packs/single/syntax-version/catches-newer-syntax.yaml`.
- Deleted `LtAsciiOnlyTest#setsRuleCorrectly` and
  `LtSyntaxVersionTest#setsRuleCorrectly`, which existed solely to check
  `Defect#rule()`.
- Removed the resolved `@todo #1421` puzzle from `XtLint.java`.

## Test plan

- [x] `mvn test -Dtest=LtAsciiOnlyTest,LtSyntaxVersionTest,LtByXslTest` — all green (`LtByXslTest#testsAllLints` exercises every pack, including the two updated ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BH1BjEGe39hN1GpCLQkDS1

---
_Generated by [Claude Code](https://claude.ai/code/session_01BH1BjEGe39hN1GpCLQkDS1)_