### PR TITLE
fix(#1434): teach `eo:test-name` the `p🌵`/`n🌵` test markers

### DIFF
--- a/src/main/java/org/eolang/lints/LtTestNotVerb.java
+++ b/src/main/java/org/eolang/lints/LtTestNotVerb.java
@@ -48,7 +48,7 @@ final class LtTestNotVerb implements Lint {
     @Override
     public Collection<Defect> defects(final XML xmir) throws IOException {
         return new Xnav(xmir.inner())
-            .path("/object//o[@name and starts-with(@name, '+')]")
+            .path(MarkedName.positives())
             .filter(object -> !this.isVerb(object))
             .map(LtTestNotVerb::verbDefect)
             .collect(Collectors.toList());
@@ -65,9 +65,7 @@ final class LtTestNotVerb implements Lint {
     }
 
     private boolean isVerb(final Xnav object) {
-        return this.vocabulary.isVerb(
-            object.attribute("name").text().get().replace("+", "")
-        );
+        return this.vocabulary.isVerb(LtTestNotVerb.title(object));
     }
 
     private static Defect verbDefect(final Xnav object) {
@@ -77,8 +75,12 @@ final class LtTestNotVerb implements Lint {
             new LineOf(object).value(),
             String.format(
                 "Test object name: \"%s\" doesn't start with verb in singular form",
-                object.attribute("name").text().get().replace("+", "")
+                LtTestNotVerb.title(object)
             )
         );
+    }
+
+    private static String title(final Xnav object) {
+        return new MarkedName(object.attribute("name").text().get()).title();
     }
 }

--- a/src/main/java/org/eolang/lints/MarkedName.java
+++ b/src/main/java/org/eolang/lints/MarkedName.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lints;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * The {@code @name} of a unit test attribute, as the EO parser spells it.
+ *
+ * <p>The parser marks a truthy test attribute with the {@code p🌵} prefix
+ * and a throwing one with {@code n🌵}. Older parsers used {@code +} and
+ * {@code -} for the same purpose, which are not legal φ-calculus attribute
+ * names. Both spellings are accepted, so that {@code eo:lints} and
+ * {@code eo} may move independently.</p>
+ *
+ * <p>This is the Java twin of {@code /org/eolang/funcs/test-name.xsl}, for
+ * the lints that are not XSL stylesheets. Keep the two in sync.</p>
+ *
+ * @since 0.2.12
+ */
+final class MarkedName {
+
+    /**
+     * Markers of a truthy test attribute, which asserts that something works.
+     */
+    private static final Collection<String> POSITIVE = Collections.unmodifiableList(
+        Arrays.asList("p🌵", "+")
+    );
+
+    /**
+     * Markers of a throwing test attribute, which asserts that something fails.
+     */
+    private static final Collection<String> NEGATIVE = Collections.unmodifiableList(
+        Arrays.asList("n🌵", "-")
+    );
+
+    /**
+     * The name, with the marker still attached to it.
+     */
+    private final String origin;
+
+    /**
+     * Ctor.
+     * @param name The name of the attribute, with the marker
+     */
+    MarkedName(final String name) {
+        this.origin = name;
+    }
+
+    /**
+     * The name with its marker removed, e.g. {@code can-do-it} for
+     * {@code p🌵can-do-it}. A name that is not a test comes back untouched.
+     * @return The name, without the marker
+     */
+    String title() {
+        String title = this.origin;
+        for (final String marker : MarkedName.markers()) {
+            if (this.origin.startsWith(marker)) {
+                title = this.origin.substring(marker.length());
+                break;
+            }
+        }
+        return title;
+    }
+
+    /**
+     * XPath that selects every truthy test attribute of an XMIR document.
+     * @return XPath expression
+     */
+    static String positives() {
+        return MarkedName.POSITIVE.stream()
+            .map(marker -> String.format("starts-with(@name, '%s')", marker))
+            .collect(Collectors.joining(" or ", "/object//o[@name and (", ")]"));
+    }
+
+    private static Collection<String> markers() {
+        return Stream.concat(
+            MarkedName.POSITIVE.stream(), MarkedName.NEGATIVE.stream()
+        ).collect(Collectors.toList());
+    }
+}

--- a/src/main/resources/org/eolang/funcs/test-name.xsl
+++ b/src/main/resources/org/eolang/funcs/test-name.xsl
@@ -1,17 +1,46 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 * SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" id="test-name" version="2.0">
   <!--
-  TRUE if the given attribute name belongs to a unit test. The EO parser
-  marks a truthy test attribute by prefixing its `@name` with a plus, and a
-  throwing test attribute by prefixing it with a minus (see
-  `Suffix.attribute` in `eo-parser`). Both kinds are tests.
+  The marker the EO parser puts in front of the `@name` of a unit test, or
+  an empty string when the name is not a test at all. A truthy test is
+  marked with `p🌵` and a throwing one with `n🌵` (see `Suffix.attribute`
+  in `eo-parser`). Older parsers used `+` and `-` for the same purpose,
+  which are not legal φ-calculus attribute names; both spellings are
+  accepted here, so that `eo:lints` and `eo` may move independently.
+  Markers differ in width, thus every consumer must strip them through
+  `eo:test-title` instead of cutting one character off the name.
+  -->
+  <xsl:function name="eo:test-marker" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:sequence select="(('p🌵', 'n🌵', '+', '-')[starts-with($name, .)], '')[1]"/>
+  </xsl:function>
+  <!--
+  TRUE if the given attribute name belongs to a unit test, no matter
+  whether it is a truthy one or a throwing one.
   -->
   <xsl:function name="eo:test-name" as="xs:boolean">
     <xsl:param name="name"/>
-    <xsl:sequence select="starts-with($name, '+') or starts-with($name, '-')"/>
+    <xsl:sequence select="eo:test-marker($name) != ''"/>
+  </xsl:function>
+  <!--
+  The name of a unit test with its marker removed, e.g. `can-do-it` for
+  `p🌵can-do-it`. A name that is not a test comes back untouched.
+  -->
+  <xsl:function name="eo:test-title" as="xs:string">
+    <xsl:param name="name"/>
+    <xsl:sequence select="substring($name, string-length(eo:test-marker($name)) + 1)"/>
+  </xsl:function>
+  <!--
+  TRUE if the given attribute name belongs to a truthy unit test. Such a
+  test asserts that something works, thus it is a positive one, while a
+  throwing test asserts that something fails, thus it is a negative one.
+  -->
+  <xsl:function name="eo:positive-test" as="xs:boolean">
+    <xsl:param name="name"/>
+    <xsl:sequence select="eo:test-marker($name) = ('p🌵', '+')"/>
   </xsl:function>
 </xsl:stylesheet>

--- a/src/main/resources/org/eolang/lints/misc/incorrect-test-object-name.xsl
+++ b/src/main/resources/org/eolang/lints/misc/incorrect-test-object-name.xsl
@@ -13,7 +13,7 @@
     <defects>
       <xsl:for-each select="/object//o[eo:test-name(@name)]">
         <xsl:variable name="regexp" select="'^[a-z][a-z0-9]*(-[a-z0-9]+)*$'"/>
-        <xsl:if test="not(matches(substring(@name, 2), $regexp))">
+        <xsl:if test="not(matches(eo:test-title(@name), $regexp))">
           <defect>
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">

--- a/src/main/resources/org/eolang/lints/tests/bad-test-name.xsl
+++ b/src/main/resources/org/eolang/lints/tests/bad-test-name.xsl
@@ -17,9 +17,9 @@
         while a throwing test asserts that something fails, thus it is a
         negative one. Each kind has its own set of allowed prefixes.
         -->
-        <xsl:variable name="positive" as="xs:boolean" select="starts-with(@name, '+')"/>
+        <xsl:variable name="positive" as="xs:boolean" select="eo:positive-test(@name)"/>
         <xsl:variable name="regexp" as="xs:string" select="if ($positive) then '^(can|accepts)-' else '^(cannot|rejects|stops-on)-'"/>
-        <xsl:if test="not(matches(substring(@name, 2), $regexp))">
+        <xsl:if test="not(matches(eo:test-title(@name), $regexp))">
           <defect>
             <xsl:variable name="line" select="eo:lineno(@line)"/>
             <xsl:attribute name="line">
@@ -34,7 +34,7 @@
             <xsl:text>The name of the </xsl:text>
             <xsl:value-of select="if ($positive) then 'positive' else 'negative'"/>
             <xsl:text> test object </xsl:text>
-            <xsl:value-of select="eo:escape(substring(@name, 2))"/>
+            <xsl:value-of select="eo:escape(eo:test-title(@name))"/>
             <xsl:text> must start with one of the prefixes </xsl:text>
             <xsl:value-of select="eo:escape(if ($positive) then 'can-, accepts-' else 'cannot-, rejects-, stops-on-')"/>
           </defect>

--- a/src/main/resources/org/eolang/lints/tests/unit-test-without-phi.xsl
+++ b/src/main/resources/org/eolang/lints/tests/unit-test-without-phi.xsl
@@ -27,7 +27,7 @@
             <xsl:text>warning</xsl:text>
           </xsl:attribute>
           <xsl:text>The unit test doesn't have "@" attribute: </xsl:text>
-          <xsl:value-of select="eo:escape(substring(@name, 2))"/>
+          <xsl:value-of select="eo:escape(eo:test-title(@name))"/>
         </xsl:element>
       </xsl:for-each>
     </defects>

--- a/src/main/resources/org/eolang/lints/tests/wrong-test-order.xsl
+++ b/src/main/resources/org/eolang/lints/tests/wrong-test-order.xsl
@@ -28,7 +28,7 @@
               <xsl:text>warning</xsl:text>
             </xsl:attribute>
             <xsl:text>The unit test wrongly ordered: </xsl:text>
-            <xsl:value-of select="eo:escape(substring(@name, 2))"/>
+            <xsl:value-of select="eo:escape(eo:test-title(@name))"/>
           </xsl:element>
         </xsl:if>
       </xsl:for-each>

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name/allows-cactus-marked-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name/allows-cactus-marked-tests.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/bad-test-name.xsl
+defects: 0
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="1" name="foo">
+      <o line="2" name="p🌵can-do-something"/>
+      <o line="3" name="p🌵accepts-input"/>
+      <o line="4" name="n🌵cannot-do-something"/>
+      <o line="5" name="n🌵rejects-input"/>
+      <o line="6" name="n🌵stops-on-error"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-cactus-marked-bad-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-cactus-marked-bad-name.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/bad-test-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[contains(text(), 'positive test object "it-works"')]
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="1" name="foo">
+      <o line="2" name="p🌵it-works"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-negative-prefix-in-cactus-positive-test.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-negative-prefix-in-cactus-positive-test.yaml
@@ -5,11 +5,11 @@ sheets:
   - /org/eolang/lints/tests/bad-test-name.xsl
 asserts:
   - /defects[count(defect[@severity='warning'])=1]
-  - /defects/defect[contains(text(), 'positive test object "cannot-do-something"')]
+  - /defects/defect[contains(text(), 'positive test object "cannot-run"')]
 ignore-schema: true
 document: |
   <object author="tests">
     <o line="1" name="foo">
-      <o line="2" name="p🌵cannot-do-something"/>
+      <o line="2" name="p🌵cannot-run"/>
     </o>
   </object>

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-negative-prefix-in-cactus-positive-test.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-negative-prefix-in-cactus-positive-test.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/bad-test-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[contains(text(), 'positive test object "cannot-do-something"')]
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="1" name="foo">
+      <o line="2" name="p🌵cannot-do-something"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-positive-prefix-in-cactus-negative-test.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/bad-test-name/catches-positive-prefix-in-cactus-negative-test.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/bad-test-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[contains(text(), 'negative test object "can-do-something"')]
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="1" name="foo">
+      <o line="2" name="n🌵can-do-something"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-test-object-name/allows-kebab-cactus-marked-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-test-object-name/allows-kebab-cactus-marked-tests.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/incorrect-test-object-name.xsl
+defects: 0
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="1" name="foo">
+      <o line="2" name="p🌵can-do-something"/>
+      <o line="3" name="n🌵cannot-do-something"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/incorrect-test-object-name/catches-snake-case-in-cactus-marked-test.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/incorrect-test-object-name/catches-snake-case-in-cactus-marked-test.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/incorrect-test-object-name.xsl
+asserts:
+  - /defects[count(defect[@severity='warning' and @line='2'])=1]
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="1" name="foo">
+      <o line="2" name="p🌵test_abc"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/sparse-decoration/allows-sparse-in-cactus-marked-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/sparse-decoration/allows-sparse-in-cactus-marked-tests.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/misc/sparse-decoration.xsl
+defects: 0
+document: |
+  <object author="tests">
+    <o line="1" name="foo">
+      <o line="2" name="p🌵can-do-something">
+        <o base="Φ.number" line="3" name="φ">
+          <o base="Φ.bytes" line="3">40-14-00-00-00-00-00-00</o>
+        </o>
+      </o>
+      <o line="5" name="n🌵cannot-do-something">
+        <o base="Φ.number" line="6" name="φ">
+          <o base="Φ.bytes" line="6">40-14-00-00-00-00-00-00</o>
+        </o>
+      </o>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/unit-test-is-not-verb/allows-cactus-marked-verb.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unit-test-is-not-verb/allows-cactus-marked-verb.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: unit-test-is-not-verb
+asserts:
+  - /defects[count(defect)=0]
+document: |
+  <object author="tests">
+    <o line="1" name="foo">
+      <o line="2" name="p🌵generates-report">
+        <o base="Φ.number" line="3" name="φ">
+          <o base="Φ.bytes" line="3">40-14-00-00-00-00-00-00</o>
+        </o>
+      </o>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/unit-test-is-not-verb/catches-cactus-marked-bad-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unit-test-is-not-verb/catches-cactus-marked-bad-name.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: unit-test-is-not-verb
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[contains(text(), '"it-works"')]
+document: |
+  <object author="tests">
+    <o line="1" name="foo">
+      <o line="2" name="p🌵it-works">
+        <o base="Φ.number" line="3" name="φ">
+          <o base="Φ.bytes" line="3">40-14-00-00-00-00-00-00</o>
+        </o>
+      </o>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/unit-test-missing/allows-object-with-cactus-marked-tests.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unit-test-missing/allows-object-with-cactus-marked-tests.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/unit-test-missing.xsl
+defects: 0
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="1" name="foo">
+      <o line="2" name="p🌵prints-hello-world"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/unit-test-without-phi/catches-cactus-marked-test-without-phi.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unit-test-without-phi/catches-cactus-marked-test-without-phi.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/unit-test-without-phi.xsl
+asserts:
+  - /defects[count(defect[@severity='warning' and @line='4'])=1]
+  - /defects/defect[contains(text(), '"runs-without-phi"')]
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="2" name="foo" pos="0">
+      <o line="4" name="p🌵runs-without-phi" pos="2">
+        <o base="Q.number" line="5" name="x" pos="4"/>
+      </o>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/allows-cactus-marked-tests-at-the-end.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/allows-cactus-marked-tests-at-the-end.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/wrong-test-order.xsl
+defects: 0
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="1" name="foo">
+      <o line="2" name="bar"/>
+      <o line="3" name="p🌵runs-program"/>
+      <o line="4" name="n🌵cannot-run-program"/>
+    </o>
+  </object>

--- a/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/catches-cactus-marked-test-before-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/wrong-test-order/catches-cactus-marked-test-before-object.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/lints/tests/wrong-test-order.xsl
+asserts:
+  - /defects[count(defect[@severity='warning' and @line='3'])=1]
+  - /defects/defect[contains(text(), '"runs-program"')]
+ignore-schema: true
+document: |
+  <object author="tests">
+    <o line="1" name="foo">
+      <o line="2" name="bar"/>
+      <o line="3" name="p🌵runs-program"/>
+      <o line="4" name="boom"/>
+    </o>
+  </object>


### PR DESCRIPTION
Closes #1434.

The EO parser stops prefixing a test attribute `@name` with `+` or `-`, since neither is a legal φ-calculus attribute name (objectionary/eo#8566). A truthy test now arrives as `p🌵name` and a throwing one as `n🌵name`.

### `funcs/test-name.xsl`

A marker-aware set of functions rather than a single predicate:

- `eo:test-marker` — the marker in front of the name, or an empty string. Accepts `p🌵` and `n🌵` alongside the old `+` and `-`, so `lints` and `eo` may move independently, after which the old pair can be dropped for good.
- `eo:test-name` — unchanged signature, now true for either spelling.
- `eo:test-title` — the name with whichever marker is present removed. `substring(@name, 2)` cannot do this: Saxon counts 🌵 as one codepoint, so slicing one character off `p🌵can-do-x` leaves `🌵can-do-x`.
- `eo:positive-test` — polarity read from the marker.

### Call sites moved onto them

| File | Was | Now |
| --- | --- | --- |
| `tests/bad-test-name.xsl` | `starts-with(@name, '+')`, `substring(@name, 2)` | `eo:positive-test`, `eo:test-title` |
| `tests/wrong-test-order.xsl` | `substring(@name, 2)` | `eo:test-title` |
| `tests/unit-test-without-phi.xsl` | `substring(@name, 2)` | `eo:test-title` |
| `misc/incorrect-test-object-name.xsl` | `substring(@name, 2)` | `eo:test-title` |

The lints that only ask `eo:test-name` — `unit-test-missing`, `sparse-decoration`, `test-word`, `test-with-comment`, `excessive-visibility`, `non-kebab-name`, `unsorted-named-attributes`, `invalid-name-notation` — follow the function and need no edit.

### `LtTestNotVerb`

Its XPath had `starts-with(@name, '+')` written inline and stripped the marker with `replace("+", "")`, so `unit-test-is-not-verb` went dark whatever `test-name.xsl` said. It now goes through `MarkedName`, the Java twin of the same function, which holds the marker list in one place.

### Tests

New YAML packs feed XMIR carrying the new markers straight through `document:`, since the parser on the classpath still emits the old ones: `bad-test-name` (4), `wrong-test-order` (2), `unit-test-without-phi`, `incorrect-test-object-name` (2), `unit-test-missing`, `sparse-decoration`, and a new `unit-test-is-not-verb` pack for the Java lint. The `catches-` ones assert the defect text, which pins the stripped title and the polarity.

`mvn test` — 710 pass. `mvn -Pqulice verify` and `xcop` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWJEebtyWwtj6cuN9AoRiq

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWJEebtyWwtj6cuN9AoRiq)_