### PR TITLE
#1440: Treat rho as a special name

### DIFF
--- a/src/main/resources/org/eolang/funcs/special-name.xsl
+++ b/src/main/resources/org/eolang/funcs/special-name.xsl
@@ -7,6 +7,6 @@
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:function name="eo:special" as="xs:boolean">
     <xsl:param name="name"/>
-    <xsl:sequence select="$name = '&#x3C6;' or $name = $eo:lambda or $name = $eo:xi or contains($name, $eo:cactoos)"/>
+    <xsl:sequence select="$name = '&#x3C6;' or $name = $eo:lambda or $name = $eo:xi or $name = $eo:rho or contains($name, $eo:cactoos)"/>
   </xsl:function>
 </xsl:stylesheet>

--- a/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/allows-special-names.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/invalid-name-notation/allows-special-names.yaml
@@ -12,6 +12,7 @@ document: |
         <o line="3" name="a🌵3-5" pos="4"/>
         <o line="4" name="φ" pos="4">
           <o base="Q.q" line="5" name="ξ" pos="6"/>
+          <o line="6" name="ρ" pos="6"/>
         </o>
       </o>
     </o>


### PR DESCRIPTION
Closes #1440.

Adds the receiver name `ρ` to the shared `eo:special()` predicate used by `invalid-name-notation` and other name lints. `ρ` is a reserved structural name just like `φ`, `λ`, and `ξ`; applying the ordinary `[a-z]+(-[a-z]+)*` naming rule to it produces false positives for every explicit receiver.

The existing `invalid-name-notation/allows-special-names.yaml` fixture now includes a `ρ`-named object alongside the other special forms and still expects zero defects.

This intentionally addresses only the receiver false positives from #1440. The separate question of digits in domain names such as `u8`/`i64` is unchanged.

Validation before commit: XSL is well-formed XML and `git diff --check` is clean. The commit is GitHub-signed and `Verified`.
