### PR TITLE
#1441: Accept can-prefixed positive tests

### DIFF
--- a/src/main/java/org/eolang/lints/LtTestNotVerb.java
+++ b/src/main/java/org/eolang/lints/LtTestNotVerb.java
@@ -68,7 +68,8 @@ final class LtTestNotVerb implements Lint {
     }
 
     private boolean isVerb(final Xnav object) {
-        return this.vocabulary.isVerb(LtTestNotVerb.title(object));
+        final String title = LtTestNotVerb.title(object);
+        return title.startsWith("can-") || this.vocabulary.isVerb(title);
     }
 
     private static Defect verbDefect(final Xnav object) {

--- a/src/test/java/org/eolang/lints/LtTestNotVerbTest.java
+++ b/src/test/java/org/eolang/lints/LtTestNotVerbTest.java
@@ -59,7 +59,7 @@ final class LtTestNotVerbTest {
     @ExtendWith(MayBeSlow.class)
     @Execution(ExecutionMode.CONCURRENT)
     @ParameterizedTest
-    @ValueSource(strings = {"generates-report", "runs", "parses-dom"})
+    @ValueSource(strings = {"generates-report", "runs", "parses-dom", "can-read-bytes"})
     void allowsGoodNames(final String name) throws IOException {
         MatcherAssert.assertThat(
             "Defects are not empty, but they shouldn't be",


### PR DESCRIPTION
Closes #1441.

Aligns `unit-test-is-not-verb` with the sibling `bad-test-name` rule. Positive test names beginning with `can-` are now accepted explicitly; all other positive names continue through the existing OpenNLP `VBZ` verb check.

This keeps `accepts-*` and ordinary singular-verb names working as before while removing the contradiction where `bad-test-name` requires/permits `can-*` but OpenNLP tags `can` as a modal (`MD`) and the Java lint rejects it.

The existing positive-name parameterized test now includes `can-read-bytes` as a regression case. `git diff --check` is clean.

The commit was created through GitHub and is cryptographically marked `Verified`.
