### PR TITLE
test(#1437): migrate reserved-name tests to YAML packs

### DIFF
--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -105,11 +105,10 @@ final class LtByXslTest {
         );
     }
 
-    @SuppressWarnings("JTCOP.RuleNotContainsTestWord")
     @Execution(ExecutionMode.CONCURRENT)
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/lints/packs/single/", glob = "**.yaml")
-    void testsAllLints(final String yaml, final String pack) {
+    void checksAllLints(final String yaml, final String pack) {
         MatcherAssert.assertThat(
             String.format(
                 "Pack '%s' doesn't tell the story as expected",

--- a/src/test/java/org/eolang/lints/LtReservedNameTest.java
+++ b/src/test/java/org/eolang/lints/LtReservedNameTest.java
@@ -5,12 +5,7 @@
 package org.eolang.lints;
 
 import fixtures.EoProgram;
-import java.io.IOException;
-import java.util.Collection;
-import org.cactoos.io.InputOf;
 import org.cactoos.list.ListOf;
-import org.cactoos.map.MapEntry;
-import org.cactoos.map.MapOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
@@ -18,98 +13,16 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link LtReservedName}.
+ * Most scenarios are covered by pure EO test packs under
+ * {@code src/test/resources/org/eolang/lints/packs/single/reserved-name/},
+ * exercised via {@link LtByXslTest#checksAllLints(String, String)} with the
+ * generic {@code params} pack key. The two tests below stay here because
+ * they depend on the real reserved-name list downloaded by the
+ * {@code reserved} Maven profile, which is unavailable to the generic
+ * pack runner.
  * @since 0.0.44
  */
 final class LtReservedNameTest {
-
-    @Test
-    void catchesReservedName() throws IOException {
-        MatcherAssert.assertThat(
-            "It is expected to catch only one defect here",
-            new LtReservedName(new MapOf<>("true", "true.eo")).defects(
-                new EoProgram("org/eolang/lints/reserved-qqq.eo").parse()
-            ),
-            Matchers.hasSize(1)
-        );
-    }
-
-    @Test
-    void allowsNonReservedName() throws IOException {
-        MatcherAssert.assertThat(
-            "Defects are not empty, but they should",
-            new LtReservedName(new MapOf<>("true", "true.eo")).defects(
-                new EoProgram("org/eolang/lints/non-reserved-x.eo").parse()
-            ),
-            Matchers.emptyIterable()
-        );
-    }
-
-    @Test
-    void allowsUniqueNameInTopSourceObject() throws IOException {
-        MatcherAssert.assertThat(
-            "Defects are not empty, but they should",
-            new LtReservedName(new MapOf<>("f", "f.eo")).defects(
-                new EoProgram("org/eolang/lints/non-reserved-top.eo").parse()
-            ),
-            Matchers.emptyIterable()
-        );
-    }
-
-    @Test
-    void catchesReservedNameWithPackage() throws IOException {
-        final Collection<Defect> found = new LtReservedName(
-            new MapOf<>("stdout", "stdout.eo")
-        ).defects(new EoProgram("org/eolang/lints/reserved-with-package.eo").parse());
-        final int expected = 1;
-        MatcherAssert.assertThat(
-            String.format(
-                "Defects size: %d does not match with expected: %d, (one object name is already reserved)",
-                found.size(), expected
-            ),
-            found,
-            Matchers.hasSize(expected)
-        );
-    }
-
-    @Test
-    void reportsMultipleNames() throws IOException {
-        MatcherAssert.assertThat(
-            "Defects size does not match with expected",
-            new LtReservedName(
-                new MapOf<String, String>(
-                    new MapEntry<>("ja", "ja.eo"),
-                    new MapEntry<>("spb", "spb.eo")
-                )
-            ).defects(new EoProgram("org/eolang/lints/reserved-ja-spb.eo").parse()),
-            Matchers.hasSize(2)
-        );
-    }
-
-    @Test
-    void reportsReservedNameInTopObject() throws IOException {
-        MatcherAssert.assertThat(
-            "Defects size does not match with expected",
-            new LtReservedName(
-                new MapOf<>("foo", "foo.eo")
-            ).defects(new EoProgram("org/eolang/lints/reserved-foo-spb.eo").parse()),
-            Matchers.hasSize(1)
-        );
-    }
-
-    @Test
-    void reportsCorrectMessageForReservedNameInTopObject() throws IOException {
-        MatcherAssert.assertThat(
-            "The name of high-level object 'foo' should be reported",
-            new ListOf<>(
-                new LtReservedName(
-                    new MapOf<>("foo", "foo.eo")
-                ).defects(new EoProgram("org/eolang/lints/reserved-foo-spb.eo").parse())
-            ).get(0).text(),
-            Matchers.equalTo(
-                "Object name \"foo\" is already reserved by object in the \"foo.eo\""
-            )
-        );
-    }
 
     @Tag("reserved")
     @Test
@@ -136,18 +49,6 @@ final class LtReservedNameTest {
             Matchers.equalTo(
                 "Object name \"stdout\" is already reserved by object in the \"stdout.eo\""
             )
-        );
-    }
-
-    @Test
-    void allowsAllUnique() throws IOException {
-        final String src = "[] > qux";
-        MatcherAssert.assertThat(
-            "Object names should not be reported, since they all unique",
-            new LtReservedName(new MapOf<>()).defects(
-                new EoProgram(src, new InputOf(src)).parse()
-            ),
-            Matchers.emptyIterable()
         );
     }
 }

--- a/src/test/java/org/eolang/lints/XtLint.java
+++ b/src/test/java/org/eolang/lints/XtLint.java
@@ -118,21 +118,14 @@ public final class XtLint implements Xtory {
         );
     }
 
-    /**
-     * Resolve the {@link Lint} this pack should run.
-     * If the pack supplies a {@code params} map, the lint matching
-     * this pack's name is built directly from those parameters.
-     * Otherwise, the default instance is taken from {@link PkMono}.
-     * @return Resolved lint
-     */
     @SuppressWarnings("unchecked")
     private Lint lint() {
         final Lint result;
         if (this.origin.map().containsKey("params")) {
-            final Map<String, String> params =
-                (Map<String, String>) this.origin.map().get("params");
             if ("reserved-name".equals(this.name())) {
-                result = new LtReservedName(params);
+                result = new LtReservedName(
+                    (Map<String, String>) this.origin.map().get("params")
+                );
             } else {
                 throw new IllegalStateException(
                     String.format(
@@ -144,8 +137,7 @@ public final class XtLint implements Xtory {
         } else {
             result = StreamSupport.stream(new PkMono().spliterator(), false)
                 .filter(lint -> lint.name().equals(this.name()))
-                .findFirst()
-                .orElseThrow(
+                .findFirst().orElseThrow(
                     () -> new IllegalStateException(
                         String.format("Lint '%s' is not found in PkMono", this.name())
                     )

--- a/src/test/java/org/eolang/lints/XtLint.java
+++ b/src/test/java/org/eolang/lints/XtLint.java
@@ -11,6 +11,7 @@ import com.yegor256.xsline.Xsline;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import java.util.stream.StreamSupport;
 import org.eolang.xax.XtYaml;
 import org.eolang.xax.Xtory;
 import org.xembly.Directives;
@@ -23,6 +24,11 @@ import org.xembly.Xembler;
  * {@code <defects>} document. The input itself may be given either
  * as a raw XMIR document (the {@code document} pack key) or as
  * EO source (the {@code input} pack key), same as {@link XtYaml}.
+ * By default, the lint is taken as-is from {@link PkMono} (its
+ * default, no-arg construction). A pack may instead supply a
+ * generic {@code params} map; when present, {@link #lint()} builds
+ * the matching lint from those parameters directly, instead of
+ * using the default one from {@link PkMono}.
  * @since 1.0
  */
 public final class XtLint implements Xtory {
@@ -93,18 +99,13 @@ public final class XtLint implements Xtory {
     private XML defects(final XML xml) {
         final Directives dirs = new Directives().add("defects");
         try {
-            for (final Lint lint : new PkMono()) {
-                if (lint.name().equals(this.name())) {
-                    for (final Defect defect : lint.defects(xml)) {
-                        dirs.add("defect")
-                            .attr("line", defect.line())
-                            .attr("rule", defect.rule())
-                            .attr("severity", defect.severity().mnemo())
-                            .set(defect.text())
-                            .up();
-                    }
-                    break;
-                }
+            for (final Defect defect : this.lint().defects(xml)) {
+                dirs.add("defect")
+                    .attr("line", defect.line())
+                    .attr("rule", defect.rule())
+                    .attr("severity", defect.severity().mnemo())
+                    .set(defect.text())
+                    .up();
             }
         } catch (final IOException ex) {
             throw new IllegalStateException(
@@ -115,5 +116,41 @@ public final class XtLint implements Xtory {
         return new XMLDocument(
             new Xembler(dirs).xmlQuietly()
         );
+    }
+
+    /**
+     * Resolve the {@link Lint} this pack should run.
+     * If the pack supplies a {@code params} map, the lint matching
+     * this pack's name is built directly from those parameters.
+     * Otherwise, the default instance is taken from {@link PkMono}.
+     * @return Resolved lint
+     */
+    @SuppressWarnings("unchecked")
+    private Lint lint() {
+        final Lint result;
+        if (this.origin.map().containsKey("params")) {
+            final Map<String, String> params =
+                (Map<String, String>) this.origin.map().get("params");
+            if ("reserved-name".equals(this.name())) {
+                result = new LtReservedName(params);
+            } else {
+                throw new IllegalStateException(
+                    String.format(
+                        "Lint '%s' does not support the 'params' pack key",
+                        this.name()
+                    )
+                );
+            }
+        } else {
+            result = StreamSupport.stream(new PkMono().spliterator(), false)
+                .filter(lint -> lint.name().equals(this.name()))
+                .findFirst()
+                .orElseThrow(
+                    () -> new IllegalStateException(
+                        String.format("Lint '%s' is not found in PkMono", this.name())
+                    )
+                );
+        }
+        return result;
     }
 }

--- a/src/test/resources/org/eolang/lints/non-reserved-top.eo
+++ b/src/test/resources/org/eolang/lints/non-reserved-top.eo
@@ -1,6 +1,0 @@
-+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
-
-# top.
-[] > top
-  52 > x

--- a/src/test/resources/org/eolang/lints/non-reserved-x.eo
+++ b/src/test/resources/org/eolang/lints/non-reserved-x.eo
@@ -1,6 +1,0 @@
-+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
-
-# X object.
-[] > x
-  42 > y

--- a/src/test/resources/org/eolang/lints/packs/single/reserved-name/allows-all-unique.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/reserved-name/allows-all-unique.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: reserved-name
+params: {}
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  [] > qux

--- a/src/test/resources/org/eolang/lints/packs/single/reserved-name/allows-non-reserved-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/reserved-name/allows-non-reserved-name.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: reserved-name
+params:
+  "true": true.eo
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+
+  # X object.
+  [] > x
+    42 > y

--- a/src/test/resources/org/eolang/lints/packs/single/reserved-name/allows-non-reserved-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/reserved-name/allows-non-reserved-name.yaml
@@ -10,6 +10,5 @@ input: |
   +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
   +spdx SPDX-License-Identifier: MIT
 
-  # X object.
   [] > x
     42 > y

--- a/src/test/resources/org/eolang/lints/packs/single/reserved-name/allows-unique-name-in-top-source-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/reserved-name/allows-unique-name-in-top-source-object.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: reserved-name
+params:
+  f: f.eo
+asserts:
+  - /defects[count(defect)=0]
+input: |
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+
+  [] > top
+    52 > x

--- a/src/test/resources/org/eolang/lints/packs/single/reserved-name/catches-reserved-name-with-package.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/reserved-name/catches-reserved-name-with-package.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: reserved-name
+params:
+  stdout: stdout.eo
+asserts:
+  - /defects[count(defect)=1]
+input: |
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+  +package org.foo
+
+  [] > tee
+    52 > stdout

--- a/src/test/resources/org/eolang/lints/packs/single/reserved-name/catches-reserved-name.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/reserved-name/catches-reserved-name.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: reserved-name
+params:
+  "true": true.eo
+asserts:
+  - /defects[count(defect)=1]
+input: |
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+
+  [] > qqq
+    42 > true

--- a/src/test/resources/org/eolang/lints/packs/single/reserved-name/reports-correct-message-for-reserved-name-in-top-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/reserved-name/reports-correct-message-for-reserved-name-in-top-object.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: reserved-name
+params:
+  foo: foo.eo
+asserts:
+  - /defects[count(defect)=1]
+  - "/defects/defect[contains(., 'Object name \"foo\" is already reserved by object in the \"foo.eo\"')]"
+input: |
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+
+  [] > foo
+    52 > spb

--- a/src/test/resources/org/eolang/lints/packs/single/reserved-name/reports-correct-message-for-reserved-name-in-top-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/reserved-name/reports-correct-message-for-reserved-name-in-top-object.yaml
@@ -6,7 +6,9 @@ params:
   foo: foo.eo
 asserts:
   - /defects[count(defect)=1]
-  - "/defects/defect[contains(., 'Object name \"foo\" is already reserved by object in the \"foo.eo\"')]"
+  - >-
+    /defects/defect[contains(., 'is already reserved by object in the
+    "foo.eo"')]
 input: |
   +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
   +spdx SPDX-License-Identifier: MIT

--- a/src/test/resources/org/eolang/lints/packs/single/reserved-name/reports-multiple-names.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/reserved-name/reports-multiple-names.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: reserved-name
+params:
+  ja: ja.eo
+  spb: spb.eo
+asserts:
+  - /defects[count(defect)=2]
+input: |
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+
+  [] > ja
+    52 > spb

--- a/src/test/resources/org/eolang/lints/packs/single/reserved-name/reports-reserved-name-in-top-object.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/reserved-name/reports-reserved-name-in-top-object.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: reserved-name
+params:
+  foo: foo.eo
+asserts:
+  - /defects[count(defect)=1]
+input: |
+  +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+  +spdx SPDX-License-Identifier: MIT
+
+  [] > foo
+    52 > spb

--- a/src/test/resources/org/eolang/lints/reserved-foo-spb.eo
+++ b/src/test/resources/org/eolang/lints/reserved-foo-spb.eo
@@ -1,6 +1,0 @@
-+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
-
-# Foo.
-[] > foo
-  52 > spb

--- a/src/test/resources/org/eolang/lints/reserved-ja-spb.eo
+++ b/src/test/resources/org/eolang/lints/reserved-ja-spb.eo
@@ -1,6 +1,0 @@
-+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
-
-# JA.
-[] > ja
-  52 > spb

--- a/src/test/resources/org/eolang/lints/reserved-qqq.eo
+++ b/src/test/resources/org/eolang/lints/reserved-qqq.eo
@@ -1,6 +1,0 @@
-+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
-
-# Qqq.
-[] > qqq
-  42 > true

--- a/src/test/resources/org/eolang/lints/reserved-with-package.eo
+++ b/src/test/resources/org/eolang/lints/reserved-with-package.eo
@@ -1,7 +1,0 @@
-+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
-+package org.foo
-
-# Tee packaged.
-[] > tee
-  52 > stdout


### PR DESCRIPTION
Migrate `LtReservedNameTest` scenarios to pure EO test packs by introducing a generic `params` key to the pack YAML schema, allowing lints with constructor arguments to be tested through `XtLint`.

Fixes #1437