### PR TITLE
#1442: Handle overflowing syntax versions

### DIFF
--- a/src/main/java/org/eolang/lints/Version.java
+++ b/src/main/java/org/eolang/lints/Version.java
@@ -57,13 +57,19 @@ final class Version {
         final Matcher matcher = Version.CORE.matcher(text.trim());
         final Optional<Version> result;
         if (matcher.find()) {
-            result = Optional.of(
-                new Version(
-                    Integer.parseInt(matcher.group(1)),
-                    Integer.parseInt(matcher.group(2)),
-                    Integer.parseInt(matcher.group(3))
-                )
-            );
+            Optional<Version> parsed;
+            try {
+                parsed = Optional.of(
+                    new Version(
+                        Integer.parseInt(matcher.group(1)),
+                        Integer.parseInt(matcher.group(2)),
+                        Integer.parseInt(matcher.group(3))
+                    )
+                );
+            } catch (final NumberFormatException ignored) {
+                parsed = Optional.empty();
+            }
+            result = parsed;
         } else {
             result = Optional.empty();
         }

--- a/src/test/java/org/eolang/lints/LtSyntaxVersionTest.java
+++ b/src/test/java/org/eolang/lints/LtSyntaxVersionTest.java
@@ -78,6 +78,18 @@ final class LtSyntaxVersionTest {
     }
 
     @Test
+    void ignoresOverflowingSyntaxValue() throws IOException {
+        final String src = LtSyntaxVersionTest.program(
+            "+syntax 999999999999999999999999.2.3"
+        );
+        MatcherAssert.assertThat(
+            "an overflowing +syntax value must be treated as malformed, not crash linting",
+            new LtSyntaxVersion().defects(new EoProgram(src, new InputOf(src)).parse()),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
     void ignoresProgramsWithoutSyntaxMeta() throws IOException {
         final String src = LtSyntaxVersionTest.program("+home https://example.com");
         MatcherAssert.assertThat(


### PR DESCRIPTION
Closes #1442.

`Version.parsed()` now treats an overflowing numeric `major.minor.patch` component the same way it treats other malformed/non-SemVer values: it returns `Optional.empty()` instead of leaking `NumberFormatException` out of the lint pipeline.

The existing strict numeric comparison remains unchanged for representable versions. A regression test feeds `+syntax 999999999999999999999999.2.3` through `LtSyntaxVersion` and asserts that linting neither crashes nor produces a syntax-version defect.

Validation performed before the commit:
- `git diff --check` is clean;
- standalone compilation of `Version.java` confirms `1.2.3 -> Optional[1.2.3]` and the overflowing value -> `Optional.empty()`.

The commit was created through GitHub and is cryptographically marked `Verified`.
