### PR TITLE
#1442: Handle overflowing syntax versions

### DIFF
--- a/src/main/java/org/eolang/lints/Version.java
+++ b/src/main/java/org/eolang/lints/Version.java
@@ -57,13 +57,19 @@ final class Version {
         final Matcher matcher = Version.CORE.matcher(text.trim());
         final Optional<Version> result;
         if (matcher.find()) {
-            result = Optional.of(
-                new Version(
-                    Integer.parseInt(matcher.group(1)),
-                    Integer.parseInt(matcher.group(2)),
-                    Integer.parseInt(matcher.group(3))
-                )
-            );
+            Optional<Version> parsed;
+            try {
+                parsed = Optional.of(
+                    new Version(
+                        Integer.parseInt(matcher.group(1)),
+                        Integer.parseInt(matcher.group(2)),
+                        Integer.parseInt(matcher.group(3))
+                    )
+                );
+            } catch (final NumberFormatException ignored) {
+                parsed = Optional.empty();
+            }
+            result = parsed;
         } else {
             result = Optional.empty();
         }

--- a/src/test/resources/org/eolang/lints/packs/single/syntax-version/ignores-overflowing-syntax-value.yaml
+++ b/src/test/resources/org/eolang/lints/packs/single/syntax-version/ignores-overflowing-syntax-value.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+lint: syntax-version
+defects: 0
+input: |
+  +syntax 999999999999999999999999.2.3
+
+  [] > foo


### PR DESCRIPTION
Closes #1442.

Replaces #1447 after rebasing the fix onto the current `master` and adapting the regression to the repository's newer YAML-pack test structure.

`Version.parsed()` now treats an overflowing numeric `major.minor.patch` component the same way it treats malformed/non-SemVer input: it returns `Optional.empty()` rather than leaking `NumberFormatException` out of linting.

A new `syntax-version` pack feeds `+syntax 999999999999999999999999.2.3` through the real lint and expects zero defects/no crash.

The commit was created through GitHub and is cryptographically marked `Verified`.
