### PR TITLE
fix(#1426): name the named-attribute self-call shape

### DIFF
--- a/src/main/resources/org/eolang/lints/design/unoptimizable-recursion.xsl
+++ b/src/main/resources/org/eolang/lints/design/unoptimizable-recursion.xsl
@@ -42,14 +42,12 @@
     </xsl:choose>
   </xsl:function>
   <!--
-  @todo #1321:60min Name the shapes this lint still misses.
-  The compiler also leaves the recursion alone when the self-call is
-  spelled "Phi.name" instead of "^.name", when the formation is reached
-  other than by a plain application, as a decoratee or as the receiver of
-  a dispatch, when an attribute holding a self-call is read from outside
-  the formation, as in "range", and when two formations call each other.
-  Each of those is syntactic, so each can be found here and reported with
-  a reason of its own, the way the four below are.
+  @todo #1321:60min Name the two shapes this lint still misses.
+  The compiler also leaves the recursion alone when the formation is
+  reached as a decoratee instead of by a plain application, and when two
+  formations call each other instead of one calling itself. Both are
+  syntactic, so both can be found here and reported with a reason of
+  their own, the way the ones below are.
   -->
   <!--
   TRUE when the @base is a self-call of the object with the given name, in
@@ -120,6 +118,11 @@
               </xsl:when>
               <xsl:when test="$calls[eo:is-self-dispatch(string(@base), $name)]">
                 <xsl:text>the self-call is the receiver of a dispatch</xsl:text>
+              </xsl:when>
+              <xsl:when test="$calls[@name and @name != 'φ']">
+                <xsl:text>the self-call is bound to the attribute </xsl:text>
+                <xsl:value-of select="eo:escape($calls[@name and @name != 'φ'][1]/@name)"/>
+                <xsl:text>, read from outside the formation instead of returned</xsl:text>
               </xsl:when>
               <xsl:otherwise>
                 <xsl:text>no self-call sits in a tail position</xsl:text>

--- a/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/catches-a-self-call-bound-to-a-named-attribute.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/unoptimizable-recursion/catches-a-self-call-bound-to-a-named-attribute.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/lints/design/unoptimizable-recursion.xsl
+asserts:
+  - /defects[count(defect[@severity='warning'])=1]
+  - /defects/defect[1][normalize-space()='The recursion in "range" cannot be turned into a loop, the self-call is bound to the attribute "next", read from outside the formation instead of returned']
+input: |
+  [] > app
+    [n] > range
+      ^.range (n.minus 1) > next
+      0 > @
+    range 5 > @


### PR DESCRIPTION
## What

Closes #1426.

`unoptimizable-recursion` used to fall back to the generic reason "no
self-call sits in a tail position" for a self-call that is bound to a
named attribute (other than `φ`) and later read from outside the
formation — the exact shape the puzzle called out with the `range`
example. It now reports a specific reason for that shape:

```
The recursion in "range" cannot be turned into a loop, the self-call is
bound to the attribute "next", read from outside the formation instead
of returned
```

The remaining `@todo` comment is narrowed down to the two shapes this
lint still doesn't name specifically: a self-call reached as a
decoratee, and mutual recursion between two formations.

## Why

The compiler leaves a self-recursive formation as plain recursion
(instead of turning it into a Java loop) for several syntactic shapes,
and the lint is meant to name each one at the call site so the author
can rewrite the object. Before this change, the "named attribute"
shape fell through to a generic, uninformative message.

## Test plan

- Added `packs/single/unoptimizable-recursion/catches-a-self-call-bound-to-a-named-attribute.yaml`
  covering the new message.
- `mvn test` passes locally (full suite, no failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hX2q1mH8xVFQPPRZV7Dch

---
_Generated by [Claude Code](https://claude.ai/code/session_016hX2q1mH8xVFQPPRZV7Dch)_