### PR TITLE
Upgrade qulice to 0.35.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.35.1</version>
+            <version>0.35.2</version>
           </plugin>
           <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>

--- a/src/main/java/org/eolang/lints/Defect.java
+++ b/src/main/java/org/eolang/lints/Defect.java
@@ -80,6 +80,7 @@ public interface Defect {
 
     /**
      * Experimental?
+     *
      * @return Experimental
      */
     boolean experimental();
@@ -120,6 +121,7 @@ public interface Defect {
 
         /**
          * Ctor.
+         *
          * @param rule Rule name
          * @param severity Severity level
          * @param line Line number

--- a/src/main/java/org/eolang/lints/DefectMissing.java
+++ b/src/main/java/org/eolang/lints/DefectMissing.java
@@ -13,6 +13,7 @@ import org.cactoos.set.SetOf;
 
 /**
  * Is defect missing?
+ *
  * @since 0.0.44
  */
 final class DefectMissing implements Function<String, Boolean> {
@@ -29,6 +30,7 @@ final class DefectMissing implements Function<String, Boolean> {
 
     /**
      * Ctor.
+     *
      * @param present Present defects
      * @param exld Excluded lints
      */

--- a/src/main/java/org/eolang/lints/DfContext.java
+++ b/src/main/java/org/eolang/lints/DfContext.java
@@ -6,6 +6,7 @@ package org.eolang.lints;
 
 /**
  * Defect with context.
+ *
  * @since 0.0.40
  */
 final class DfContext implements Defect {
@@ -22,6 +23,7 @@ final class DfContext implements Defect {
 
     /**
      * Ctor.
+     *
      * @param orgn Origin defect
      * @param context Context
      */

--- a/src/main/java/org/eolang/lints/Fix.java
+++ b/src/main/java/org/eolang/lints/Fix.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 
 /**
  * A fix for a lint defect.
+ *
  * @since 0.2.1
  */
 @FunctionalInterface
@@ -16,6 +17,7 @@ public interface Fix {
 
     /**
      * Apply the fix and return the corrected XMIR.
+     *
      * @param xmir The XMIR to fix
      * @return Fixed XMIR
      * @throws IOException If something goes wrong

--- a/src/main/java/org/eolang/lints/FxByXsl.java
+++ b/src/main/java/org/eolang/lints/FxByXsl.java
@@ -18,6 +18,7 @@ import org.cactoos.text.TextOf;
 
 /**
  * Fix implemented by a sequence of XSL stylesheets.
+ *
  * @since 0.2.1
  */
 public final class FxByXsl implements Fix {
@@ -29,6 +30,7 @@ public final class FxByXsl implements Fix {
 
     /**
      * Constructor.
+     *
      * @param paths Classpath resource paths to XSL stylesheets (leading slash optional)
      * @checkstyle ConstructorsCodeFreeCheck (5 lines)
      */

--- a/src/main/java/org/eolang/lints/FxEmpty.java
+++ b/src/main/java/org/eolang/lints/FxEmpty.java
@@ -9,6 +9,7 @@ import com.jcabi.xml.XML;
 /**
  * A no-op fix that returns the XMIR unchanged.
  * Used by lints that do not support auto-fixing.
+ *
  * @since 0.2.1
  */
 public final class FxEmpty implements Fix {

--- a/src/main/java/org/eolang/lints/FxResource.java
+++ b/src/main/java/org/eolang/lints/FxResource.java
@@ -16,6 +16,7 @@ import org.cactoos.text.TextOf;
 /**
  * Fix loaded from a classpath resource.
  * If the resource does not exist, the XMIR is returned unchanged.
+ *
  * @since 0.2.1
  */
 public final class FxResource implements Fix {
@@ -27,6 +28,7 @@ public final class FxResource implements Fix {
 
     /**
      * Ctor.
+     *
      * @param path Classpath path to the XSL fix stylesheet
      */
     FxResource(final String path) {
@@ -35,6 +37,7 @@ public final class FxResource implements Fix {
 
     /**
      * Ctor.
+     *
      * @param path Classpath path to the XSL fix stylesheet
      */
     FxResource(final Text path) {

--- a/src/main/java/org/eolang/lints/LineOf.java
+++ b/src/main/java/org/eolang/lints/LineOf.java
@@ -26,6 +26,7 @@ final class LineOf {
 
     /**
      * Ctor.
+     *
      * @param elem XML element to read from
      */
     LineOf(final Xnav elem) {
@@ -34,6 +35,7 @@ final class LineOf {
 
     /**
      * Line number, or {@code 0} when the attribute is missing or not an integer.
+     *
      * @return Line number
      */
     int value() {

--- a/src/main/java/org/eolang/lints/Lint.java
+++ b/src/main/java/org/eolang/lints/Lint.java
@@ -10,18 +10,21 @@ import java.util.Collection;
 
 /**
  * A single checker for an {@code .xmir} file.
+ *
  * @since 0.0.1
  */
 public interface Lint {
 
     /**
      * Name of the lint.
+     *
      * @return Lint name
      */
     String name();
 
     /**
      * Find and return defects.
+     *
      * @param xmir The XMIR to analyze
      * @return Defects
      * @throws IOException if something went wrong
@@ -30,6 +33,7 @@ public interface Lint {
 
     /**
      * Returns motive for a lint, explaining why this lint exists.
+     *
      * @return Motive text about lint
      * @throws IOException if something went wrong
      */
@@ -38,6 +42,7 @@ public interface Lint {
     /**
      * Returns a fix for defects found by this lint.
      * If the lint does not support auto-fixing, return {@link FxEmpty}.
+     *
      * @return Fix for this lint
      */
     Fix fix();

--- a/src/main/java/org/eolang/lints/LtAlways.java
+++ b/src/main/java/org/eolang/lints/LtAlways.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 
 /**
  * Lint that always complains.
+ *
  * @since 0.0.1
  */
 final class LtAlways implements Lint {

--- a/src/main/java/org/eolang/lints/LtAsciiOnly.java
+++ b/src/main/java/org/eolang/lints/LtAsciiOnly.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 
 /**
  * A comment must include only ASCII characters.
+ *
  * @since 0.1.0
  * @todo #14:35min Calculate comment line number with abusive character.
  *  For now we just reusing object line number (via @line), which is not correct

--- a/src/main/java/org/eolang/lints/LtByXsl.java
+++ b/src/main/java/org/eolang/lints/LtByXsl.java
@@ -27,6 +27,7 @@ import org.cactoos.text.TextOf;
 
 /**
  * Lint by XSL.
+ *
  * @since 0.0.1
  */
 final class LtByXsl implements Lint {
@@ -53,6 +54,7 @@ final class LtByXsl implements Lint {
 
     /**
      * Ctor.
+     *
      * @param xsl Relative path of XSL
      */
     LtByXsl(final String xsl) {
@@ -71,6 +73,7 @@ final class LtByXsl implements Lint {
 
     /**
      * Ctor.
+     *
      * @param xsl XSL content
      * @param motive Motive document
      * @param fix Fix for this lint
@@ -91,6 +94,7 @@ final class LtByXsl implements Lint {
 
     /**
      * Ctor.
+     *
      * @param xml XSL stylesheet as XML
      * @param motive Motive document
      * @param fix Fix for this lint

--- a/src/main/java/org/eolang/lints/LtDfSticky.java
+++ b/src/main/java/org/eolang/lints/LtDfSticky.java
@@ -35,6 +35,7 @@ final class LtDfSticky implements Lint {
 
     /**
      * Ctor.
+     *
      * @param origin Object wrapped by a decorator
      * @checkstyle ConstructorsCodeFreeCheck (4 lines)
      */

--- a/src/main/java/org/eolang/lints/LtIncorrectUnlint.java
+++ b/src/main/java/org/eolang/lints/LtIncorrectUnlint.java
@@ -13,6 +13,7 @@ import org.cactoos.set.SetOf;
 
 /**
  * Lint that all unlint metas point to existing lint.
+ *
  * @since 0.0.38
  */
 final class LtIncorrectUnlint implements Lint {
@@ -24,6 +25,7 @@ final class LtIncorrectUnlint implements Lint {
 
     /**
      * Ctor.
+     *
      * @param lints All possible lint names
      */
     LtIncorrectUnlint(final Iterable<String> lints) {

--- a/src/main/java/org/eolang/lints/LtMono.java
+++ b/src/main/java/org/eolang/lints/LtMono.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 
 /**
  * Lint that always returns a given defect.
+ *
  * @since 0.0.35
  */
 final class LtMono implements Lint {
@@ -21,6 +22,7 @@ final class LtMono implements Lint {
 
     /**
      * Ctor.
+     *
      * @param dft The defect to return
      */
     LtMono(final Defect dft) {

--- a/src/main/java/org/eolang/lints/LtReservedName.java
+++ b/src/main/java/org/eolang/lints/LtReservedName.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 
 /**
  * Lint for reserved names.
+ *
  * @since 0.0.44
  */
 final class LtReservedName implements Lint {
@@ -32,6 +33,7 @@ final class LtReservedName implements Lint {
 
     /**
      * Ctor.
+     *
      * @param names Reserved names
      */
     LtReservedName(final Map<String, String> names) {

--- a/src/main/java/org/eolang/lints/LtTestNotVerb.java
+++ b/src/main/java/org/eolang/lints/LtTestNotVerb.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
  * This lint uses <a href="https://opennlp.apache.org/">OpenNLP models</a>
  * with POS tagging capabilities in order to determine the part of speech and
  * tense for test object name.
+ *
  * @since 0.0.22
  */
 final class LtTestNotVerb implements Lint {
@@ -26,6 +27,7 @@ final class LtTestNotVerb implements Lint {
 
     /**
      * Ctor.
+     *
      * @throws IOException If fails
      */
     LtTestNotVerb() throws IOException {
@@ -34,6 +36,7 @@ final class LtTestNotVerb implements Lint {
 
     /**
      * Ctor.
+     *
      * @param vocab Vocabulary to use for name checks
      */
     LtTestNotVerb(final Vocabulary vocab) {

--- a/src/main/java/org/eolang/lints/LtUnlint.java
+++ b/src/main/java/org/eolang/lints/LtUnlint.java
@@ -16,6 +16,7 @@ import org.cactoos.list.ListOf;
 
 /**
  * Lint that ignores linting if {@code +unlint} meta is present.
+ *
  * @since 0.0.1
  */
 final class LtUnlint implements Lint {
@@ -27,6 +28,7 @@ final class LtUnlint implements Lint {
 
     /**
      * Ctor.
+     *
      * @param lint The lint to decorate
      */
     LtUnlint(final Lint lint) {

--- a/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
+++ b/src/main/java/org/eolang/lints/LtUnlintNonExistingDefect.java
@@ -18,6 +18,7 @@ import org.cactoos.list.ListOf;
 
 /**
  * Lint for checking `+unlint` meta to suppress non-existing defects in single XMIR scope.
+ *
  * @since 0.0.40
  */
 final class LtUnlintNonExistingDefect implements Lint {
@@ -34,6 +35,7 @@ final class LtUnlintNonExistingDefect implements Lint {
 
     /**
      * Ctor.
+     *
      * @param lnts Lints
      */
     LtUnlintNonExistingDefect(final Iterable<Lint> lnts) {
@@ -42,6 +44,7 @@ final class LtUnlintNonExistingDefect implements Lint {
 
     /**
      * Ctor.
+     *
      * @param lnts Lints
      * @param exld Lint names to exclude
      */

--- a/src/main/java/org/eolang/lints/MarkedName.java
+++ b/src/main/java/org/eolang/lints/MarkedName.java
@@ -47,6 +47,7 @@ final class MarkedName {
 
     /**
      * Ctor.
+     *
      * @param name The name of the attribute, with the marker
      */
     MarkedName(final String name) {
@@ -56,6 +57,7 @@ final class MarkedName {
     /**
      * The name with its marker removed, e.g. {@code can-do-it} for
      * {@code p🌵can-do-it}. A name that is not a test comes back untouched.
+     *
      * @return The name, without the marker
      */
     String title() {
@@ -71,6 +73,7 @@ final class MarkedName {
 
     /**
      * XPath that selects every truthy test attribute of an XMIR document.
+     *
      * @return XPath expression
      */
     static String positives() {

--- a/src/main/java/org/eolang/lints/MeasuredXsl.java
+++ b/src/main/java/org/eolang/lints/MeasuredXsl.java
@@ -11,6 +11,7 @@ import com.jcabi.xml.XSL;
 
 /**
  * XSL that measures the time of transformation.
+ *
  * @since 0.1
  */
 final class MeasuredXsl implements XSL {
@@ -32,6 +33,7 @@ final class MeasuredXsl implements XSL {
 
     /**
      * Ctor.
+     *
      * @param name Rule name
      * @param decorated Decorated XSL
      */
@@ -41,6 +43,7 @@ final class MeasuredXsl implements XSL {
 
     /**
      * Ctor.
+     *
      * @param name Rule name
      * @param decorated Decorated XSL
      * @param threshold Custom threshold in milliseconds

--- a/src/main/java/org/eolang/lints/MonoLintNames.java
+++ b/src/main/java/org/eolang/lints/MonoLintNames.java
@@ -12,6 +12,7 @@ import org.cactoos.list.ListOf;
  * Mono lint names.
  * Caches the lint names collection statically to avoid repeated
  * expensive iteration over MonoLints during Program instantiation.
+ *
  * @since 0.0.43
  */
 final class MonoLintNames extends IterableEnvelope<String> {

--- a/src/main/java/org/eolang/lints/MonoLints.java
+++ b/src/main/java/org/eolang/lints/MonoLints.java
@@ -15,6 +15,7 @@ import org.cactoos.list.ListOf;
 /**
  * Mono lints.
  * Mono lints represent a list of lints for single XMIR scope.
+ *
  * @since 0.0.43
  */
 final class MonoLints extends IterableEnvelope<Lint> {

--- a/src/main/java/org/eolang/lints/MonoWithout.java
+++ b/src/main/java/org/eolang/lints/MonoWithout.java
@@ -8,6 +8,7 @@ import org.cactoos.iterable.IterableEnvelope;
 
 /**
  * Mono lints without lint names.
+ *
  * @since 0.0.46
  */
 final class MonoWithout extends IterableEnvelope<Lint> {
@@ -19,6 +20,7 @@ final class MonoWithout extends IterableEnvelope<Lint> {
 
     /**
      * Ctor.
+     *
      * @param names Lints to exclude
      */
     MonoWithout(final String... names) {

--- a/src/main/java/org/eolang/lints/MotiveFrom.java
+++ b/src/main/java/org/eolang/lints/MotiveFrom.java
@@ -30,6 +30,7 @@ final class MotiveFrom {
 
     /**
      * Ctor, picking the document by dimension and lint name.
+     *
      * @param dimension Motive dimension (e.g. {@code "errors"}, {@code "misc"}, {@code "names"})
      * @param lint Lint name, used as the markdown file basename
      */
@@ -43,6 +44,7 @@ final class MotiveFrom {
 
     /**
      * Ctor.
+     *
      * @param src Raw input of the motive document
      */
     MotiveFrom(final Input src) {
@@ -51,6 +53,7 @@ final class MotiveFrom {
 
     /**
      * Read the motive document as a string.
+     *
      * @return Motive content
      * @throws IOException If reading the resource fails
      */

--- a/src/main/java/org/eolang/lints/PkByXsl.java
+++ b/src/main/java/org/eolang/lints/PkByXsl.java
@@ -20,6 +20,7 @@ import org.cactoos.text.FormattedText;
  * All lints defined by XSLs.
  * Caches all XSL-based lint instances statically to avoid repeated
  * expensive parsing of XSL files during Program instantiation.
+ *
  * @since 0.1.0
  */
 final class PkByXsl extends IterableEnvelope<Lint> {

--- a/src/main/java/org/eolang/lints/PkMono.java
+++ b/src/main/java/org/eolang/lints/PkMono.java
@@ -36,6 +36,7 @@ final class PkMono extends IterableEnvelope<Lint> {
 
     /**
      * Ctor.
+     *
      * @param lints Lints
      */
     PkMono(final Iterable<Lint> lints) {

--- a/src/main/java/org/eolang/lints/ReservedNames.java
+++ b/src/main/java/org/eolang/lints/ReservedNames.java
@@ -16,6 +16,7 @@ import org.cactoos.map.MapOf;
 
 /**
  * Reserved EO top object names.
+ *
  * @since 0.0.49
  */
 final class ReservedNames extends MapEnvelope<String, String> {
@@ -29,6 +30,7 @@ final class ReservedNames extends MapEnvelope<String, String> {
 
     /**
      * Ctor.
+     *
      * @param path Path to reserved names
      */
     ReservedNames(final String path) {

--- a/src/main/java/org/eolang/lints/ScopedDefects.java
+++ b/src/main/java/org/eolang/lints/ScopedDefects.java
@@ -10,12 +10,14 @@ import org.cactoos.list.ListOf;
 
 /**
  * Defects, marked with their scopes.
+ *
  * @since 0.0.48
  */
 final class ScopedDefects extends CollectionEnvelope<Defect> {
 
     /**
      * Ctor.
+     *
      * @param origin Origin defects
      * @param marker Marker
      */

--- a/src/main/java/org/eolang/lints/Severity.java
+++ b/src/main/java/org/eolang/lints/Severity.java
@@ -6,6 +6,7 @@ package org.eolang.lints;
 
 /**
  * Severity.
+ *
  * @since 0.0.1
  */
 public enum Severity {
@@ -32,6 +33,7 @@ public enum Severity {
 
     /**
      * Ctor.
+     *
      * @param txt Name of it
      */
     Severity(final String txt) {
@@ -40,6 +42,7 @@ public enum Severity {
 
     /**
      * Mnemo of it.
+     *
      * @return Mnemo
      */
     public String mnemo() {
@@ -48,6 +51,7 @@ public enum Severity {
 
     /**
      * Parse it from the text.
+     *
      * @param text Text of it
      * @return Severity
      */

--- a/src/main/java/org/eolang/lints/Source.java
+++ b/src/main/java/org/eolang/lints/Source.java
@@ -16,6 +16,7 @@ import org.cactoos.iterable.Synced;
 
 /**
  * A single source XMIR to analyze.
+ *
  * @see <a href="https://news.eolang.org/2022-11-25-xmir-guide.html">XMIR</a>
  * @since 0.1.0
  */
@@ -42,6 +43,7 @@ public final class Source {
 
     /**
      * Ctor.
+     *
      * @param file The absolute path of the XMIR file
      * @throws FileNotFoundException If file isn't found
      */
@@ -51,6 +53,7 @@ public final class Source {
 
     /**
      * Ctor.
+     *
      * @param xml The XMIR
      */
     public Source(final XML xml) {
@@ -73,6 +76,7 @@ public final class Source {
 
     /**
      * Source with disabled lints.
+     *
      * @param names Lint names
      * @return Program analysis without specific name
      */
@@ -84,6 +88,7 @@ public final class Source {
      * Apply all available fixes to the XMIR, returning the corrected document.
      * A lint's fix is applied only when the lint reports at least one defect
      * on the current document, so clean XMIR stays untouched.
+     *
      * @return Fixed XMIR
      * @throws IOException If a fix fails to apply
      */
@@ -99,6 +104,7 @@ public final class Source {
 
     /**
      * Find defects possible defects in the XMIR file.
+     *
      * @return All defects found
      * @see <a href="https://news.eolang.org/2022-11-25-xmir-guide.html">XMIR guide</a>
      * @see <a href="https://www.eolang.org/XMIR.html">XMIR specification</a>

--- a/src/main/java/org/eolang/lints/UnlintInRange.java
+++ b/src/main/java/org/eolang/lints/UnlintInRange.java
@@ -11,6 +11,7 @@ import org.cactoos.list.ListOf;
 
 /**
  * Does unlint in the range?
+ *
  * @since 0.0.54
  */
 final class UnlintInRange implements Predicate<Integer> {
@@ -22,6 +23,7 @@ final class UnlintInRange implements Predicate<Integer> {
 
     /**
      * Ctor.
+     *
      * @param unlt The unlint expression
      */
     UnlintInRange(final String unlt) {

--- a/src/main/java/org/eolang/lints/Version.java
+++ b/src/main/java/org/eolang/lints/Version.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 
 /**
  * A strict {@code major.minor.patch} version.
+ *
  * @since 0.2.11
  */
 final class Version {
@@ -36,6 +37,7 @@ final class Version {
 
     /**
      * Ctor.
+     *
      * @param mjr Major version
      * @param mnr Minor version
      * @param pch Patch version

--- a/src/main/java/org/eolang/lints/Vocabulary.java
+++ b/src/main/java/org/eolang/lints/Vocabulary.java
@@ -5,6 +5,7 @@
 package org.eolang.lints;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.concurrent.locks.ReentrantLock;
@@ -42,20 +43,16 @@ final class Vocabulary {
 
     /**
      * Ctor.
+     *
      * @throws IOException If fails to load the POS model resource
      */
     Vocabulary() throws IOException {
-        this(
-            new POSModel(
-                new InputStreamOf(
-                    new ResourceOf("en-pos-perceptron.bin")
-                )
-            )
-        );
+        this(Vocabulary.model());
     }
 
     /**
      * Ctor.
+     *
      * @param mdl Part-Of-Speech model
      */
     Vocabulary(final POSModel mdl) {
@@ -64,6 +61,7 @@ final class Vocabulary {
 
     /**
      * Ctor.
+     *
      * @param pos Part-Of-Speech tagger
      */
     Vocabulary(final POSTaggerME pos) {
@@ -93,6 +91,12 @@ final class Vocabulary {
             );
         } finally {
             this.lock.unlock();
+        }
+    }
+
+    private static POSModel model() throws IOException {
+        try (InputStream stream = new InputStreamOf(new ResourceOf("en-pos-perceptron.bin"))) {
+            return new POSModel(stream);
         }
     }
 }

--- a/src/main/java/org/eolang/lints/VoidXpath.java
+++ b/src/main/java/org/eolang/lints/VoidXpath.java
@@ -12,6 +12,7 @@ import org.cactoos.list.ListOf;
 
 /**
  * XPath expression to the void attribute reference.
+ *
  * @since 0.0.50
  */
 final class VoidXpath implements Text {
@@ -23,6 +24,7 @@ final class VoidXpath implements Text {
 
     /**
      * Ctor.
+     *
      * @param base Void FQN
      */
     VoidXpath(final String base) {

--- a/src/main/java/org/eolang/lints/WithoutLints.java
+++ b/src/main/java/org/eolang/lints/WithoutLints.java
@@ -11,12 +11,14 @@ import org.cactoos.list.ListOf;
 
 /**
  * Lints without some lints.
+ *
  * @since 0.0.46
  */
 final class WithoutLints extends IterableEnvelope<Lint> {
 
     /**
      * Ctor.
+     *
      * @param origin Origin
      * @param names Lint names to exclude
      */
@@ -26,6 +28,7 @@ final class WithoutLints extends IterableEnvelope<Lint> {
 
     /**
      * Ctor.
+     *
      * @param origin Origin lints
      * @param names Lint names to exclude
      */

--- a/src/main/java/org/eolang/lints/package-info.java
+++ b/src/main/java/org/eolang/lints/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Lints (style checkers).
+ *
  * @since 0.0.1
  */
 package org.eolang.lints;

--- a/src/test/java/benchmarks/BenchmarkState.java
+++ b/src/test/java/benchmarks/BenchmarkState.java
@@ -16,6 +16,7 @@ import org.openjdk.jmh.annotations.State;
 
 /**
  * Benchmark state.
+ *
  * @since 0.0.45
  */
 @State(Scope.Benchmark)
@@ -52,6 +53,7 @@ public class BenchmarkState {
 
     /**
      * The XMIR to scan.
+     *
      * @return The XMIR
      */
     public XML xmir() {

--- a/src/test/java/benchmarks/SourceBench.java
+++ b/src/test/java/benchmarks/SourceBench.java
@@ -18,6 +18,7 @@ import org.openjdk.jmh.annotations.Warmup;
 
 /**
  * Benchmark for {@link Source}.
+ *
  * @since 0.0.34
  * @checkstyle NonStaticMethodCheck (100 lines)
  */
@@ -39,6 +40,7 @@ public class SourceBench {
     /**
      * Benchmark for XMIR scanning.
      * Scans XMIR.
+     *
      * @param state State
      */
     @Benchmark

--- a/src/test/java/benchmarks/package-info.java
+++ b/src/test/java/benchmarks/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Benchmarks.
+ *
  * @since 0.0.1
  */
 package benchmarks;

--- a/src/test/java/fixtures/BytecodeClass.java
+++ b/src/test/java/fixtures/BytecodeClass.java
@@ -19,6 +19,7 @@ import org.xembly.Xembler;
 
 /**
  * XMIR document from Java bytecode.
+ *
  * @since 0.0.31
  */
 public final class BytecodeClass implements Scalar<XML> {
@@ -35,6 +36,7 @@ public final class BytecodeClass implements Scalar<XML> {
 
     /**
      * Constructor.
+     *
      * @param jclass Java class to transform
      */
     public BytecodeClass(final String jclass) {
@@ -43,6 +45,7 @@ public final class BytecodeClass implements Scalar<XML> {
 
     /**
      * Constructor.
+     *
      * @param nme Program name
      * @param jclass Java class to transform
      */

--- a/src/test/java/fixtures/EoProgram.java
+++ b/src/test/java/fixtures/EoProgram.java
@@ -17,6 +17,7 @@ import org.eolang.parser.EoSyntax;
 
 /**
  * Parsed EO program from a classpath resource, with bounded in-memory caching.
+ *
  * @since 0.2.0
  */
 public final class EoProgram {
@@ -40,6 +41,7 @@ public final class EoProgram {
 
     /**
      * Constructor.
+     *
      * @param res Classpath resource path to the EO source file
      */
     public EoProgram(final String res) {
@@ -48,6 +50,7 @@ public final class EoProgram {
 
     /**
      * Constructor.
+     *
      * @param nme Cache key and log label for this program
      * @param input EO source input
      */
@@ -58,6 +61,7 @@ public final class EoProgram {
 
     /**
      * Parse the EO resource into XMIR, using the cache when available.
+     *
      * @return Parsed XMIR document
      */
     public XML parse() {

--- a/src/test/java/fixtures/FixPack.java
+++ b/src/test/java/fixtures/FixPack.java
@@ -15,6 +15,7 @@ import org.yaml.snakeyaml.Yaml;
 /**
  * A YAML test pack for a fix, exposing the normalized fixed and
  * expected XMIR for comparison in tests.
+ *
  * @since 0.2.1
  */
 public final class FixPack {
@@ -26,6 +27,7 @@ public final class FixPack {
 
     /**
      * Constructor.
+     *
      * @param yaml Raw YAML string containing 'sheets', 'input' and 'output' fields
      */
     @SuppressWarnings("unchecked")
@@ -35,6 +37,7 @@ public final class FixPack {
 
     /**
      * Constructor.
+     *
      * @param pack Parsed YAML map
      */
     private FixPack(final Map<String, Object> pack) {
@@ -43,6 +46,7 @@ public final class FixPack {
 
     /**
      * Returns normalized XMIR after applying the fix to the input program.
+     *
      * @return Normalized XMIR string
      * @throws Exception If parsing or fix application fails
      */
@@ -52,6 +56,7 @@ public final class FixPack {
 
     /**
      * Returns normalized XMIR after applying a custom fix to the input program.
+     *
      * @param fix Fix to apply
      * @return Normalized XMIR string
      * @throws Exception If parsing or fix application fails
@@ -69,6 +74,7 @@ public final class FixPack {
 
     /**
      * Returns normalized XMIR of the expected output program.
+     *
      * @return Normalized XMIR string
      */
     public String expected() {

--- a/src/test/java/fixtures/SourceSize.java
+++ b/src/test/java/fixtures/SourceSize.java
@@ -6,6 +6,7 @@ package fixtures;
 
 /**
  * Program size.
+ *
  * @since 0.0.45
  */
 public enum SourceSize {
@@ -62,6 +63,7 @@ public enum SourceSize {
 
     /**
      * Ctor.
+     *
      * @param txt Txt largeness
      * @param start Minimum size in executable lines
      * @param end Maximum size in executable lines
@@ -76,6 +78,7 @@ public enum SourceSize {
 
     /**
      * Source largeness.
+     *
      * @return Program type as string
      */
     public String type() {
@@ -84,6 +87,7 @@ public enum SourceSize {
 
     /**
      * Min allowed count of executable lines.
+     *
      * @return Lines count
      */
     public int minAllowed() {
@@ -92,6 +96,7 @@ public enum SourceSize {
 
     /**
      * Max allowed count of executable lines.
+     *
      * @return Lines count
      */
     public int maxAllowed() {
@@ -100,6 +105,7 @@ public enum SourceSize {
 
     /**
      * Java path.
+     *
      * @return Path to Java bytecode class
      */
     public String java() {

--- a/src/test/java/fixtures/XtDefects.java
+++ b/src/test/java/fixtures/XtDefects.java
@@ -14,6 +14,7 @@ import org.eolang.xax.Xtory;
 
 /**
  * A story with a short defect-count assertion.
+ *
  * @since 1.0
  */
 public final class XtDefects implements Xtory {
@@ -25,6 +26,7 @@ public final class XtDefects implements Xtory {
 
     /**
      * New story.
+     *
      * @param story Original story
      */
     public XtDefects(final Xtory story) {

--- a/src/test/java/fixtures/package-info.java
+++ b/src/test/java/fixtures/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Fixtures.
+ *
  * @since 0.0.1
  */
 package fixtures;

--- a/src/test/java/matchers/DefectMatcher.java
+++ b/src/test/java/matchers/DefectMatcher.java
@@ -14,6 +14,7 @@ import org.hamcrest.Matchers;
 
 /**
  * Hamcrest matcher for a single defect.
+ *
  * @since 0.0.34
  */
 public final class DefectMatcher extends BaseMatcher<Defect> {

--- a/src/test/java/matchers/DefectsMatcher.java
+++ b/src/test/java/matchers/DefectsMatcher.java
@@ -16,6 +16,7 @@ import org.hamcrest.Matchers;
 
 /**
  * Hamcrest matcher for defects in XML.
+ *
  * @since 0.0.34
  */
 public final class DefectsMatcher extends BaseMatcher<XML> {

--- a/src/test/java/matchers/GrammarMatcher.java
+++ b/src/test/java/matchers/GrammarMatcher.java
@@ -22,6 +22,7 @@ import org.languagetool.rules.spelling.SpellingCheckRule;
 /**
  * Hamcrest matcher for a single piece of text, to make sure it's
  * grammatically valid.
+ *
  * @since 0.0.34
  */
 public final class GrammarMatcher extends BaseMatcher<String> {

--- a/src/test/java/matchers/package-info.java
+++ b/src/test/java/matchers/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Matchers.
+ *
  * @since 0.0.1
  */
 package matchers;

--- a/src/test/java/org/eolang/lints/DefectMissingTest.java
+++ b/src/test/java/org/eolang/lints/DefectMissingTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link DefectMissing}.
+ *
  * @since 0.0.44
  */
 final class DefectMissingTest {

--- a/src/test/java/org/eolang/lints/DefectTest.java
+++ b/src/test/java/org/eolang/lints/DefectTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link Defect}.
+ *
  * @since 0.0.12
  */
 final class DefectTest {

--- a/src/test/java/org/eolang/lints/DfContextTest.java
+++ b/src/test/java/org/eolang/lints/DfContextTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link DfContext}.
+ *
  * @since 0.0.40
  */
 final class DfContextTest {

--- a/src/test/java/org/eolang/lints/FixTest.java
+++ b/src/test/java/org/eolang/lints/FixTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 
 /**
  * Tests {@link Fix}.
+ *
  * @since 0.2.1
  */
 final class FixTest {

--- a/src/test/java/org/eolang/lints/FxEmptyTest.java
+++ b/src/test/java/org/eolang/lints/FxEmptyTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link FxEmpty}.
+ *
  * @since 0.2.1
  */
 final class FxEmptyTest {

--- a/src/test/java/org/eolang/lints/FxResourceTest.java
+++ b/src/test/java/org/eolang/lints/FxResourceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link FxResource}.
+ *
  * @since 0.2.1
  */
 final class FxResourceTest {

--- a/src/test/java/org/eolang/lints/LineOfTest.java
+++ b/src/test/java/org/eolang/lints/LineOfTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link LineOf}.
+ *
  * @since 0.0.50
  */
 final class LineOfTest {

--- a/src/test/java/org/eolang/lints/LintTest.java
+++ b/src/test/java/org/eolang/lints/LintTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link Lint}.
+ *
  * @since 0.23
  */
 final class LintTest {

--- a/src/test/java/org/eolang/lints/LtAlwaysTest.java
+++ b/src/test/java/org/eolang/lints/LtAlwaysTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link LtAlways}.
+ *
  * @since 0.0.1
  */
 final class LtAlwaysTest {

--- a/src/test/java/org/eolang/lints/LtByXslTest.java
+++ b/src/test/java/org/eolang/lints/LtByXslTest.java
@@ -25,7 +25,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import matchers.DefectsMatcher;
 import org.cactoos.io.InputOf;
-import org.cactoos.io.ReaderOf;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.map.MapOf;
 import org.cactoos.set.SetOf;
@@ -56,6 +55,7 @@ import org.yaml.snakeyaml.Yaml;
 
 /**
  * Test for {@link LtByXsl}.
+ *
  * @since 0.0.1
  * @checkstyle ClassFanOutComplexityCheck (500 lines)
  */
@@ -366,7 +366,7 @@ final class LtByXslTest {
                 .filter(Files::isRegularFile)
                 .filter(LtByXslTest.yamls()).map(
                     (Function<Path, Map<Path, Map<String, Object>>>)
-                        p -> new MapOf<>(p, new Yaml().load(new ReaderOf(p.toFile())))
+                        p -> new MapOf<>(p, LtByXslTest.yaml(p))
                 ).filter(
                     pack -> {
                         final Map<String, Object> yaml = pack.values().stream().findFirst().get();
@@ -387,7 +387,7 @@ final class LtByXslTest {
         ).filter(Files::isRegularFile)
             .filter(LtByXslTest.yamls()).map(
                 (Function<Path, Map<Path, Map<String, Object>>>)
-                    p -> new MapOf<>(p, new Yaml().load(new ReaderOf(p.toFile())))
+                    p -> new MapOf<>(p, LtByXslTest.yaml(p))
             )
             .filter(LtByXslTest::eligibleForValidation)
             .filter(pack -> !LtByXslTest.eoErrorFree(pack))
@@ -453,6 +453,10 @@ final class LtByXslTest {
                 )
             ).parse().inner()
         ).path("/object[errors]").findAny().isEmpty();
+    }
+
+    private static Map<String, Object> yaml(final Path path) {
+        return new Yaml().load(new UncheckedText(new TextOf(path)).asString());
     }
 
     @SuppressWarnings("UnnecessaryLambda")

--- a/src/test/java/org/eolang/lints/LtDfStickyTest.java
+++ b/src/test/java/org/eolang/lints/LtDfStickyTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link LtDfSticky}.
+ *
  * @since 0.0.42
  */
 final class LtDfStickyTest {
@@ -80,6 +81,7 @@ final class LtDfStickyTest {
 
     /**
      * Counter for lint calls.
+     *
      * @since 0.0.42
      */
     private static final class LtCounter implements Function<XML, Collection<Defect>> {
@@ -102,6 +104,7 @@ final class LtDfStickyTest {
 
     /**
      * Fake class for Lint class.
+     *
      * @since 0.0.42
      */
     private static final class LtFake implements Lint {
@@ -123,6 +126,7 @@ final class LtDfStickyTest {
 
         /**
          * Constructor. Name and motive are hardcoded.
+         *
          * @param defects Lint defects supplier
          */
         LtFake(final Function<XML, Collection<Defect>> defects) {
@@ -131,6 +135,7 @@ final class LtDfStickyTest {
 
         /**
          * Constructor.
+         *
          * @param name Lint name supplier
          * @param defects Lint defects supplier
          * @param motive Lint motive supplier

--- a/src/test/java/org/eolang/lints/LtIncorrectUnlintTest.java
+++ b/src/test/java/org/eolang/lints/LtIncorrectUnlintTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link LtIncorrectUnlint}.
+ *
  * @since 0.0.38
  */
 final class LtIncorrectUnlintTest {

--- a/src/test/java/org/eolang/lints/LtReservedNameTest.java
+++ b/src/test/java/org/eolang/lints/LtReservedNameTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
  * they depend on the real reserved-name list downloaded by the
  * {@code reserved} Maven profile, which is unavailable to the generic
  * pack runner.
+ *
  * @since 0.0.44
  */
 final class LtReservedNameTest {

--- a/src/test/java/org/eolang/lints/LtSyntaxVersionTest.java
+++ b/src/test/java/org/eolang/lints/LtSyntaxVersionTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link LtSyntaxVersion}.
+ *
  * @since 0.2.11
  */
 final class LtSyntaxVersionTest {

--- a/src/test/java/org/eolang/lints/LtTestNotVerbTest.java
+++ b/src/test/java/org/eolang/lints/LtTestNotVerbTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for {@link LtTestNotVerb}.
+ *
  * @since 0.0.22
  */
 final class LtTestNotVerbTest {

--- a/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
+++ b/src/test/java/org/eolang/lints/LtUnlintNonExistingDefectTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link LtUnlintNonExistingDefect}.
+ *
  * @since 0.0.40
  */
 final class LtUnlintNonExistingDefectTest {
@@ -52,6 +53,7 @@ final class LtUnlintNonExistingDefectTest {
 
     /**
      * Fake lint that explodes when invoked.
+     *
      * @since 0.0.40
      */
     private static final class Boom implements Lint {

--- a/src/test/java/org/eolang/lints/MonoLintNamesTest.java
+++ b/src/test/java/org/eolang/lints/MonoLintNamesTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link MonoLintNames}.
+ *
  * @since 0.0.43
  */
 final class MonoLintNamesTest {

--- a/src/test/java/org/eolang/lints/MonoLintsTest.java
+++ b/src/test/java/org/eolang/lints/MonoLintsTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link MonoLints}.
+ *
  * @since 0.0.43
  */
 final class MonoLintsTest {

--- a/src/test/java/org/eolang/lints/PkByXslTest.java
+++ b/src/test/java/org/eolang/lints/PkByXslTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link PkByXsl}.
+ *
  * @since 0.0.1
  */
 final class PkByXslTest {
@@ -138,6 +139,7 @@ final class PkByXslTest {
 
     /**
      * Checks that XSL stylesheet ID matches filename.
+     *
      * @since 0.0.1
      */
     private static final class IdChecker implements Predicate<Resource> {

--- a/src/test/java/org/eolang/lints/PkMonoTest.java
+++ b/src/test/java/org/eolang/lints/PkMonoTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link PkMono}.
+ *
  * @since 0.23
  */
 final class PkMonoTest {

--- a/src/test/java/org/eolang/lints/ReservedNamesTest.java
+++ b/src/test/java/org/eolang/lints/ReservedNamesTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
  * Tests for {@link ReservedNames}.
  * The tests should be executed only in deep profile, since, we reserved name processing
  * happens only in that profile.
+ *
  * @since 0.0.49
  */
 @Tag("reserved")

--- a/src/test/java/org/eolang/lints/ScopedDefectsTest.java
+++ b/src/test/java/org/eolang/lints/ScopedDefectsTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link ScopedDefects}.
+ *
  * @since 0.0.48
  */
 final class ScopedDefectsTest {

--- a/src/test/java/org/eolang/lints/SeverityTest.java
+++ b/src/test/java/org/eolang/lints/SeverityTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link Severity}.
+ *
  * @since 0.0.12
  */
 final class SeverityTest {

--- a/src/test/java/org/eolang/lints/SourceTest.java
+++ b/src/test/java/org/eolang/lints/SourceTest.java
@@ -61,6 +61,7 @@ import org.objectweb.asm.Opcodes;
 
 /**
  * Test for {@link Source}.
+ *
  * @since 0.0.1
  */
 @ExtendWith(MktmpResolver.class)
@@ -417,6 +418,7 @@ final class SourceTest {
 
     /**
      * Benchmarked source.
+     *
      * @since 0.0.29
      */
     private static final class BcSource {
@@ -461,6 +463,7 @@ final class SourceTest {
 
         /**
          * Ctor.
+         *
          * @param source XMIR source to lint
          * @param size Source size
          */
@@ -475,6 +478,7 @@ final class SourceTest {
 
         /**
          * Ctor.
+         *
          * @param source XMIR source file to lint
          * @param lnts Lints to apply
          * @param tmngs Timings
@@ -491,6 +495,7 @@ final class SourceTest {
 
         /**
          * Defects.
+         *
          * @return Defects
          */
         Collection<Defect> defects() {
@@ -506,6 +511,7 @@ final class SourceTest {
 
     /**
      * Wrapper for timed lint execution.
+     *
      * @since 0.0.45
      */
     private static final class TimedLint implements Lint {
@@ -527,6 +533,7 @@ final class SourceTest {
 
         /**
          * Ctor.
+         *
          * @param lnt Lint
          * @param tmngs Timings
          * @param mrkr Marker
@@ -570,6 +577,7 @@ final class SourceTest {
      * Here, we count executable lines from Java bytecode class. However, if compiler
      * decides to skip them, we will get 0 here. Thus, all classes must be compiled with
      * lines.
+     *
      * @since 0.0.45
      */
     private static final class LineCountVisitor extends ClassVisitor {
@@ -604,6 +612,7 @@ final class SourceTest {
 
         /**
          * Total found.
+         *
          * @return Lines count
          */
         int total() {
@@ -613,6 +622,7 @@ final class SourceTest {
 
     /**
      * A lint that reports no defects but mutates the XMIR when its fix is applied.
+     *
      * @since 0.1.0
      */
     private static final class DestructiveLint implements Lint {

--- a/src/test/java/org/eolang/lints/UnlintInRangeTest.java
+++ b/src/test/java/org/eolang/lints/UnlintInRangeTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Tests for {@link UnlintInRange}.
+ *
  * @since 0.0.54
  */
 final class UnlintInRangeTest {

--- a/src/test/java/org/eolang/lints/VocabularyTest.java
+++ b/src/test/java/org/eolang/lints/VocabularyTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for {@link Vocabulary}.
+ *
  * @since 0.2.0
  */
 final class VocabularyTest {

--- a/src/test/java/org/eolang/lints/VoidXpathTest.java
+++ b/src/test/java/org/eolang/lints/VoidXpathTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Tests for {@link VoidXpath}.
+ *
  * @since 0.0.50
  */
 final class VoidXpathTest {

--- a/src/test/java/org/eolang/lints/WithoutLintsTest.java
+++ b/src/test/java/org/eolang/lints/WithoutLintsTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for {@link WithoutLints}.
+ *
  * @since 0.0.46
  */
 final class WithoutLintsTest {
@@ -90,6 +91,7 @@ final class WithoutLintsTest {
 
     /**
      * Fake lint.
+     *
      * @since 0.0.57
      */
     static final class LtFake implements Lint {
@@ -101,6 +103,7 @@ final class WithoutLintsTest {
 
         /**
          * Ctor.
+         *
          * @param nme The lint name
          */
         LtFake(final String nme) {

--- a/src/test/java/org/eolang/lints/XtLint.java
+++ b/src/test/java/org/eolang/lints/XtLint.java
@@ -29,6 +29,7 @@ import org.xembly.Xembler;
  * generic {@code params} map; when present, {@link #lint()} builds
  * the matching lint from those parameters directly, instead of
  * using the default one from {@link PkMono}.
+ *
  * @since 1.0
  */
 public final class XtLint implements Xtory {
@@ -40,6 +41,7 @@ public final class XtLint implements Xtory {
 
     /**
      * Ctor.
+     *
      * @param yaml YAML pack
      * @param parser Parser
      */
@@ -49,6 +51,7 @@ public final class XtLint implements Xtory {
 
     /**
      * Ctor.
+     *
      * @param origin Original story
      */
     private XtLint(final Xtory origin) {

--- a/src/test/java/org/eolang/lints/package-info.java
+++ b/src/test/java/org/eolang/lints/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Linters.
+ *
  * @since 0.0.1
  */
 package org.eolang.lints;


### PR DESCRIPTION
Bumps `qulice-maven-plugin` from `0.35.1` to `0.35.2` in the `qulice` profile of `pom.xml`.

The new version introduced two additional rules, which produced 166 violations. Both are fixed here:

- **`JavadocEmptyLineBeforeTagCheck`** (164 violations, 80 files) — an empty Javadoc line is now required before the block of at-clauses. Added `*` separator lines before the first `@param`/`@return`/`@since`/`@throws` tag.
- **`CloseInlineResourceRule`** (2 violations) — inline `AutoCloseable` expressions must be closed with try-with-resources:
  - `Vocabulary` — the `InputStreamOf` wrapping the OpenNLP model resource is now opened in a try-with-resources block inside a private `model()` helper.
  - `LtByXslTest` — the two inline `new ReaderOf(p.toFile())` YAML loads are replaced with a `yaml(Path)` helper that reads via `TextOf`, dropping the now-unused `ReaderOf` import.

Verified locally:

- `mvn clean verify -PskipTests -Pqulice` — `BUILD SUCCESS`, zero violations.
- `mvn test -Dtest='VocabularyTest,LtByXslTest'` — 605 tests, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWNy4KFmfg1LDcDEMufvR8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWNy4KFmfg1LDcDEMufvR8)_