### PR TITLE
test(#1021): cover incorrect-unlint with a real lint name and line suffix

### DIFF
--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-unlint/allows-real-lint-with-line-suffix.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-unlint/allows-real-lint-with-line-suffix.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: incorrect-unlint
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  +unlint many-void-attributes:37
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+
+  [] > foo


### PR DESCRIPTION
## Summary

`LtIncorrectUnlint` reports "Suppressing ... does not make sense" for
`+unlint many-void-attributes:37`-style suppressions of a *real* lint,
because it looks up the lint name after stripping the `:line` suffix.

Looking at `src/main/java/org/eolang/lints/LtIncorrectUnlint.java` on
`master`, this is already correct: `nameOf()` splits the tail on `:`
before checking membership in the known-lints set, and
`LtIncorrectUnlintTest#understandsUnlintsWithLineNumber` already covers
the shape generically. That fix landed as a side effect of PR #1404
(closing #1388), which rewrote this class, but #1021 itself was never
closed and had no coverage using an actual registered lint name run
through the production pack pipeline (the exact way the originally
reported `eo-maven-plugin:lint` failure on `win32.eo` exercised it).

This PR adds that missing integration-level regression pack, using the
real `many-void-attributes` lint name with a line suffix, asserting
zero defects — so this exact scenario can never silently regress again.

## Test plan

- [x] `mvn test -Dtest=LtByXslTest,LtIncorrectUnlintTest` passes locally, including the new pack `packs/single/incorrect-unlint/allows-real-lint-with-line-suffix.yaml`
- [ ] CI green

Closes #1021

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JuFSRNk5QvWp5dnwsqPyW

---
_Generated by [Claude Code](https://claude.ai/code/session_011JuFSRNk5QvWp5dnwsqPyW)_